### PR TITLE
Continue build if a patch fails

### DIFF
--- a/targets/repository.proj
+++ b/targets/repository.proj
@@ -43,7 +43,7 @@
 
     <PropertyGroup>
       <PatchCommand Condition="'$(IsJenkinsBuild)' == 'true'">git apply --ignore-whitespace --whitespace=nowarn</PatchCommand>
-      <PatchCommand Condition="'$(IsJenkinsBuild)' != 'true'">patch -p1 --ignore-whitespace -i</PatchCommand>
+      <PatchCommand Condition="'$(IsJenkinsBuild)' != 'true'">patch -p1 --ignore-whitespace -i || true</PatchCommand>
     </PropertyGroup>
 
     <Exec Command="$(PatchCommand) %(PatchesToApply.Identity)"


### PR DESCRIPTION
Resolves #121.

I only updated the one condition, when `$(IsJenkinsBuild) != 'true'`, as it seems like when `$(IsJenkinsBuild) == 'true'` then a clean build environment should be expected. Let me know if this is not the case, and I should update both to keep them the same (or if we should merge these so we're not using two different commands for CI and non-CI builds!)