### PR TITLE
Switch to always using git apply to eliminate patch dependency

### DIFF
--- a/targets/repository.proj
+++ b/targets/repository.proj
@@ -42,8 +42,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <PatchCommand Condition="'$(IsJenkinsBuild)' == 'true'">git apply --ignore-whitespace --whitespace=nowarn</PatchCommand>
-      <PatchCommand Condition="'$(IsJenkinsBuild)' != 'true'">patch -p1 --ignore-whitespace -i</PatchCommand>
+      <PatchCommand>git apply --ignore-whitespace --whitespace=nowarn</PatchCommand>
     </PropertyGroup>
 
     <Exec Command="$(PatchCommand) %(PatchesToApply.Identity)"


### PR DESCRIPTION
cc @karajas 

While trying to make this work on other OS's we have to needlessly pull in this dependency and the entire forked patch mechanism doesn't seem necessary so just always use git apply instead of patch. 