### PR TITLE
Fix websdk on Windows

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -79,7 +79,7 @@
     <EnvironmentVariables Include="DOTNET_TOOL_DIR=$(DotNetCliToolDir)" />
     <EnvironmentVariables Include="BUILD_TOOLS_TOOL_DIR=$(ProjectDir)Tools/" />
     <EnvironmentVariables Include="BUILDTOOLS_SKIP_CROSSGEN=1" />
-    <EnvironmentVariables Include="DotNet_BuildFromSource=true" />
+    <EnvironmentVariables Include="DotNetBuildFromSource=true" />
   </ItemGroup>
 
   <Import Project="repositories.props" />

--- a/patches/cli-deps-satellites/0001-Allow-cli-deps-satellites-to-skip-signing-on-Windows.patch
+++ b/patches/cli-deps-satellites/0001-Allow-cli-deps-satellites-to-skip-signing-on-Windows.patch
@@ -18,7 +18,7 @@ index 042f2ab..191b194 100644
      <SignToolConfig>$(MSBuildThisFileDirectory)..\build\$(StrongNameKey).json</SignToolConfig>
      <SignAssembly>true</SignAssembly>
 -    
-+    <SkipSignSatellites Condition="'$(SkipSignSatellites)' == '' and '$(DotNet_BuildFromSource)' == 'true'">true</SkipSignSatellites>
++    <SkipSignSatellites Condition="'$(SkipSignSatellites)' == '' and '$(DotNetBuildFromSource)' == 'true'">true</SkipSignSatellites>
 +
      <!-- Use delay signing instead of public signing on full msbuild to workaround https://github.com/Microsoft/msbuild/issues/1490 -->
      <PublicSign Condition="'$(SignType)' != 'real' and '$(MSBuildRuntimeType)' == 'Core'">true</PublicSign>

--- a/patches/nuget-client/0004-Only-build-netstandard-and-netcoreapp-assets-on-NIX.patch
+++ b/patches/nuget-client/0004-Only-build-netstandard-and-netcoreapp-assets-on-NIX.patch
@@ -28,7 +28,7 @@ index 80cae27..303002a 100644
  
    <PropertyGroup>
      <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
++    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' or '$(DotNetBuildFromSource)' == 'true'">netstandard1.3</TargetFrameworks>
      <NoWarn>$(NoWarn);CS1591</NoWarn>
      <AssemblyName>NuGet.Build.Tasks.Pack</AssemblyName>
  	<RootNamespace>$(AssemblyName)</RootNamespace>
@@ -40,7 +40,7 @@ index 649e788..c915374 100644
  
    <PropertyGroup>
      <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
++    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' or '$(DotNetBuildFromSource)' == 'true'">netstandard1.3</TargetFrameworks>
      <TargetFramework/>
      <Shipping>true</Shipping>
      <IncludeInVSIX>true</IncludeInVSIX>
@@ -52,7 +52,7 @@ index 53a7cd7..82e7578 100644
    <PropertyGroup>
      <Description>NuGet wrapper for dotnet.exe</Description>
      <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
-+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' or '$(DotNet_BuildFromSource)' == 'true'">netcoreapp1.0</TargetFrameworks>
++    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' or '$(DotNetBuildFromSource)' == 'true'">netcoreapp1.0</TargetFrameworks>
      <RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' ">win7-x86</RuntimeIdentifier>
      <NoWarn>$(NoWarn);CS1591</NoWarn>
      <OutputType>Exe</OutputType>
@@ -64,7 +64,7 @@ index ccb584e..65f1d43 100644
    <PropertyGroup>
      <Description>Complete commands common to command-line and GUI NuGet clients</Description>
      <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
++    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' or '$(DotNetBuildFromSource)' == 'true'">netstandard1.3</TargetFrameworks>
      <TargetFramework />
      <NoWarn>$(NoWarn);CS1591;CS1574;CS1573;CS1584;CS1658</NoWarn>
      <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
@@ -76,7 +76,7 @@ index 3706879..ebe1959 100644
  
    <PropertyGroup>
      <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
++    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' or '$(DotNetBuildFromSource)' == 'true'">netstandard1.3</TargetFrameworks>
      <TargetFramework />
      <NoWarn>$(NoWarn);CS1591;CS1574</NoWarn>
      <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
@@ -88,7 +88,7 @@ index 00b2170..6b2a19a 100644
      <Description>NuGet's client configuration settings implementation.</Description>
      <NoWarn>$(NoWarn);CS1591</NoWarn>
      <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
