### PR TITLE
Add submodule auto-update

### DIFF
--- a/.toolversions
+++ b/.toolversions
@@ -1,0 +1,1 @@
+Microsoft.DotNet.BuildTools=1.0.27-prerelease-01308-01

--- a/build.proj
+++ b/build.proj
@@ -49,4 +49,6 @@
     <Message Text="Build Environment: $(Platform) $(Configuration) $(TargetOS) $(TargetRid)" />
   </Target>
 
+  <Import Project="$(MSBuildThisfileDirectory)scripts/auto-update/update-submodules.targets" />
+
 </Project>

--- a/build.sh
+++ b/build.sh
@@ -121,14 +121,15 @@ bootstrap()
 # Parse command-line arguments
 # parse_args
 
-# Bootstrap supported or unsupported OS
-bootstrap
-echo "SDKPATH: $SDKPATH"
-
+# Create a fake HOME if none is set
 if [ -z "${HOME:-}" ]; then
     mkdir -p $SCRIPT_ROOT/bin/obj/home
     export HOME=$SCRIPT_ROOT/bin/obj/home
 fi
+
+# Bootstrap supported or unsupported OS
+bootstrap
+echo "SDKPATH: $SDKPATH"
 
 # Main build loop
 (set -x ; $CLIPATH/dotnet restore tasks/Microsoft.DotNet.SourceBuild.Tasks/Microsoft.DotNet.SourceBuild.Tasks.csproj)

--- a/dir.props
+++ b/dir.props
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <ShellExtension Condition="'$(OS)' == 'Windows_NT'">.cmd</ShellExtension>
     <ShellExtension Condition="'$(OS)' != 'Windows_NT'">.sh</ShellExtension>
     <TarBallExtension Condition="'$(OS)' == 'Windows_NT'">.zip</TarBallExtension>
@@ -13,13 +17,14 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <SubmoduleDirectory Condition="'$(SubmoduleDirectory)' == ''">$(MSBuildThisFileDirectory)src/</SubmoduleDirectory>
+    <SubmoduleDirectory Condition="'$(SubmoduleDirectory)' == ''">$(ProjectDir)src/</SubmoduleDirectory>
     <Only Condition="'$(Only)' == ''">standard;coreclr;corefx;roslyn;libuv;core-setup</Only>
   </PropertyGroup>
 
   <PropertyGroup>
-    <BaseOutputPath>$(MSBuildThisFileDirectory)bin/</BaseOutputPath>
-    <TaskDirectory>$(MSBuildThisFileDirectory)tasks/</TaskDirectory>
+    <BaseOutputPath>$(ProjectDir)bin/</BaseOutputPath>
+    <ToolsDir>$(ProjectDir)Tools/</ToolsDir>
+    <TaskDirectory>$(ProjectDir)tasks/</TaskDirectory>
     <BaseIntermediatePath>$(BaseOutputPath)obj/</BaseIntermediatePath>
     <OutputPath>$(BaseOutputPath)$(Platform)/$(Configuration)/</OutputPath>
     <IntermediatePath>$(BaseIntermediatePath)$(Platform)/$(Configuration)/</IntermediatePath>

--- a/scripts/auto-update/build.proj
+++ b/scripts/auto-update/build.proj
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="dir.props" />
+
+  <Import Project="$(ToolsDir)VersionTools.targets" />
+</Project>

