### PR TITLE
Only build dummy and ref packages when building in offline mode

### DIFF
--- a/tools-local/init-build.proj
+++ b/tools-local/init-build.proj
@@ -48,7 +48,7 @@
      <Exec Condition="'$(Platform)' == 'armel'" Command="$(ArmEnvironmentVariables) ./cross/armel/tizen-build-rootfs.sh" />
   </Target>
 
-  <Target Name="BuildDummyPackages">
+  <Target Name="BuildDummyPackages" Condition="'$(BuildOffline)' == 'true'">
     <ItemGroup>
       <DummyPackage Include="Castle.Core" Version="3.3.3" />
       <DummyPackage Include="Castle.Core" Version="4.0.0-beta001" />
@@ -286,7 +286,7 @@
                         OutputPath="$(SourceBuiltPackagesPath)" />
   </Target>
 
-  <Target Name="BuildReferenceAssemblies">
+  <Target Name="BuildReferenceAssemblies" Condition="'$(BuildOffline)' == 'true'">
     <Exec Command="$(DotNetCliToolDir)/dotnet build $(SubmoduleDirectory)/reference-assemblies/build.proj" />
     <Exec Command="$(DotNetCliToolDir)/dotnet restore $(SubmoduleDirectory)/reference-assemblies/nuspecs/pack.csproj" />
     <Exec Command="$(DotNetCliToolDir)/dotnet pack $(SubmoduleDirectory)/reference-assemblies/nuspecs/PackAll.proj" />


### PR DESCRIPTION
The dummy packages are starting to get in our way as we update to the latest shas for the submodules and as best we can tell they aren't needed at all unless you are in offline mode so I've conditioned them to only be built in offline mode.

cc @crummel @karajas @eerhardt 