### PR TITLE
Add patches to unblock CI.

### DIFF
--- a/patches/cli/0012-allow-intermediate-package-cache.patch
+++ b/patches/cli/0012-allow-intermediate-package-cache.patch
@@ -1,0 +1,52 @@
+From d8d39ebf8c98a5339089cb89d5838e4ece71780f Mon Sep 17 00:00:00 2001
+From: karajas <karajas@microsoft.com>
+Date: Wed, 6 Sep 2017 18:33:13 -0400
+Subject: [PATCH] Allow cli to restore to an intermdiate package cache to pick up source built packages 
+
+---
+ build/Prepare.targets | 22 +++++++++++++++++++++-
+ 1 file changed, 21 insertions(+), 1 deletion(-)
+
+diff --git a/build/Prepare.targets b/build/Prepare.targets
+index 214b1f7..b94b60a 100644
+--- a/build/Prepare.targets
++++ b/build/Prepare.targets
+@@ -83,6 +83,26 @@
+                    ProjectPath="&quot;%(RestoreToolsPackagesInput.FullPath)&quot;"
+                    AdditionalParameters="/p:UsePortableLinuxSharedFramework=$(UsePortableLinuxSharedFramework)" />
+ 
++
++      <PropertyGroup>
++        <IntermediateToolsPackages>$(MSBuildThisFileDirectory)packages</IntermediateToolsPackages>
++        <FilesToCopyPattern>$(MSBuildThisFileDirectory)packages/**/*</FilesToCopyPattern>
++      </PropertyGroup>
++  
++      <DotNetRestore ToolPath="$(Stage0Directory)"
++                     ProjectPath="&quot;$(RepoRoot)/tools/CrossGen.Dependencies/CrossGen.Dependencies.csproj&quot;"
++                     Source="$(SourceBuiltPackages)"
++                     Runtime="$(SharedFrameworkRid)"
++                     Packages="$(IntermediateToolsPackages)"
++                     AdditionalParameters="/p:UsePortableLinuxSharedFramework=$(UsePortableLinuxSharedFramework)" />
++                     
++      <ItemGroup>
++        <FilesToCopy Include="$(FilesToCopyPattern)" />
++      </ItemGroup>
++  
++    <Message importance="high" text="KARTHIKDEBUG '@(FilesToCopy)' '$(NuGetPackagesDir)'" />
++    <Copy SourceFiles="@(FilesToCopy)" OverwriteReadOnlyFiles="true" DestinationFolder="$(NuGetPackagesDir)/%(RecursiveDir)"/>
++
+   </Target>
+ 
+   <Target Name="CleanToolsLockFiles" >
+@@ -94,7 +114,7 @@
+ 
+   <Target Name="SetupRestoreToolsPackagesInputsOutputs">
+     <ItemGroup>
+-      <RestoreToolsPackagesInput Include="$(RepoRoot)/tools/**/*.csproj" />
++      <RestoreToolsPackagesInput Include="$(RepoRoot)/tools/**/*.csproj" Exclude="$(RepoRoot)/tools/CrossGen.Dependencies/CrossGen.Dependencies.csproj" />
+     </ItemGroup>
+   </Target>
+ 
+-- 
+1.8.3.1
+

