### PR TITLE
Fix args passed to build.proj from build.ps1

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,14 +1,14 @@
 Set-StrictMode -version 2.0
 $ErrorActionPreference = "Stop"
 
-# Handy function for executing a command in powershell and throwing if it 
-# fails.  
+# Handy function for executing a command in powershell and throwing if it
+# fails.
 #
-# Use this when the full command is known at script authoring time and 
+# Use this when the full command is known at script authoring time and
 # doesn't require any dynamic argument build up.  Example:
 #
 #   Exec-Block { & $msbuild Test.proj }
-# 
+#
 # Original sample came from: http://jameskovacs.com/2010/02/25/the-exec-problem/
 function Exec-Block([scriptblock]$cmd) {
     & $cmd
@@ -18,7 +18,7 @@ function Exec-Block([scriptblock]$cmd) {
     # - $lastexitcode: did a windows command executed by the script block end in error
     if ((-not $?) -or ($lastexitcode -ne 0)) {
         throw "Command failed to execute: $cmd"
-    } 
+    }
 }
 
 $SCRIPT_ROOT = "$PSScriptRoot"
@@ -34,10 +34,12 @@ Exec-Block { & "$SCRIPT_ROOT\init-tools.cmd" } | Out-Host
 $CLIPATH = "$SCRIPT_ROOT\Tools\dotnetcli"
 $SDKPATH = "$CLIPATH\sdk\$SdkVersion"
 
+$captured_args = $args
+
 Exec-Block { & "$CLIPATH\dotnet" restore "$SCRIPT_ROOT\tasks\Microsoft.DotNet.SourceBuild.Tasks\Microsoft.DotNet.SourceBuild.Tasks.csproj" } | Out-Host
 Exec-Block { & "$CLIPATH\dotnet" build "$SCRIPT_ROOT\tasks\Microsoft.DotNet.SourceBuild.Tasks\Microsoft.DotNet.SourceBuild.Tasks.csproj" } | Out-Host
 
 Remove-Item -Recurse -Force "$env:NUGET_PACKAGES"
 
-Exec-Block { & "$CLIPATH\dotnet" "$SDKPATH/MSBuild.dll" "$SCRIPT_ROOT/build.proj" @args /t:WriteDynamicPropsToStaticPropsFiles /p:GeneratingStaticPropertiesFile=true } | Out-Host
-Exec-Block { & "$CLIPATH\dotnet" "$SDKPATH/MSBuild.dll" "$SCRIPT_ROOT/build.proj" /flp:v=detailed /clp:v=detailed @args } | Out-Host
+Exec-Block { & "$CLIPATH\dotnet" "$SDKPATH/MSBuild.dll" "$SCRIPT_ROOT/build.proj" $captured_args /t:WriteDynamicPropsToStaticPropsFiles /p:GeneratingStaticPropertiesFile=true } | Out-Host
+Exec-Block { & "$CLIPATH\dotnet" "$SDKPATH/MSBuild.dll" "$SCRIPT_ROOT/build.proj" /flp:v=detailed /clp:v=detailed $captured_args } | Out-Host


### PR DESCRIPTION
Given we are wrapping in a script block we need to capture the
args for the root script outside of the script block.

@eerhardt 