--- a/scripts/auto-update/dependencies.props
+++ b/scripts/auto-update/dependencies.props
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Source of truth for dependency tooling: the commit hash of the dotnet/versions master branch as of the last auto-upgrade. -->
+  <PropertyGroup>
+    <CoreFxCurrentRef>8c02c8b91856b5b8f6e5d7f1707f6b2f0de67644</CoreFxCurrentRef>
+  </PropertyGroup>
+
+  <!-- Package dependency verification/auto-upgrade configuration. -->
+  <PropertyGroup>
+    <BaseDotNetBuildInfo>build-info/dotnet/</BaseDotNetBuildInfo>
+    <DependencyBranch>master</DependencyBranch>
+    <CurrentRefXmlPath>$(MSBuildThisFileFullPath)</CurrentRefXmlPath>
+    <DotNetCoreV2BaseUrl>https://dotnet.myget.org/F/dotnet-core/api/v2</DotNetCoreV2BaseUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <RemoteDependencyBuildInfo Include="CoreFx">
+      <BuildInfoPath>$(BaseDotNetBuildInfo)corefx/$(DependencyBranch)</BuildInfoPath>
+      <CurrentRef>$(CoreFxCurrentRef)</CurrentRef>
+    </RemoteDependencyBuildInfo>
+
+    <DependencyBuildInfo Include="@(RemoteDependencyBuildInfo)">
+      <RawVersionsBaseUrl>https://raw.githubusercontent.com/dotnet/versions</RawVersionsBaseUrl>
+    </DependencyBuildInfo>
+  </ItemGroup>
+
+  <!-- Set up submodule updaters. -->
+  <ItemGroup>
+    <UpdateStep Include="CoreFX">
+      <UpdaterType>Submodule from package</UpdaterType>
+      <Path>$(SubmoduleDirectory)corefx</Path>
+      <IndicatorPackage>Microsoft.NETCore.Platforms</IndicatorPackage>
+      <PackageDownloadBaseUrl>$(DotNetCoreV2BaseUrl)</PackageDownloadBaseUrl>
+    </UpdateStep>
+
+    <UpdateStep Include="Core-Setup">
+      <UpdaterType>Submodule from latest</UpdaterType>
+      <Path>$(SubmoduleDirectory)core-setup</Path>
+      <Repository>origin</Repository>
+      <Ref>master</Ref>
+    </UpdateStep>
+    <UpdateStep Include="CoreCLR">
+      <UpdaterType>Submodule from latest</UpdaterType>
+      <Path>$(SubmoduleDirectory)coreclr</Path>
+      <Repository>origin</Repository>
+      <Ref>master</Ref>
+    </UpdateStep>
+    <UpdateStep Include="libuv">
+      <UpdaterType>Submodule from latest</UpdaterType>
+      <Path>$(SubmoduleDirectory)libuv</Path>
+      <Repository>origin</Repository>
+      <Ref>master</Ref>
+    </UpdateStep>
+    <UpdateStep Include="Roslyn">
+      <UpdaterType>Submodule from latest</UpdaterType>
+      <Path>$(SubmoduleDirectory)roslyn</Path>
+      <Repository>origin</Repository>
+      <Ref>master</Ref>
+    </UpdateStep>
+    <UpdateStep Include="Standard">
+      <UpdaterType>Submodule from latest</UpdaterType>
+      <Path>$(SubmoduleDirectory)standard</Path>
+      <Repository>origin</Repository>
+      <Ref>master</Ref>
+    </UpdateStep>
+  </ItemGroup>
+</Project>

--- a/scripts/auto-update/dir.props
+++ b/scripts/auto-update/dir.props
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <BuildToolsTargetsDesktop>true</BuildToolsTargetsDesktop>
+    <BuildToolsTargetsDesktop Condition="'$(MSBuildRuntimeType)'=='core'">false</BuildToolsTargetsDesktop>
+  </PropertyGroup>
+
+  <Import Project="$(ToolsDir)Build.Common.props" />
+  <Import Project="dependencies.props" />
+</Project>

--- a/scripts/auto-update/update-submodules.targets
+++ b/scripts/auto-update/update-submodules.targets
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="UpdateSubmodules">
+    <MSBuild 
+      Projects="$(MSBuildThisFileDirectory)build.proj"
+      Targets="UpdateDependencies" 
+    />
+  </Target>
+
+  <Target Name="VerifySubmodules">
+    <MSBuild 
+      Projects="$(MSBuildThisFileDirectory)build.proj"
+      Targets="VerifyDependencies" 
+    />
+  </Target>
+
+  <Target Name="UpdateSubmodulesAndSubmitPullRequest">
+    <MSBuild 
+      Projects="$(MSBuildThisFileDirectory)build.proj"
+      Targets="UpdateDependenciesAndSubmitPullRequest" 
+    />
+  </Target>
+</Project>


### PR DESCRIPTION
Adds updaters currently in PR in https://github.com/dotnet/buildtools/pull/1324 to update submodules automatically. Right now none of the build from source branches are being official built, so the only option is the "LatestCommit" updater.

You can see the setup needed for a indicator package updater here, though: https://github.com/dotnet/source-build/commit/db10bc7310fa9480eef761ae5a17086f02fe6ea4.

Known work:
 * I did some work to bootstrap.ps1 to get the BuildTools package--might not be the way to go. I could instead restore the VersionTools non-msbuild package and add to the `tasks` project, if that dependency isn't a problem. If auto-update should be completely isolated and have its own independent .toolversions, I could also do that.
 * ~~Work on the xplat side. I think that will just be updating bootstrap.sh too.~~
 * ~~Hook up the rest of the submodules.~~
 * ~~Add wiring for the auto-update-and-submit-PR target.~~

Once this is in, we can hook it up to Maestro to run on every commit of all the build from source submodule repo branches. If there are too many commits, it can run on a schedule.

@ellismg 