### PR TITLE
Fix cli-deps-satellites on windows to not sign the satellites during source-build, since we are using a dummy RoslynTools package.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 * text=auto
+
+# patch files need lf line-endings, even on Windows
+*.patch text eol=lf

--- a/dir.props
+++ b/dir.props
@@ -79,6 +79,7 @@
     <EnvironmentVariables Include="DOTNET_TOOL_DIR=$(DotNetCliToolDir)" />
     <EnvironmentVariables Include="BUILD_TOOLS_TOOL_DIR=$(ProjectDir)Tools/" />
     <EnvironmentVariables Include="BUILDTOOLS_SKIP_CROSSGEN=1" />
+    <EnvironmentVariables Include="DotNet_SourceBuild=true" />
   </ItemGroup>
 
   <Import Project="repositories.props" />

--- a/dir.props
+++ b/dir.props
@@ -79,7 +79,7 @@
     <EnvironmentVariables Include="DOTNET_TOOL_DIR=$(DotNetCliToolDir)" />
     <EnvironmentVariables Include="BUILD_TOOLS_TOOL_DIR=$(ProjectDir)Tools/" />
     <EnvironmentVariables Include="BUILDTOOLS_SKIP_CROSSGEN=1" />
-    <EnvironmentVariables Include="DotNet_SourceBuild=true" />
+    <EnvironmentVariables Include="DotNet_BuildFromSource=true" />
   </ItemGroup>
 
   <Import Project="repositories.props" />

--- a/patches/cli-deps-satellites/0001-Allow-cli-deps-satellites-to-skip-signing-on-Windows.patch
+++ b/patches/cli-deps-satellites/0001-Allow-cli-deps-satellites-to-skip-signing-on-Windows.patch
@@ -1,0 +1,41 @@
+From ad9db12008d9d07bc6137c69234670112d5899fb Mon Sep 17 00:00:00 2001
+From: Eric Erhardt <eric.erhardt@microsoft.com>
+Date: Fri, 15 Sep 2017 20:08:48 -0500
+Subject: [PATCH] Allow cli-deps-satellites to skip signing on Windows during
+ source-build since we don't have the RoslynTools package
+
+---
+ src/Directory.Build.props   | 3 ++-
+ src/Directory.Build.targets | 2 +-
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/Directory.Build.props b/src/Directory.Build.props
+index 042f2ab..191b194 100644
+--- a/src/Directory.Build.props
++++ b/src/Directory.Build.props
+@@ -33,7 +33,8 @@
+     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\build\$(StrongNameKey).snk</AssemblyOriginatorKeyFile>
+     <SignToolConfig>$(MSBuildThisFileDirectory)..\build\$(StrongNameKey).json</SignToolConfig>
+     <SignAssembly>true</SignAssembly>
+-    
++    <SkipSignSatellites Condition="'$(SkipSignSatellites)' == '' and '$(DotNetBuildType)' == 'Source'">true</SkipSignSatellites>
++
+     <!-- Use delay signing instead of public signing on full msbuild to workaround https://github.com/Microsoft/msbuild/issues/1490 -->
+     <PublicSign Condition="'$(SignType)' != 'real' and '$(MSBuildRuntimeType)' == 'Core'">true</PublicSign>
+     <DelaySign Condition="'$(PublicSign)' != 'true'">true</DelaySign>
+diff --git a/src/Directory.Build.targets b/src/Directory.Build.targets
+index 8e76325..0f87c86 100644
+--- a/src/Directory.Build.targets
++++ b/src/Directory.Build.targets
+@@ -21,7 +21,7 @@
+ 
+   <Target Name="SignSatellites"
+           BeforeTargets="PackSatellites"
+-          Condition="$(IsPackage) and '$(OS)' == 'Windows_NT'">
++          Condition="$(IsPackage) and '$(OS)' == 'Windows_NT' and '$(SkipSignSatellites)' != 'true'">
+     <ItemGroup>
+       <SignToolArg Include="-nugetPackagesPath $(NuGetPackageRoot)" />
+       <SignToolArg Include="-intermediateOutputPath $(IntermediateOutputPath)" />
+-- 
+2.11.0 (Apple Git-81)
+

--- a/patches/cli-deps-satellites/0001-Allow-cli-deps-satellites-to-skip-signing-on-Windows.patch
+++ b/patches/cli-deps-satellites/0001-Allow-cli-deps-satellites-to-skip-signing-on-Windows.patch
@@ -18,7 +18,7 @@ index 042f2ab..191b194 100644
      <SignToolConfig>$(MSBuildThisFileDirectory)..\build\$(StrongNameKey).json</SignToolConfig>
      <SignAssembly>true</SignAssembly>
 -    
