### PR TITLE
Move CI to OSX 10.12

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -48,13 +48,13 @@ def addPushJob(String project, String branch, String os, String configuration)
     Utilities.addGithubPushTrigger(newJob);
 }
 
-["Ubuntu14.04", "RHEL7.2", "Windows_NT", "OSX"].each { os ->
+["Ubuntu14.04", "RHEL7.2", "Windows_NT", "OSX10.12"].each { os ->
   addPullRequestJob(project, branch, os, "Release", true);
   addPullRequestJob(project, branch, os, "Debug", false);
 };
 
 // Per push, run all the jobs
-["Ubuntu14.04", "RHEL7.2", "Windows_NT", "OSX"].each { os ->
+["Ubuntu14.04", "RHEL7.2", "Windows_NT", "OSX10.12"].each { os ->
   ["Release", "Debug"].each { configuration ->
     addPushJob(project, branch, os, configuration);
   };


### PR DESCRIPTION
CoreFX has a dependency on this now so we need to start using these
machines to build.