### PR TITLE
Docker images for building

### DIFF
--- a/docker/build-docker-images.sh
+++ b/docker/build-docker-images.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+SCRIPT_ROOT="$(cd -P "$( dirname "$0" )" && pwd)"
+
+if [ -z "${1:-}" ]; then
+    echo "usage: $0 <image-base-name>"
+    exit 1
+fi
+
+IMAGE_NAME=$1
+IMAGE_TIMESTAMP=$(date +%Y%m%d%H%M%S)
+
+for DIR in $SCRIPT_ROOT/*; do
+    if [ -d $DIR ]; then
+        (set -x ; docker build -t "$IMAGE_NAME:$(basename $DIR).$IMAGE_TIMESTAMP" $DIR)
+    fi
+done

--- a/docker/centos.7/Dockerfile
+++ b/docker/centos.7/Dockerfile
@@ -1,0 +1,28 @@
+FROM centos:7
+
+RUN curl -L -o /etc/yum.repos.d/EfficiOS-RHEL7-x86-64.repo https://packages.efficios.com/repo.files/EfficiOS-RHEL7-x86-64.repo && \
+    yum update -y && \
+    yum install -y git \
+        libunwind-devel \
+        gettext \
+        libuuid-devel \
+        lttng-ust-devel \
+        libcurl-devel \
+        openssl-devel \
+        zlib-devel \
+        libicu-devel \
+        cmake \
+        make \
+        automake \
+        libtool \
+        which \
+        https://matell.blob.core.windows.net/rpms/clang-3.6.2-1.el7.centos.x86_64.rpm \
+        https://matell.blob.core.windows.net/rpms/clang-libs-3.6.2-1.el7.centos.x86_64.rpm \
+        https://matell.blob.core.windows.net/rpms/lldb-3.6.2-1.el7.centos.x86_64.rpm \
+        https://matell.blob.core.windows.net/rpms/lldb-devel-3.6.2-1.el7.centos.x86_64.rpm \
+        https://matell.blob.core.windows.net/rpms/llvm-3.6.2-1.el7.centos.x86_64.rpm \
+        https://matell.blob.core.windows.net/rpms/llvm-libs-3.6.2-1.el7.centos.x86_64.rpm && \
+    yum clean all && \
+    rm -rf /tmp/* /var/tmp/*
+
+ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8

--- a/docker/fedora.23/Dockerfile
+++ b/docker/fedora.23/Dockerfile
@@ -1,0 +1,25 @@
+FROM fedora:23
+
+RUN dnf update -y && \
+    dnf install -y git \
+        python \
+        hostname \
+        libunwind-devel \
+        gettext \
+        libuuid-devel \
+        lttng-ust-devel \
+        libcurl-devel \
+        openssl-devel \
+        zlib-devel \
+        libicu-devel \
+        cmake \
+        make \
+        automake \
+        libtool \
+        which \
+        clang \
+        lldb-devel && \
+    dnf clean all && \
+    rm -rf /tmp/* /var/tmp/*
+
+ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8

--- a/docker/ubuntu.14.04/Dockerfile
+++ b/docker/ubuntu.14.04/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:14.04
+
+RUN apt-get update && \
+    apt-get upgrade -qqy && \
+    apt-get install -qqy curl \
+        unzip \
+        git \
+        python \
+        build-essential \
+        cmake \
+        automake \
+        libtool \
+        clang-3.5 \
+        lldb-3.6-dev \
+        libunwind8-dev \
+        libicu-dev \
+        liblttng-ust-dev \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        uuid-dev \
+        gettext && \
+    locale-gen en_US.UTF-8 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+DOCKER_FILE=""
+DOCKER_IMAGE=""
+SCRIPT_ROOT="$(cd -P "$( dirname "$0" )" && pwd)"
+REPO_ROOT="$(cd -P "$SCRIPT_ROOT/../" && pwd)"
+
+case $(echo $1 | awk '{print tolower($0)}') in
+    -d | --dockerfile)
+        DOCKER_FILE=$2
+        ;;
+    -i | --image)
+        DOCKER_IMAGE=$2
+        ;;
+    *)
+        echo "usage: $0 [[-d | --dockerfile] <path-to-dockerfile>] | [-i | --image] <image-id>]] cmd-to-run"
+        exit 1
+        ;;
+esac
+
+shift
+shift
+
+if [ $DOCKER_FILE ]; then
+    if [ -d $DOCKER_FILE ]; then
+        DOCKER_FILE="$DOCKER_FILE/Dockerfile"
+    fi
+
+    DOCKER_FILE_DIR=$(dirname $DOCKER_FILE)
+    DOCKER_IMAGE=$(set -x ; docker build -q -f $DOCKER_FILE $DOCKER_FILE_DIR)
+fi
+
+DOCKER_USERADD_AND_SWITCH_CMD=""
+
+if [ ! $(id -u) = 0 ]; then
+    DOCKER_USERADD_AND_SWITCH_CMD="useradd -m -u $(id -u) $(id -n -u) && su $(id -n -u) -c "
+fi
+
+ARGS=$(IFS=' ' ; echo $@)
+(set -x ; docker run --rm --init -v $REPO_ROOT:/code -t $DOCKER_IMAGE /bin/sh -c "cd /code ; $DOCKER_USERADD_AND_SWITCH_CMD\"$ARGS\"")


### PR DESCRIPTION
This changes adds Dockerfiles that describe a build environment for
.NET Core for CentOS 7, Ubuntu 14.0 and Fedora Core 23.

In addition there are some helper scripts to automate building an
image from a Dockerfile and then spin up a transient docker container
based on that image, with the source code mounted in it. The scripts
do work to ensure that the UID of the worker *inside* the container
matches the UID of the user that invoked the script *outside* the
container so any generated files are owned by the user instead of
root.

Example usage:

```
./scripts/docker-run.sh -d docker/ubuntu.14.04/Dockerfile ./build.sh
```

This will build an image based on the
docker/ubuntu.14.04/Dockerfile (this will be slow the first time but
docker caching on a local machine will make everything faster on the
next invocation, the spin up a container with the source code mounted
in /code (which will be the CWD for the command). When the command
finishes, the docker container will be removed.  Artifacts from the
build continue to be present in `<repo-root>/bin` as expected.

At some point I would like to move CI to consume these docker
images. We'll either need to push images to an Azure docker
registry (the right long term thing) or dockerhub (a good short term
hack).