### PR TITLE
Fix repo branches to match submodules

### DIFF
--- a/repositories.props
+++ b/repositories.props
@@ -18,7 +18,7 @@
     </Repository>
     <Repository Include="roslyn" >
       <Organization>dotnet</Organization>
-      <Branch>netcore1.0</Branch>
+      <Branch>master</Branch>
       <PathToRepo>$(PathToRoslyn)</PathToRepo>
     </Repository>
     <Repository Include="core-setup" >
@@ -28,7 +28,7 @@
     </Repository>
     <Repository Include="sdk" >
       <Organization>dotnet</Organization>
-      <Branch>master</Branch>
+      <Branch>release/2.0.0</Branch>
       <PathToRepo>$(PathToSdk)</PathToRepo>
     </Repository>
     <Repository Include="nuget-client" >
@@ -43,7 +43,7 @@
     </Repository>
     <Repository Include="vstest" >
       <Organization>microsoft</Organization>
-      <Branch>master</Branch>
+      <Branch>rel/15.3-rtm</Branch>
       <PathToRepo>$(PathToVstest)</PathToRepo>
     </Repository>
     <Repository Include="msbuild" >


### PR DESCRIPTION
For each `<Branch>` that didn't contain the submodule commit, I used `git branch --contains` and `git tag --points-at` to find reasonable values. I tried to pick the option that looked most correct when there was more than one.

Fixes https://github.com/dotnet/source-build/issues/112