--- a/patches/core-setup/0008-add-intermediate-packages.patch
+++ b/patches/core-setup/0008-add-intermediate-packages.patch
@@ -1,0 +1,106 @@
+From fdf6d172cb103288b16f8bfcd5fc1df69783e907 Mon Sep 17 00:00:00 2001
+From: karajas <karajas@microsoft.com>
+Date: Tue, 5 Sep 2017 17:36:32 -0400
+Subject: [PATCH] Add core-setup patch to allow intermediate package cache to pick up source built packages 
+
+---
+ dir.props                                        |  3 ++-
+ src/sharedFramework/framework/framework.csproj   |  4 ++++
+ src/sharedFramework/lockedhost/lockedhost.csproj |  3 +++
+ src/sharedFramework/sharedFramework.proj         | 16 ++++++++--------
+ 4 files changed, 17 insertions(+), 9 deletions(-)
+
+diff --git a/dir.props b/dir.props
+index 2909110..5ae64a9 100644
+--- a/dir.props
++++ b/dir.props
+@@ -276,6 +276,7 @@
+ 
+     <SharedFrameworkPublishDir>$(IntermediateOutputRootPath)sharedFrameworkPublish\</SharedFrameworkPublishDir>
+     <SharedFrameworkPublishSymbolsDir>$(IntermediateOutputRootPath)sharedFrameworkPublish.symbols\</SharedFrameworkPublishSymbolsDir>
++    <SharedFrameworkIntermediatePackagesDir>$(IntermediateOutputRootPath)sharedFrameworkPublish\packages\</SharedFrameworkIntermediatePackagesDir>
+     <SharedFrameworkNameAndVersionRoot>$(SharedFrameworkPublishDir)shared\$(SharedFrameworkName)\$(SharedFrameworkNugetVersion)</SharedFrameworkNameAndVersionRoot>
+   </PropertyGroup>
+ 
+@@ -429,4 +430,4 @@
+   <!-- Use Roslyn Compilers to build -->
+   <Import Project="$(RoslynPropsFile)" Condition="'$(OsEnvironment)'!='Windows_NT' and Exists('$(RoslynPropsFile)') and '$(UseRoslynCompilers)'!='false'" />
+   <Import Project="$(RoslynPropsFile)" Condition="'$(OsEnvironment)'=='Windows_NT' and Exists('$(RoslynPropsFile)')" />
+-</Project>
+\ No newline at end of file
++</Project>
+diff --git a/src/sharedFramework/framework/framework.csproj b/src/sharedFramework/framework/framework.csproj
+index 52e6553..d4bcf1d 100644
+--- a/src/sharedFramework/framework/framework.csproj
++++ b/src/sharedFramework/framework/framework.csproj
+@@ -4,4 +4,8 @@
+     <OutputType>Exe</OutputType>
+   </PropertyGroup>
+ 
++  <ItemGroup>
++    <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.0.0" />
++  </ItemGroup>
++
+ </Project>
+diff --git a/src/sharedFramework/lockedhost/lockedhost.csproj b/src/sharedFramework/lockedhost/lockedhost.csproj
+index aaf2c49..8080dd0 100644
+--- a/src/sharedFramework/lockedhost/lockedhost.csproj
++++ b/src/sharedFramework/lockedhost/lockedhost.csproj
+@@ -3,6 +3,9 @@
+   <PropertyGroup>
+     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
++    <CopyBuildOutputToPublishDirectory>false</CopyBuildOutputToPublishDirectory>
++    <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
++    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+   </PropertyGroup>
+ 
+   <ItemGroup>
+diff --git a/src/sharedFramework/sharedFramework.proj b/src/sharedFramework/sharedFramework.proj
+index d287053..e07a8a8 100644
+--- a/src/sharedFramework/sharedFramework.proj
++++ b/src/sharedFramework/sharedFramework.proj
+@@ -28,13 +28,13 @@
+ 
+     <RemoveDir Directories="$(SharedFrameworkNameAndVersionRoot)" />
+ 
+-    <Exec Command="$(DotnetRestoreCommand) --source $(PackagesOutDir) $(CommonSharedFrameworkArgs)"
++    <Exec Command="$(DotnetToolCommand) restore --packages $(SharedFrameworkIntermediatePackagesDir) --source $(PackagesOutDir) --source $(PackagesDir) $(CommonSharedFrameworkArgs)"
+           WorkingDirectory="$(SharedFrameworkSourceRoot)" />
+ 
+     <!-- We publish to a sub folder of the PublishRoot so tools like heat and zip can generate folder structures easier. -->
+-    <Exec Command="$(DotnetToolCommand) publish --output $(SharedFrameworkNameAndVersionRoot) $(CommonSharedFrameworkArgs)"
++    <Exec Command="$(DotnetToolCommand) publish --output $(SharedFrameworkNameAndVersionRoot) $(CommonSharedFrameworkArgs) /p:PackagesDir=$(SharedFrameworkIntermediatePackagesDir)"
+           WorkingDirectory="$(SharedFrameworkSourceRoot)"
+-          EnvironmentVariables="NUGET_PACKAGES=$(PackagesDir)" />
++          EnvironmentVariables="NUGET_PACKAGES=$(SharedFrameworkIntermediatePackagesDir)" />
+ 
+     <!-- Clean deps.json -->
+     <ChangeEntryPointLibraryName DepsFile="$(SharedFrameworkNameAndVersionRoot)/framework.deps.json" />
+@@ -134,17 +134,17 @@
+     <PropertyGroup>
+       <LockedHostSourceRoot>$(MSBuildThisFileDirectory)lockedhost</LockedHostSourceRoot>
+       <CommonLockedHostArgs>/p:TargetFramework=$(Framework) /p:RuntimeIdentifier=$(PackageTargetRid) /p:HostResolverVersion=$(HostResolverVersion) /p:HostVersion=$(HostVersion)</CommonLockedHostArgs>
++      <LockedCoreHostRestoreCommand>$(DotnetToolCommand) restore --packages $(SharedFrameworkIntermediatePackagesDir) --source $(PackagesOutDir) $(CommonLockedHostArgs)</LockedCoreHostRestoreCommand>
+     </PropertyGroup>
+ 
+     <RemoveDir Directories="$(CoreHostLockedDir)" />
+ 
+-    <Exec Command="$(DotnetRestoreCommand) --source $(PackagesOutDir) $(CommonLockedHostArgs)"
+-          WorkingDirectory="$(LockedHostSourceRoot)" />
++    <Exec Command="$(LockedCoreHostRestoreCommand)" WorkingDirectory="$(LockedHostSourceRoot)" />
+ 
+ 
+-    <Exec Command="$(DotnetToolCommand) publish --output $(CoreHostLockedDir) $(CommonLockedHostArgs)"
++    <Exec Command="$(DotnetToolCommand) publish --output $(CoreHostLockedDir) $(CommonLockedHostArgs) /p:PackagesDir=$(SharedFrameworkIntermediatePackagesDir)"
+           WorkingDirectory="$(LockedHostSourceRoot)"
+-          EnvironmentVariables="NUGET_PACKAGES=$(PackagesDir)" />
++          EnvironmentVariables="NUGET_PACKAGES=$(SharedFrameworkIntermediatePackagesDir)" />
+   </Target>
+ 
+-</Project>
+\ No newline at end of file
++</Project>
+-- 
+1.8.3.1
+

