### PR TITLE
Use non-binary patching to work around different line endings than we expect.

### DIFF
--- a/targets/repository.proj
+++ b/targets/repository.proj
@@ -43,7 +43,7 @@
 
     <PropertyGroup>
       <PatchCommand Condition="'$(IsJenkinsBuild)' == 'true'">git apply --ignore-whitespace --whitespace=nowarn</PatchCommand>
-      <PatchCommand Condition="'$(IsJenkinsBuild)' != 'true'">patch -p1 --ignore-whitespace --binary -i</PatchCommand>
+      <PatchCommand Condition="'$(IsJenkinsBuild)' != 'true'">patch -p1 --ignore-whitespace -i</PatchCommand>
     </PropertyGroup>
 
     <Exec Command="$(PatchCommand) %(PatchesToApply.Identity)"


### PR DESCRIPTION
Default git behavior has changed over time and people can have different `core.eol` and `core.autocrlf` settings, which can cause issues when we try to apply patches.  This change makes us use text patching instead of binary, which handles differing line endings.