### PR TITLE
only generate rootfs for cross-compile if it doesn't exist

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -30,8 +30,8 @@
   </Target>
 
   <Target Name="GenerateRootFs">
-     <Exec Condition="$(Platform.Contains('arm')) AND '$(Platform)' != 'armel'" Command="$(ArmEnvironmentVariables) sh -c 'if [ ! -d &quot;$ROOTFS_DIR&quot; ]; then ./cross/build-rootfs.sh; fi'" />
-     <Exec Condition="'$(Platform)' == 'armel'" Command="$(ArmEnvironmentVariables) sh -c 'if [ ! -d &quot;$ROOTFS_DIR&quot; ]; then ./cross/armel/tizen-build-rootfs.sh; fi'" />
+     <Exec Condition="!Exists($(CrossRootFsDir)) AND $(Platform.Contains('arm')) AND '$(Platform)' != 'armel'" Command="$(ArmEnvironmentVariables) ./cross/build-rootfs.sh;" />
+     <Exec Condition="!Exists($(CrossRootFsDir)) AND '$(Platform)' == 'armel'" Command="$(ArmEnvironmentVariables) ./cross/armel/tizen-build-rootfs.sh" />
   </Target>
 
   <Target Name="BuildDummyPackages">

--- a/build.proj
+++ b/build.proj
@@ -30,8 +30,8 @@
   </Target>
 
   <Target Name="GenerateRootFs">
-     <Exec Condition="$(Platform.Contains('arm')) AND '$(Platform)' != 'armel'" Command="$(ArmEnvironmentVariables) ./cross/build-rootfs.sh" />
-     <Exec Condition="'$(Platform)' == 'armel'" Command="$(ArmEnvironmentVariables) ./cross/armel/tizen-build-rootfs.sh" />
+     <Exec Condition="$(Platform.Contains('arm')) AND '$(Platform)' != 'armel'" Command="$(ArmEnvironmentVariables) sh -c 'if [ ! -d &quot;$ROOTFS_DIR&quot; ]; then ./cross/build-rootfs.sh; fi'" />
+     <Exec Condition="'$(Platform)' == 'armel'" Command="$(ArmEnvironmentVariables) sh -c 'if [ ! -d &quot;$ROOTFS_DIR&quot; ]; then ./cross/armel/tizen-build-rootfs.sh; fi'" />
   </Target>
 
   <Target Name="BuildDummyPackages">

--- a/dir.props
+++ b/dir.props
@@ -59,8 +59,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-     <ArmEnvironmentVariables Condition="'$(ArmEnvironmentVariables)' == ''">ROOTFS_DIR=$(BaseIntermediatePath)crossrootfs/arm</ArmEnvironmentVariables>
-     <ArmEnvironmentVariables Condition="'$(Platform)' == 'armel'">ROOTFS_DIR=$(BaseIntermediatePath)crossrootfs/armel</ArmEnvironmentVariables>
+     <CrossRootFsDir Condition="'$(CrossRootFsDir)' == '' AND '$(Platform)' == 'armel'">$(ProjectDir)cross/rootfs/armel</CrossRootFsDir>
+     <CrossRootFsDir Condition="'$(CrossRootFsDir)' == ''">$(ProjectDir)cross/rootfs/arm</CrossRootFsDir>
+     <ArmEnvironmentVariables Condition="'$(ArmEnvironmentVariables)' == ''">ROOTFS_DIR=$(CrossRootFsDir)</ArmEnvironmentVariables>
    </PropertyGroup>
  
    <Import Project="$(TargetInfoProps)" Condition="$(GeneratingStaticPropertiesFile) != 'true' AND Exists('$(TargetInfoProps)')" />


### PR DESCRIPTION
Resolves #113.

Sorry for the wonky `Command`, but since the `ROOTFS_DIR` environment variable is passed in as part of the `Command`, we can't use the `Condition` attribute to check for it there.