### PR TITLE
Allow VsTest repo to build on machines with Mono installed

### DIFF
--- a/patches/vstest/0009-Suppress-Mono-check-during-build.-See-https-github.c.patch
+++ b/patches/vstest/0009-Suppress-Mono-check-during-build.-See-https-github.c.patch
@@ -1,0 +1,44 @@
+From 43d6b05323e27cadc40294f4a2591d91a8ab1d89 Mon Sep 17 00:00:00 2001
+From: Eric Erhardt <eric.erhardt@microsoft.com>
+Date: Fri, 29 Sep 2017 10:46:12 -0500
+Subject: [PATCH] Suppress Mono check during build. See
+ https://github.com/Microsoft/vstest/issues/1153
+
+---
+ scripts/build.sh | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/scripts/build.sh b/scripts/build.sh
+index 342be5f..3057831 100755
+--- a/scripts/build.sh
++++ b/scripts/build.sh
+@@ -22,6 +22,7 @@ FAIL_FAST=false
+ DISABLE_LOCALIZED_BUILD=false
+ CI_BUILD=false
+ VERBOSE=false
++CHECK_MONO=true
+ PROJECT_NAME_PATTERNS=
+ 
+ while [ $# -gt 0 ]; do
+@@ -62,6 +63,9 @@ while [ $# -gt 0 ]; do
+         -verbose)
+             VERBOSE=true
+             ;;
++        -nomono)
++            CHECK_MONO=false
++            ;;
+         *)
+             break
+             ;;
+@@ -102,7 +106,7 @@ TPB_Version=$(test -z $VERSION_SUFFIX && echo $VERSION || echo $VERSION-$VERSION
+ TPB_CIBuild=$CI_BUILD
+ TPB_LocalizedBuild=$DISABLE_LOCALIZED_BUILD
+ TPB_Verbose=$VERBOSE
+-TPB_HasMono=$(command -v mono > /dev/null && echo true || echo false)
++TPB_HasMono=$($CHECK_MONO && command -v mono > /dev/null && echo true || echo false)
+ 
+ #
+ # Logging
+-- 
+1.9.1
+

--- a/targets/vstest.props
+++ b/targets/vstest.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectDirectory Condition="'$(PathToRepo)' != ''">$(PathToRepo)</ProjectDirectory>
-    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) -c $(Configuration) -r $(TargetRid) -v 15.3.0 -vs preview-20170628-02</BuildCommand>
+    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) -c $(Configuration) -r $(TargetRid) -v 15.3.0 -vs preview-20170628-02 -nomono</BuildCommand>
     <PackagesOutput>$(ProjectDirectory)/artifacts/$(Configuration)/packages</PackagesOutput>
   </PropertyGroup>
 


### PR DESCRIPTION
The vstest repo is failing to build on my machine because I have mono installed on it.

Adding a patch to vstest to disable the special mono checking until https://github.com/Microsoft/vstest/issues/1153 is fixed.