++    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' or '$(DotNetBuildFromSource)' == 'true'">netstandard1.3</TargetFrameworks>
      <TargetFramework />
      <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
      <PackProject>true</PackProject>
@@ -100,7 +100,7 @@ index dd71f8e..899cac8 100644
  
    <PropertyGroup>
      <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
++    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' or '$(DotNetBuildFromSource)' == 'true'">netstandard1.3</TargetFrameworks>
      <TargetFramework />
      <NoWarn>$(NoWarn);CS1591;CS1574</NoWarn>
      <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
@@ -112,7 +112,7 @@ index 5b31803..04e3870 100644
    <PropertyGroup>
      <Description>The understanding of target frameworks for NuGet.Packaging</Description>
      <TargetFrameworks>netstandard1.3;net45;net40</TargetFrameworks>
-+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
++    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' or '$(DotNetBuildFromSource)' == 'true'">netstandard1.3</TargetFrameworks>
      <TargetFramework />
      <NoWarn>$(NoWarn);CS1591;CS1574;CS1573</NoWarn>
      <LangVersion>5</LangVersion>
@@ -124,7 +124,7 @@ index 7e7e463..b0bcf71 100644
  
    <PropertyGroup>
      <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
++    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' or '$(DotNetBuildFromSource)' == 'true'">netstandard1.3</TargetFrameworks>
      <TargetFramework />
      <NoWarn>$(NoWarn);CS1591</NoWarn>
      <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
@@ -136,7 +136,7 @@ index 67f63e8..445c9b6 100644
    <PropertyGroup>
      <Description>The core data structures for NuGet.Packaging</Description>
      <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
++    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' or '$(DotNetBuildFromSource)' == 'true'">netstandard1.3</TargetFrameworks>
      <TargetFramework />
      <NoWarn>$(NoWarn);CS1591</NoWarn>
      <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
@@ -148,7 +148,7 @@ index 6c080fb..738c1e0 100644
    <PropertyGroup>
      <Description>NuGet's implementation for reading nupkg package and nuspec package specification files.</Description>
      <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
++    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' or '$(DotNetBuildFromSource)' == 'true'">netstandard1.3</TargetFrameworks>
      <TargetFramework />
      <NoWarn>$(NoWarn);CS1591;CS1574;CS1573;CS1572</NoWarn>
      <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
@@ -160,7 +160,7 @@ index cd02d8f..afb5eb1 100644
  
    <PropertyGroup>
      <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
++    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' or '$(DotNetBuildFromSource)' == 'true'">netstandard1.3</TargetFrameworks>
      <TargetFramework />
      <NoWarn>$(NoWarn);CS1591;CS1573</NoWarn>
      <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
@@ -172,7 +172,7 @@ index 06d0071..73bc456 100644
  
    <PropertyGroup>
      <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
++    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' or '$(DotNetBuildFromSource)' == 'true'">netstandard1.3</TargetFrameworks>
      <TargetFramework />
      <NoWarn>$(NoWarn);CS1591;CS1573;CS0012</NoWarn>
      <PackageTags>nuget protocol</PackageTags>
@@ -184,7 +184,7 @@ index fa06e72..cec4839 100644
  
    <PropertyGroup>
      <TargetFrameworks>netstandard1.0;net45</TargetFrameworks>
-+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.0</TargetFrameworks>
++    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' or '$(DotNetBuildFromSource)' == 'true'">netstandard1.0</TargetFrameworks>
      <TargetFramework />
      <Description>NuGet's implementation of Semantic Versioning.</Description>
      <PackageTags>semver;semantic versioning</PackageTags>

--- a/patches/websdk/0001-Support-building-on-nix.patch
+++ b/patches/websdk/0001-Support-building-on-nix.patch
@@ -176,8 +176,8 @@ index 16d9288..e587e48 100644
    <PropertyGroup>
 -    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
      <PlatformTarget>AnyCPU</PlatformTarget>
-+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net46;netstandard1.3</TargetFrameworks>
-+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
++    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
++    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT' or '$(DotNetBuildFromSource)' == 'true'">netstandard1.3</TargetFrameworks>
      <AssemblyName>Microsoft.NET.Sdk.Publish.Tasks</AssemblyName>
    </PropertyGroup>
    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">


### PR DESCRIPTION
Don't build for desktop during source-build, since the ref assemblies don't have all the desktop APIs.

Also renaming DotNetBuildFromSource parameter to match the spec.