### PR TITLE
Update build docs and fix bash shebangs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ You can use these scripts to build the .NET Core product for Windows, macOS or L
 
 ## Using the Scripts
 
-The scripts are supported on Windows, macOS and Linux. The scripts are based on PowerShell on Windows and Bash on macOS and Linux.
+The scripts are supported on Windows, macOS and Linux. The scripts are based on PowerShell on Windows and Bash on macOS and Linux.  Currently, Windows scripts only build through core-setup and do not build the complete SDK.
+
+If you are building on Windows or OSX, building is possible via Docker. (https://hub.docker.com/r/microsoft/dotnet/)
 
 ### Build on Windows
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,15 @@ You can use these scripts to build the .NET Core product for Windows, macOS or L
 
 ## Using the Scripts
 
-The scripts are currently support only Linux at the moment. Windows and OSX are in the pipeline.
+The scripts are supported on Windows, macOS and Linux. The scripts are based on PowerShell on Windows and Bash on macOS and Linux.
 
-If you are building on Windows or OSX, building is possible via Docker. (https://hub.docker.com/r/microsoft/dotnet/)
+### Build on Windows
 
-### Build on Linux
+```console
+./build.ps1
+```
+
+### Build on Linux or macOS
 
 ```console
 ./build.sh

--- a/arm-ci.sh
+++ b/arm-ci.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 __currentWorkingDirectory=`pwd`
 __buildArch=$1
 shift;

--- a/armdeps.sh
+++ b/armdeps.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
- 
- apt-get install qemu qemu-user-static binfmt-support debootstrap libxml2-utils docker binutils-arm-linux-gnueabihf
- ./cross/build-rootfs.sh armel tizen
- 
+#!/usr/bin/env bash
+
+apt-get install qemu qemu-user-static binfmt-support debootstrap libxml2-utils docker binutils-arm-linux-gnueabihf
+
+./cross/build-rootfs.sh armel tizen

--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/check-submodules.sh
+++ b/check-submodules.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/docker/build-docker-images.sh
+++ b/docker/build-docker-images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 IFS=$'\n\t'
 SCRIPT_ROOT="$(cd -P "$( dirname "$0" )" && pwd)"

--- a/extract-patches.sh
+++ b/extract-patches.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/scripts/docker/docker-run.sh
+++ b/scripts/docker/docker-run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 SCRIPT_ROOT="$(cd -P "$( dirname "$0" )" && pwd)"

--- a/support/tarball/build.sh
+++ b/support/tarball/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 IFS=$'\n\t'
 


### PR DESCRIPTION
* The build notes about Windows and macOS at [./README.md](https://github.com/dotnet/source-build/tree/e45f8c0/README.md) were contradicting with [Documentation/README.md](https://github.com/dotnet/source-build/tree/e45f8c0/Documentation/README.md); now they are aligned.
* Bash is not situated at `/bin/` on every Unix-y OS; use `/usr/bin/env` to find `bash` path.