### PR TITLE
Use repositories.props branches for auto-update

### DIFF
--- a/repositories.props
+++ b/repositories.props
@@ -18,7 +18,7 @@
     </Repository>
     <Repository Include="roslyn" >
       <Organization>dotnet</Organization>
-      <Branch>netcore1.0</Branch>
+      <Branch>master</Branch>
       <PathToRepo>$(PathToRoslyn)</PathToRepo>
     </Repository>
     <Repository Include="core-setup" >

--- a/scripts/auto-update/build.proj
+++ b/scripts/auto-update/build.proj
@@ -2,5 +2,23 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="dir.props" />
 
+  <Target Name="CreateLatestCommitUpdateSteps"
+          BeforeTargets="VerifyDependencies;
+                         UpdateDependencies;
+                         UpdateDependenciesAndSubmitPullRequest">
+    <ItemGroup>
+      <RepositoriesNotUpdating Include="@(Repository)"
+                               Exclude="@(LatestCommitUpdateStep)" />
+      <UpdateStep Include="@(Repository)"
+                  Exclude="@(RepositoriesNotUpdating)"
+                  KeepMetadata="Branch">
+        <UpdaterType>Submodule from latest</UpdaterType>
+        <Path>$(SubmoduleDirectory)%(Identity)</Path>
+        <Repository>origin</Repository>
+        <Ref>%(Branch)</Ref>
+      </UpdateStep>
+    </ItemGroup>
+  </Target>
+
   <Import Project="$(ToolsDir)VersionTools.targets" />
 </Project>

--- a/scripts/auto-update/dependencies.props
+++ b/scripts/auto-update/dependencies.props
@@ -33,29 +33,9 @@
       <PackageDownloadBaseUrl>$(DotNetCoreV2BaseUrl)</PackageDownloadBaseUrl>
     </UpdateStep>
 
-    <UpdateStep Include="Core-Setup">
-      <UpdaterType>Submodule from latest</UpdaterType>
-      <Path>$(SubmoduleDirectory)core-setup</Path>
-      <Repository>origin</Repository>
-      <Ref>master</Ref>
-    </UpdateStep>
-    <UpdateStep Include="CoreCLR">
-      <UpdaterType>Submodule from latest</UpdaterType>
-      <Path>$(SubmoduleDirectory)coreclr</Path>
-      <Repository>origin</Repository>
-      <Ref>master</Ref>
-    </UpdateStep>
-    <UpdateStep Include="Roslyn">
-      <UpdaterType>Submodule from latest</UpdaterType>
-      <Path>$(SubmoduleDirectory)roslyn</Path>
-      <Repository>origin</Repository>
-      <Ref>master</Ref>
-    </UpdateStep>
-    <UpdateStep Include="Standard">
-      <UpdaterType>Submodule from latest</UpdaterType>
-      <Path>$(SubmoduleDirectory)standard</Path>
-      <Repository>origin</Repository>
-      <Ref>master</Ref>
-    </UpdateStep>
+    <LatestCommitUpdateStep Include="core-setup;
+                                     coreclr;
+                                     roslyn;
+                                     standard" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/56

I took a stab at removing the duplication of the branch names. I had to change roslyn to `master` because `netcore1.0` seems to have been deleted. The current submodule commit is contained in roslyn/master, so I picked that for now.

This is pointless to merge until https://github.com/dotnet/core-eng/issues/550 is fixed. (Auto-update builds aren't working.)