### PR TITLE
Recursively clean submodules

### DIFF
--- a/clean-submodules.cmd
+++ b/clean-submodules.cmd
@@ -1,3 +1,3 @@
 @echo off
-git submodule foreach git clean -dxf
-git submodule foreach git reset --hard
+git submodule foreach --recursive git clean -dxf
+git submodule foreach --recursive git reset --hard

--- a/clean-submodules.sh
+++ b/clean-submodules.sh
@@ -2,6 +2,6 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-git submodule foreach git clean -dxf
-git submodule foreach git reset --hard
+git submodule foreach --recursive git clean -dxf
+git submodule foreach --recursive git reset --hard
 


### PR DESCRIPTION
By default, `submodule foreach` doesn't recurse, so the helper script doesn't clean submodules inside the submodules (e.g. `src/nuget-client/submodules/FileSystem`).