### PR TITLE
Consume downstack packages during composed build

### DIFF
--- a/.toolversions
+++ b/.toolversions
@@ -1,1 +1,1 @@
-Microsoft.DotNet.BuildTools=1.0.27-prerelease-01316-07
+Microsoft.DotNet.BuildTools=1.0.27-prerelease-01430-03

--- a/targets/coreclr.props
+++ b/targets/coreclr.props
@@ -7,4 +7,17 @@
     <PackagesOutput>$(ProjectDirectory)/bin/Product/$(TargetOS).$(Platform).$(Configuration)/.nuget/pkg/</PackagesOutput>
     <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension)</CleanCommand>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <ProjectJsonFileBaseDir>$(ProjectDirectory)/tests/</ProjectJsonFileBaseDir>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      TODO: Make ProjectJsonFiles more accessible in CoreCLR to avoid duplication here.
+      Copied from tests/build.proj and rerooted. From coreclr@cb01aa8
+    -->
+    <ProjectJsonFiles Include="$(ProjectJsonFileBaseDir)src\**\project.json" />
+    <ProjectJsonFiles Include="$(ProjectJsonFileBaseDir)scripts\**\project.json" />
+  </ItemGroup>
 </Project>

--- a/targets/corefx.props
+++ b/targets/corefx.props
@@ -10,4 +10,11 @@
   <ItemGroup>
     <RepositoryReference Include="coreclr" />
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- TODO: Remove when corefx@addef97 is included. -->
+    <ProjectJsonFiles Include="$(ProjectDirectory)external\**\project.json" />
+    <ProjectJsonFiles Include="$(ProjectDirectory)external\**\optional.json" />
+    <ProjectJsonFiles Include="$(ProjectDirectory)external\**\project.json.template" />
+  </ItemGroup>
 </Project>

--- a/targets/repository.proj
+++ b/targets/repository.proj
@@ -7,6 +7,9 @@
   <!--Repo specific properties -->
   <Import Project="$(RepositoryName).props" />
 
+  <Import Project="$(ProjectDirectory)dependencies.props"
+          Condition="Exists('$(ProjectDirectory)dependencies.props')" />
+
   <Target Name="BuildRepositoryAndDependencies" DependsOnTargets="BuildRepositoryReferences;Build" />
 
   <Target Name="BuildRepositoryReferences" Condition="'@(RepositoryReference)' != ''">
@@ -56,7 +59,40 @@
     <Exec Command="$(UpdateCommand)" WorkingDirectory="$(ProjectDirectory)" />
   </Target>
 
- <Target Name="BootstrapBuildTools" BeforeTargets="Build"
+  <!--
+    Update a repository that uses the BuildTools auto-update flow.
+  -->
+  <Target Name="UpdateUsingBuildTools"
+          DependsOnTargets="UpdateDependencies"
+          BeforeTargets="Build;Update"
+          Condition="'@(DependencyBuildInfo)' != ''" />
+
+  <!--
+    Mutate the UpdateDependencies items to use only local build-infos.
+  -->
+  <Target Name="AdjustUpdateDependencyItems"
+          BeforeTargets="UpdateDependencies">
+    <ItemGroup>
+      <LocalDependencyBuildInfo Include="@(DependencyBuildInfo)"
+                                KeepMetadata="BuildInfoPath"
+                                Condition="Exists('$(IntermediatePath)%(DependencyBuildInfo.BuildInfoPath)\Latest_Packages.txt')">
+        <VersionsRepoDir>$(IntermediatePath)</VersionsRepoDir>
+      </LocalDependencyBuildInfo>
+
+      <!--
+        TODO: Strengthen association between DependencyBuildInfo and UpdateStep.
+        As of writing, it is only an unenforced convention for the ItemSpec of
+        an UpdateStep to be the name of the build-info that it uses.
+      -->
+      <UpdateStepWithoutLocalBuildInfo Include="@(UpdateStep)" Exclude="@(LocalDependencyBuildInfo)" />
+      <UpdateStep Remove="@(UpdateStepWithoutLocalBuildInfo)" />
+
+      <DependencyBuildInfo Remove="@(DependencyBuildInfo)" />
+      <DependencyBuildInfo Include="@(LocalDependencyBuildInfo)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="BootstrapBuildTools" BeforeTargets="Build"
          Condition="'$(SkipBootstrapBuildTools)' != 'true' and '$(_IsBootstrapping)' == 'true'">
    <PropertyGroup>
      <ProjectToolsDir>$(ProjectDirectory)Tools/</ProjectToolsDir>
@@ -74,6 +110,8 @@
    <Copy SourceFiles="$(BootstrapBuildToolsDir)/BuildToolsVersion.txt"
          DestinationFolder="$(ProjectDirectory)" />
   </Target>
+
+  <Import Project="$(ToolsDir)VersionTools.targets" />
 
   <!--Repo targets -->
   <Import Project="$(RepositoryName).targets" Condition="Exists('$(RepositoryName).targets')"/>


### PR DESCRIPTION
Adds an `UpdateUsingBuildTools` target in repository.proj. If it detects a dependencies.props file in the root of the repo (right now only CoreFX and CoreCLR), it figures out which BuildInfos are on disk (built earlier in this build or in earlier builds) and applies the associated updaters. (This includes earlier builds of the same repository: both CoreCLR and CoreFX are self-dependent for tests.)

Resolves https://github.com/dotnet/core-eng/issues/485, but since we don't have a buildtools submodule yet (https://github.com/dotnet/core-eng/issues/320) it isn't tested with that repo. There's no good reason this strategy won't work there, though.

I started this off by trying to call into each submodule's build to avoid bringing VersionTools.targets into repository.proj, but injecting the logic to redirect the buildinfo items was convoluted this way. I can continue that direction and just make more coreclr/corefx/buildtools changes if that sounds better, though.

---

There are todos to get rid of redundant project.json items I added to corefx.props and coreclr.props. These need coreclr and corefx changes.

---

For example, in RHEL CI, this output shows the updates:

```
UpdateDependencies:
  DEFAULT_APPNAME Information: 0 : Writing changes to /mnt/resource/j/workspace/Private/dotnet_source-build/master/dotnet_source-build_RHEL7.2_Release_prtest/src/corefx/external/ilasm/project.json.template
  DEFAULT_APPNAME Information: 0 : Writing changes to /mnt/resource/j/workspace/Private/dotnet_source-build/master/dotnet_source-build_RHEL7.2_Release_prtest/src/corefx/external/runtime/project.json.template
  DEFAULT_APPNAME Information: 0 : Writing changes to /mnt/resource/j/workspace/Private/dotnet_source-build/master/dotnet_source-build_RHEL7.2_Release_prtest/src/corefx/dependencies.props
```