### PR TITLE
Set $HOME in build.sh if it is unset

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -125,6 +125,11 @@ bootstrap()
 bootstrap
 echo "SDKPATH: $SDKPATH"
 
+if [ -z "${HOME:-}" ]; then
+    mkdir -p $SCRIPT_ROOT/bin/obj/home
+    export HOME=$SCRIPT_ROOT/bin/obj/home
+fi
+
 # Main build loop
 (set -x ; $CLIPATH/dotnet restore tasks/Microsoft.DotNet.SourceBuild.Tasks/Microsoft.DotNet.SourceBuild.Tasks.csproj)
 (set -x ; $CLIPATH/dotnet build tasks/Microsoft.DotNet.SourceBuild.Tasks/Microsoft.DotNet.SourceBuild.Tasks.csproj)


### PR DESCRIPTION
$HOME is unset on the OSX CI machines, this causes an exception during
dotnet restore. If we don't have a $HOME, make a fake run under
bin/obj and use that for the build.