-+    <SkipSignSatellites Condition="'$(SkipSignSatellites)' == '' and '$(DotNetBuildType)' == 'Source'">true</SkipSignSatellites>
++    <SkipSignSatellites Condition="'$(SkipSignSatellites)' == '' and '$(DotNet_SourceBuild)' == 'true'">true</SkipSignSatellites>
 +
      <!-- Use delay signing instead of public signing on full msbuild to workaround https://github.com/Microsoft/msbuild/issues/1490 -->
      <PublicSign Condition="'$(SignType)' != 'real' and '$(MSBuildRuntimeType)' == 'Core'">true</PublicSign>

--- a/patches/cli-deps-satellites/0001-Allow-cli-deps-satellites-to-skip-signing-on-Windows.patch
+++ b/patches/cli-deps-satellites/0001-Allow-cli-deps-satellites-to-skip-signing-on-Windows.patch
@@ -18,7 +18,7 @@ index 042f2ab..191b194 100644
      <SignToolConfig>$(MSBuildThisFileDirectory)..\build\$(StrongNameKey).json</SignToolConfig>
      <SignAssembly>true</SignAssembly>
 -    
-+    <SkipSignSatellites Condition="'$(SkipSignSatellites)' == '' and '$(DotNet_SourceBuild)' == 'true'">true</SkipSignSatellites>
++    <SkipSignSatellites Condition="'$(SkipSignSatellites)' == '' and '$(DotNet_BuildFromSource)' == 'true'">true</SkipSignSatellites>
 +
      <!-- Use delay signing instead of public signing on full msbuild to workaround https://github.com/Microsoft/msbuild/issues/1490 -->
      <PublicSign Condition="'$(SignType)' != 'real' and '$(MSBuildRuntimeType)' == 'Core'">true</PublicSign>

--- a/patches/nuget-client/0004-Only-build-netstandard-and-netcoreapp-assets-on-NIX.patch
+++ b/patches/nuget-client/0004-Only-build-netstandard-and-netcoreapp-assets-on-NIX.patch
@@ -52,7 +52,7 @@ index 53a7cd7..82e7578 100644
    <PropertyGroup>
      <Description>NuGet wrapper for dotnet.exe</Description>
      <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
-+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' or '$(DotNet_SourceBuild)' == 'true'">netcoreapp1.0</TargetFrameworks>
++    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' or '$(DotNet_BuildFromSource)' == 'true'">netcoreapp1.0</TargetFrameworks>
      <RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' ">win7-x86</RuntimeIdentifier>
      <NoWarn>$(NoWarn);CS1591</NoWarn>
      <OutputType>Exe</OutputType>

--- a/patches/nuget-client/0004-Only-build-netstandard-and-netcoreapp-assets-on-NIX.patch
+++ b/patches/nuget-client/0004-Only-build-netstandard-and-netcoreapp-assets-on-NIX.patch
@@ -52,7 +52,7 @@ index 53a7cd7..82e7578 100644
    <PropertyGroup>
      <Description>NuGet wrapper for dotnet.exe</Description>
      <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
-+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp1.0</TargetFrameworks>
++    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' or '$(DotNet_SourceBuild)' == 'true'">netcoreapp1.0</TargetFrameworks>
      <RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' ">win7-x86</RuntimeIdentifier>
      <NoWarn>$(NoWarn);CS1591</NoWarn>
      <OutputType>Exe</OutputType>

--- a/targets/cli-deps-satellites.props
+++ b/targets/cli-deps-satellites.props
@@ -10,6 +10,7 @@
   <ItemGroup>
     <EnvironmentVariables Include="BuildNumber=$(BuildNumber)" />
     <EnvironmentVariables Include="Configuration=$(Configuration)" />
+    <EnvironmentVariables Include="DotNetBuildType=Source" />
   </ItemGroup>
 </Project>
 

--- a/targets/cli-deps-satellites.props
+++ b/targets/cli-deps-satellites.props
@@ -10,7 +10,6 @@
   <ItemGroup>
     <EnvironmentVariables Include="BuildNumber=$(BuildNumber)" />
     <EnvironmentVariables Include="Configuration=$(Configuration)" />
-    <EnvironmentVariables Include="DotNetBuildType=Source" />
   </ItemGroup>
 </Project>
 


### PR DESCRIPTION
/cc @crummel @dagood @weshaggard @jaredpar 