--- a/patches/sdk/0002-Unify-versions.patch
+++ b/patches/sdk/0002-Unify-versions.patch
@@ -21,7 +21,7 @@ index 0e78565..ba8d754 100644
 +    <MsBuildPackagesVersion>15.3.409</MsBuildPackagesVersion>
 +    <DependencyModelVersion>2.0.0</DependencyModelVersion>
 +    <PlatformAbstractionsVersion>2.0.0</PlatformAbstractionsVersion>
-     <NuGetVersion>4.3.0-rtm-4324</NuGetVersion>
+     <NuGetVersion>4.3.0-rtm-4382</NuGetVersion>
      <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
      <SystemReflectionMetadataVersion>1.4.2</SystemReflectionMetadataVersion>
 -    <NETStandardLibraryNETFrameworkVersion>2.0.0-preview2-25405-01</NETStandardLibraryNETFrameworkVersion>

--- a/patches/xliff-tasks/0001-build-pack-project.patch
+++ b/patches/xliff-tasks/0001-build-pack-project.patch
@@ -1,14 +1,14 @@
-From a498d64a86c0d0c9b55d46af27c7d11b250a6f48 Mon Sep 17 00:00:00 2001
+From 47b4458cb15d7c9fb74a5c73cf52b9179033a799 Mon Sep 17 00:00:00 2001
 From: karajas <karajas@microsoft.com>
-Date: Tue, 11 Jul 2017 23:06:06 +0000
-Subject: [PATCH] Build only source project
+Date: Tue, 5 Sep 2017 17:52:05 -0400
+Subject: [PATCH] Build pack project
 
 ---
- build/build.proj | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+ build/build.proj | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/build/build.proj b/build/build.proj
-index fb1c221..e17c5cf 100644
+index fb1c221..32abffb 100644
 --- a/build/build.proj
 +++ b/build/build.proj
 @@ -14,7 +14,7 @@
@@ -20,13 +20,16 @@ index fb1c221..e17c5cf 100644
    </Target>
  
    <Target Name="Test">
-@@ -24,4 +24,4 @@
+@@ -22,6 +22,6 @@
+   </Target>
+ 
    <Target Name="Pack">
-     <MSBuild Projects="@(PackProject)" Targets="Pack" Properties="NoBuild=true" />
+-    <MSBuild Projects="@(PackProject)" Targets="Pack" Properties="NoBuild=true" />
++    <MSBuild Projects="@(PackProject)" Targets="Pack" />
    </Target>
 -</Project>
 \ No newline at end of file
 +</Project>
 -- 
-1.9.1
+1.8.3.1
 


### PR DESCRIPTION
This changeset introduces the fixes required to get a clean master and a passing CI. The struggle mainly comes from the fact that there are now 2.0.0 versioned packages from products in the official feeds.