### PR TITLE
Add new OS bootstrap doc and script

### DIFF
--- a/Documentation/boostrap-new-os.md
+++ b/Documentation/boostrap-new-os.md
@@ -1,0 +1,140 @@
+# Adding support for a new OS
+## Bootstrap CLI
+When adding support for a new OS, both the native (C++) and managed (C#) code components in the coreclr, corefx and core-setup repos need to be compiled. Making the native components build on a new OS is a quite straightforward process and the tools like CMake, Clang C/C++ compiler, python and awk that are required for the build are available for almost all platforms. 
+But for the managed code compilation, we have a chicken and egg problem. A .NET CLI toolchain is needed to build managed components in the coreclr, corefx and core-setup repos, but it is not available for the target platform yet. 
+The way to solve this problem is to create a bootstrap CLI by taking an existing CLI as a "seed" and replacing native components in it by the native components that we build for the new platform. The seed CLI we use has to be for the same processor architecture as our new platform or we have to use a seed cli that we build from sources on another platform that is already supported and opt for not crossgenning the managed components. 
+### Choosing the seed CLI
+While the bootstrap CLI can be built for any version of the seed CLI, it is important to pick a version of CLI that can be used to built current corefx, coreclr and core-setup repos. From time to time, a change in the CLI causes it to not to be usable for compiling one of the repos without fixes in the msbuild project files. So to stay on the safe side, the best practice is to pick a version used by one of the three repos. This version can be found in the `DotnetCLIVersion.txt` file in the root of each repo. 
+### Getting the seed CLI
+After getting the seed CLI version as described in the previous paragraph, it can be used to construct an URL to download the .tar.gz file with the seed CLI itself. The way to construct the URL can be found in the `init-tools.sh` file in the root of each repo. Currently, it is constructed as follows:
+```
+https://dotnetcli.azureedge.net/dotnet/Sdk/${__DOTNET_TOOLS_VERSION}/dotnet-sdk-${__DOTNET_TOOLS_VERSION}-${__PKG_RID}-${__PKG_ARCH}.tar.gz
+```
+The `${__DOTNET_TOOLS_VERSION}` is replaced by the seed CLI version, the `${__PKG_RID}` by the RID of the current platform and `${__PKG_ARCH}` by the architecture of the current platform.
+So for tools version `2.0.0` on linux distro with x64 architecture where portable dotnet core can be used, the URL is `https://dotnetcli.azureedge.net/dotnet/Sdk/2.0.0/dotnet-sdk-2.0.0-linux-x64.tar.gz`
+To download it, `wget` or `curl` tools can be used.
+Once the file is downloaded, create a new folder and untar the file into it.  
+So e.g. for the file mentioned above, use:
+```bash
+tar -xf dotnet-sdk-2.0.0-linux-x64.tar.gz
+```
+### Choosing RID for the new OS
+The new RID represents your target OS. It is used by developers to target that OS. The RID format is `<Name>.<Version>`. The name is lower case and should match the target OS. The version is optional and should be used if it is expected that in future versions the libraries that .NET Core depends on will not be binary compatible with the first supported version. So for example for FreeBSD 11, the RID would likely be `freebsd.11`.
+For OS that has `/etc/os-release` file, the RID needs to match the `$ID.$VERSION_ID` extracted from that file. 
+### Prerequisites
+The following libraries and tools need to be installed in order to build the bootstrap CLI. The precise names of the packages are OS specific.
+#### Tools
+* Clang version 3.5 or higher, 3.9 recommended
+* CMake version 2.8.12 or higher
+* Python version 2.7
+* AWK
+* SED
+#### Development libraries
+* libunwind
+* lttng-ust
+* openssl or libressl
+* krb5
+* curl
+* liblldb
+* icu
+* libuuid
+### Building the bootstrap CLI
+There is a bash script file that automatizes most of the process of building the bootstrap CLI end to end. It first creates a folder named by the new target RID, clones the coreclr, corefx and core-setup repos into it and checks out the same commit of each of the repos as the one that was used to build the seed CLI. This first step is skipped if the coreclr, corefx and core-setup folders already exist. This is important so that the sources can be modified to fix possible build issues and to target the new RID.
+The script needs to be passed several arguments. The target architecture, the build configuration, the target OS, the new RID and path to the folder with the untared seed CLI. There is also an optional option to specify the version of the Clang compiler to use to compile the native code. There is also an option to pass in a System.Private.CoreLib.dll built elsewhere and an option to crossgen it. This is useful if you are building debug configuration, since the seed CLI that comes from Azure is built for release configuration and the release version of System.Private.CoreLib.dll is not compatible with debug version of libcoreclr.so.
+Here is the summary of the options that you get from running the script with `--help` option:
+```
+Usage: buildbootstrapcli.sh [BuildType] --rid <Rid> --seedcli <SeedCli> [--arch <Architecture>] [--os <OS>] [--clang <Major.Minor>] [--corelib <CoreLib>] [--crossgen]
+
+Options:
+  BuildType               Type of build (-debug, -release), default: -debug
+  -arch <Architecture>    Architecture (x64, x86, arm, arm64, armel), default: x64
+  -clang <Major.Minor>    Override of the version of clang compiler to use
+  -config <Configuration> Build configuration (debug, release), default: debug
+  -corelib <CoreLib>      Path to System.Private.CoreLib.dll, default: use the System.Private.CoreLib.dll from the seed CLI
+  -crossgen               Crossgen the System.Private.CoreLib.dll, default: do not crossgen
+  -os <OS>                Operating system (used for corefx build), default: Linux
+  -rid <Rid>              Runtime identifier (without the architecture part)
+  -seedcli <SeedCli>      Seed CLI used to generate the target CLI
+```
+So, for example, when we were creating bootstrap CLI for RHEL / CentOS 6, the command was:
+```bash
+./buildbootstrapcli.sh -arch x64 -rid rhel.6 -release -os Linux -seedcli ~/seed-cli
+```
+After running the script, check the console output. If the last line printed is `**** Bootstrap CLI was successfully built  ****`, then everything went fine and the bootstrap CLI is ready. You can find it in the `<Rid>-<Architecture>/dotnetcli` subfolder. So for the example command above, it would be `rhel.6-x64/dotnetcli`.
+If there were build errors, they need to be looked into and fixed. After that run the `buildbootstrapcli.sh` with the same arguments again. Repeat until everything builds.
+### Testing the bootstrap CLI
+The easiest way to test the bootstrap CLI that was just created is to create, built and run a "hello world" console application. Create a new folder for the application and then run `/your/path/to/bootstrap/dotnetcli/dotnet new console` followed by `/your/path/to/bootstrap/dotnetcli/dotnet run`. If both of these succeed and the second prints "Hello world!", then everything went ok and you have a working bootstrap CLI. If there are issues in either of these steps, they need to be debugged and the culprits figured out.
+### Troubleshooting
+TODO: describe how to do debug build and replace System.Private.CoreLib.dll
+#### Using bootstrap CLI on platforms with different OS or architecture
+If the bootstrap CLI was created for OS other than the one the seed cli supports (e.g. FreeBSD) or the target architecture of the target OS differs from the architecture of the bootstrap cli (e.g. ARM64), the managed assemblies in the bootstrap CLI cannot be loaded, since they contain native code for the target OS and architecture. Fortunately, they also contain the original IL code, so they can be re-crossgened for the target OS and architecture. Or it is possible to instruct the CoreCLR runtime to ignore the native code and use the IL by setting environment variables `COMPlus_ZapDisable=1` and `COMPlus_ReadyToRun=0`. That can be useful during the bringup. But ultimately, re-crossgening should be made to improve startup performance.
+TODO: describe how to re-crossgen the managed assemblies
+## Building nuget packages
+Now that the bootstrap CLI works, it can be used to build coreclr, corefx and core-setup repos in its completeness, including the managed code. First set the `DOTNET_TOOL_DIR` env variable to the path where the boostrap CLI is located. That will cause the build process to use these tools instead of trying to download a `.tar.gz` package with OS specific tools from Azure.
+You can use the boostrap tools to build any recent state of the three repos. `release/2.0.0` branch can be used to build the 2.0.0 release packages or `master` branch to build the latest stuff.
+For the sake of simplicity, the following paragraphs assume the following:
+* we are building release configuration
+* we are targetting x64
+* the new RID is `mynewrid`
+* the coreclr, corefx and core-setup folders with clones of the three repos are in the same directory
+### Adding support for the new RID
+#### CoreCLR
+* Unless the target OS has `/etc/os-release` file that can be used to extract the RID, the `initHostDistroRid` function in the `build.sh` file needs to be updated to be able to detect the target OS and report the proper RID by setting the `__HostDistroRid` to the RID combined with the target architecture (e.g. `mynewrid-x64`).
+* In `src/.nuget/dir.props` add a new `OfficialBuildRID` element with the new RID and target architecture. So for example, `<OfficialBuildRID Include="mynewrid-x64" />`
+#### CoreFX
+* Unless the target OS has `/etc/os-release` file that can be used to extract the RID, the `initHostDistroRid` function in the `src/Native/build-native.sh` file needs to be updated to be able to detect the target OS and report the proper RID by setting the `__HostDistroRid` to the RID combined with the target architecture (e.g. `mynewrid-x64`).
+* In `dependencies.props`, the `CoreClrPackageVersion` needs to be updated to contain the version of packages built in the coreclr repo.
+* In `external/runtime/runtime.depproj`, the content of the `Version` element under `<PackageReference Include="Microsoft.NETCore.DotNetHost">` and `<PackageReference Include="Microsoft.NETCore.DotNetHostPolicy">` needs to be updated to contain the version of packages built in the core-setup repo.
+* In `external/test-runtime/XUnit.Runtime.depproj`, add `<NoWarn>NU1603</NoWarn>` to the first `<PropertyGroup>` element.
+* In `pkg/Microsoft.NETCore.Platforms/runtime.json`, add new elements describing the new RID and its relationship under the `runtimes` key. Here is an example of what we would add for Alpine Linux 3.6:
+```json
+    "alpine": {
+        "#import": [ "linux" ]
+    },
+    "alpine-x64": {
+        "#import": [ "alpine", "linux-x64" ]
+    },
+    "alpine.3.6": {
+        "#import": [ "alpine" ]
+    },
+    "alpine.3.6-x64": {
+        "#import": [ "alpine.3.6", "alpine-x64" ]
+    },
+```
+* In `pkg/Microsoft.Private.CoreFx.NETCoreApp/netcoreapp.rids.props`, add a new `OfficialBuildRID` element with the new RID and target architecture. So for example, `<OfficialBuildRID Include="mynewrid-x64" />`
+#### Core-Setup
+* Unless the target OS has `/etc/os-release` file that can be used to extract the RID, the `init_rid_plat` function in the `src/corehost/build.sh` file needs to be updated to be able to detect the target OS and report the proper RID by setting the `__rid_plat` variable. Please note that unlike the similar case in coreclr and corefx repos, this variable is set to the RID without the target architecture (so just `mynewrid` and not e.g. `mynewrid-x64`).
+* In `dependencies.props`, update the `MicrosoftPrivateCoreFxNETCoreAppPackageVersion` element to and the `MicrosoftNETCoreRuntimeCoreCLRPackageVersion` element to.
+* In `src/pkg/projects/netcoreappRIDs.props`, add a new `OfficialBuildRID` element with the new RID and target architecture. So for example, `<OfficialBuildRID Include="mynewrid-x64" />`
+### Building CoreCLR
+The first step is to build coreclr. Go to the root of the coreclr and run 
+```bash
+DOTNET_TOOL_DIR=/your/path/to/bootstrap/dotnetcli ./build.sh release -portablebuild=false msbuildonunsupportedplatform
+```
+The `DOTNET_TOOL_DIR` variable was recently renamed to `DotNetBuildToolsDir` in corefx and this change is going to be propagated to all three repos, so it is worth checking the `init-tools.sh` to see which of the variables is used there before starting the build.
+You may need to add an option to specify the version of Clang to use for the build. 
+If the build completes ok, it would generate nuget `.nupkg` package files into `bin/Product/Linux.x64.Release\.nuget\pkg`. If it fails, investigate and fix the problems and run the build command again.
+After the build succeeds, list the contents of the `bin/Product/Linux.x64.Release\.nuget\pkg` directory and note the version number e.g. in the `Microsoft.NETCore.Runtime.CoreCLR` package filename. So for example, the filename can be `Microsoft.NETCore.Runtime.CoreCLR.2.0.2-servicing-25708-0.nupkg`. The version is `2.0.2-servicing-25708-0`. It will be needed in the next step.
+### Building CoreFX
+Now that we have built the CoreCLR, we can build the CoreFX. Since CoreFX depends on CoreCLR packages, we need to pass the location of the packages built in CoreCLR as an additional nuget source using the `/p:OverridePackageSource=xxxx` option. Also, the corefx build needs to know the version of the coreclr packages so that it can get proper nuget packages. The previous paragraph on CoreCLR build describes how to get the version. 
+Change the current directory to the corefx directory, edit the `dependencies.props` file and replace the version in the `<CoreClrPackageVersion>` node by the version of your coreclr build.
+Then run the following command.
+```bash
+DOTNET_TOOL_DIR=/your/path/to/bootstrap/dotnetcli ./build.sh -release -runtimeos=mynewrid -stripSymbols -SkipTests=true -- /p:OverridePackageSource=../coreclr/bin/Product/Linux.x64.Release/.nuget/pkg/ /p:PortableBuild=false
+```
+If the build completes ok, it would generate nuget `.nupkg` package files into `bin/packages/Release`. If it fails, investigate and fix the problems and run the build command again.
+Now you need to find the version of the nuget packages that were just built. List files in the `bin/packages/Release` folder and note the version number in the `Microsoft.Private.CoreFx.NETCoreApp` package file. So for example, if the filename is `Microsoft.Private.CoreFx.NETCoreApp.4.4.0-preview1-25304-0.nupkg`, the version is `4.4.0-preview1-25304-0`. You will need it in the next step.
+### Building Core-Setup
+The core-setup build depends on the nuget packages that were just built in coreclr and corefx. Since the overriding of package source can only be a single directory, we first create a folder where we copy the nuget packages from both coreclr and corefx. 
+Change the current directory to the parent directory of coreclr, corefx and core-setup
+```bash
+mkdir combinednugets
+cp coreclr/bin/Product/Linux.x64.Release\.nuget\pkg\*.nupkg combinednugets
+cp corefx/bin/packages/Release/*.nupkg combinednugets
+```
+Now change the current directory to the core-setup directory, edit the `dependencies.props` file and replace the version in the `<MicrosoftPrivateCoreFxNETCoreAppPackageVersion>` node by the version of your corefx build and the version in the `<MicrosoftNETCoreRuntimeCoreCLRPackageVersion>` node by the version of your coreclr build.
+Then build core-setup using the following command:
+```bash
+DOTNET_TOOL_DIR=/your/path/to/bootstrap/dotnetcli ./build.sh -portable=false -release -stripSymbols -DistroRid=mynewrid-x64 -os=Linux -- /p:OverridePackageSource=../combinednugets/
+```
+If the build completes ok, it would generate nuget `.nupkg` package files into `Bin/mynewrid-x64.Release/packages`. If it fails, investigate and fix the problems and run the build command again.

--- a/scripts/bootstrap/buildbootstrapcli.sh
+++ b/scripts/bootstrap/buildbootstrapcli.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+usage()
+{
+    echo "Builds a bootstrap CLI from sources"
+    echo "Usage: $0 [BuildType] --rid <Rid> --seedcli <SeedCli> [--arch <Architecture>] [--os <OS>] [--clang <Major.Minor>] [--corelib <CoreLib>] [--crossgen]"
+    echo ""
+    echo "Options:"
+    echo "  BuildType               Type of build (-debug, -release), default: -debug"
+    echo "  -arch <Architecture>    Architecture (x64, x86, arm, arm64, armel), default: x64"
+    echo "  -clang <Major.Minor>    Override of the version of clang compiler to use"
+    echo "  -config <Configuration> Build configuration (debug, release), default: debug"
+    echo "  -corelib <CoreLib>      Path to System.Private.CoreLib.dll, default: use the System.Private.CoreLib.dll from the seed CLI"
+    echo "  -os <OS>                Operating system (used for corefx build), default: Linux"
+    echo "  -rid <Rid>              Runtime identifier (without the architecture part)"
+    echo "  -seedcli <SeedCli>      Seed CLI used to generate the target CLI"
+}
+
+disable_pax_mprotect()
+{
+    if [[ $(command -v paxctl) ]]; then
+        paxctl -c -m $1
+    fi
+}
+
+get_max_version()
+{
+    local maxversionhi=0
+    local maxversionmid=0
+    local maxversionlo=0
+    local maxversiontag
+    local versionrest
+    local versionhi
+    local versionmid
+    local versionlo
+    local versiontag
+    local foundmax
+
+    for d in $1/*; do
+
+        if [[ -d $d ]]; then
+            versionrest=$(basename $d)
+            versionhi=${versionrest%%.*}
+            versionrest=${versionrest#*.}
+            versionmid=${versionrest%%.*}
+            versionrest=${versionrest#*.}
+            versionlo=${versionrest%%-*}
+            versiontag=${versionrest#*-}
+            if [[ $versiontag == $versionrest ]]; then
+                versiontag=""
+            fi
+
+            foundmax=0
+
+            if [[ $versionhi -gt $maxversionhi ]]; then
+                foundmax=1
+            elif [[ $versionhi -eq $maxversionhi ]]; then
+                if [[ $versionmid -gt $maxversionmid ]]; then
+                    foundmax=1
+                elif [[ $versionmid -eq $maxversionmid ]]; then
+                    if [[ $versionlo -gt $maxversionlo ]]; then
+                    foundmax=1
+                    elif [[ $versionlo -eq $maxversionlo ]]; then
+                        # tags are used to mark pre-release versions, so a version without a tag
+                        # is newer than a version with one.
+                        if [[ "$versiontag" == "" || $versiontag > $maxversiontag ]]; then
+                            foundmax=1
+                        fi
+                    fi
+                fi
+            fi
+
+            if [[ $foundmax != 0 ]]; then
+                maxversionhi=$versionhi
+                maxversionmid=$versionmid
+                maxversionlo=$versionlo
+                maxversiontag=$versiontag
+            fi
+        fi
+    done
+
+    echo $maxversionhi.$maxversionmid.$maxversionlo${maxversiontag:+-$maxversiontag}
+}
+
+__build_arch=x64
+__build_os=Linux
+__runtime_id=
+__corelib=
+__configuration=debug
+__clangversion=
+
+while [[ "$1" != "" ]]; do
+    lowerI="$(echo $1 | awk '{print tolower($0)}')"
+    case $lowerI in
+    -h|--help)
+        usage
+        exit 1
+        ;;
+    -arch)
+        shift
+        __build_arch=$1
+        ;;
+    -rid)
+        shift
+        __runtime_id=$1
+        ;;
+    -os)
+        shift
+        __build_os=$1
+        ;;
+    -debug)
+        __configuration=debug
+        ;;
+    -release)
+        __configuration=release
+        ;;
+    -corelib)
+        shift
+        __corelib=$1
+        ;;
+    -seedcli)
+        shift
+        __seedclipath=$1
+        ;;
+    -clang)
+        shift
+        __clangversion=clang$1
+        ;;
+     *)
+    echo "Unknown argument to build.sh $1"; exit 1
+    esac
+    shift
+done
+
+# NOTE: when realpath is not present, use readlink -e or readlink --canonicalize depending on the platform
+__seedclipath=`realpath $__seedclipath`
+
+mkdir -p $__runtime_id-$__build_arch
+cd $__runtime_id-$__build_arch
+
+if [[ -d dotnetcli ]]; then
+    /bin/rm -r dotnetcli
+fi
+mkdir -p dotnetcli
+cp -r $__seedclipath/* dotnetcli
+
+__frameworkversion="2.0.0"
+__sdkversion="2.0.0"
+__fxrversion="2.0.0"
+
+echo "**** DETECTING VERSIONS IN SEED CLI ****"
+
+__frameworkversion=`get_max_version dotnetcli/shared/Microsoft.NETCore.App`
+__sdkversion=`get_max_version dotnetcli/sdk`
+__fxrversion=`get_max_version dotnetcli/host/fxr`
+
+echo "Framework version: $__frameworkversion"
+echo "SDK version:       $__sdkversion"
+echo "FXR version:       $__fxrversion"
+
+__frameworkpath="dotnetcli/shared/Microsoft.NETCore.App/$__frameworkversion"
+
+echo "**** DETECTING GIT COMMIT HASHES ****"
+
+# Extract the git commit hashes representig the state of the three repos that
+# the seed cli package was built from
+__coreclrhash=`strings $__seedclipath/shared/Microsoft.NETCore.App/$__frameworkversion/libcoreclr.so | grep "@(#)" | grep -o "[a-f0-9]\{40\}"`
+__corefxhash=`strings $__seedclipath/shared/Microsoft.NETCore.App/$__frameworkversion/System.Native.so | grep "@(#)" | grep -o "[a-f0-9]\{40\}"`
+__coresetuphash=`strings $__seedclipath/dotnet | grep "[a-f0-9]\{40\}"`
+
+echo "coreclr hash:    $__coreclrhash"
+echo "corefx hash:     $__corefxhash"
+echo "core-setup hash: $__coresetuphash"
+
+# Clone the three repos if they were not clonned yet. If the folders already
+# exist, leave them alone. This allows patching the cloned sources as needed
+
+if [[ ! -d coreclr ]]; then
+    echo "**** CLONING CORECLR REPOSITORY ****"
+    git clone https://github.com/dotnet/coreclr.git
+    cd coreclr
+    git checkout $__coreclrhash
+    cd ..
+fi
+
+if [[ ! -d corefx ]]; then
+    echo "**** CLONING COREFX REPOSITORY ****"
+    git clone https://github.com/dotnet/corefx.git
+    cd  corefx
+    git checkout $__corefxhash
+    cd ..
+fi
+
+if [[ ! -d core-setup ]]; then
+    echo "**** CLONING CORE-SETUP REPOSITORY ****"
+    git clone https://github.com/dotnet/core-setup.git
+    cd  core-setup
+    git checkout $__coresetuphash
+    cd ..
+fi
+
+echo "**** BUILDING CORE-SETUP NATIVE COMPONENTS ****"
+cd core-setup
+src/corehost/build.sh --arch "$__build_arch" --hostver "2.0.0" --apphostver "2.0.0" --fxrver "2.0.0" --policyver "2.0.0" --commithash `git rev-parse HEAD`
+cd ..
+
+echo "**** BUILDING CORECLR NATIVE COMPONENTS ****"
+cd coreclr
+./build.sh $__configuration $__build_arch $__clangversion 2>&1 | tee coreclr.log
+export __coreclrbin=$(cat coreclr.log | sed -n -e 's/^.*Product binaries are available at //p')
+cd ..
+echo "CoreCLR binaries will be copied from $__coreclrbin"
+
+echo "**** BUILDING COREFX NATIVE COMPONENTS ****"
+corefx/src/Native/build-native.sh $__build_arch $__configuration $__clangversion $__build_os 2>&1 | tee corefx.log
+export __corefxbin=$(cat corefx.log | sed -n -e 's/^.*Build files have been written to: //p')
+echo "CoreFX binaries will be copied from $__corefxbin"
+
+echo "**** Copying new binaries to dotnetcli/ ****"
+
+# First copy the coreclr repo binaries
+cp $__coreclrbin/*so $__frameworkpath
+cp $__coreclrbin/corerun $__frameworkpath
+cp $__coreclrbin/crossgen $__frameworkpath
+
+# Mark the coreclr executables as allowed to create executable memory mappings
+disable_pax_mprotect $__frameworkpath/corerun
+disable_pax_mprotect $__frameworkpath/crossgen
+
+# Now copy the core-setup repo binaries
+cp core-setup/cli/exe/dotnet/dotnet dotnetcli
+cp core-setup/cli/exe/dotnet/dotnet $__frameworkpath/corehost
+
+cp core-setup/cli/dll/libhostpolicy.so $__frameworkpath
+cp core-setup/cli/dll/libhostpolicy.so dotnetcli/sdk/$__sdkversion
+
+cp core-setup/cli/fxr/libhostfxr.so $__frameworkpath
+cp core-setup/cli/fxr/libhostfxr.so dotnetcli/host/fxr/$__fxrversion
+cp core-setup/cli/fxr/libhostfxr.so dotnetcli/sdk/$__sdkversion
+
+# Mark the core-setup executables as allowed to create executable memory mappings
+disable_pax_mprotect dotnetcli/dotnet
+disable_pax_mprotect $__frameworkpath/corehost
+
+# Finally copy the corefx repo binaries
+cp $__corefxbin/**/System.* $__frameworkpath
+
+# Copy System.Private.CoreLib.dll override from somewhere if requested
+if [[ "$__corelib" != "" ]]; then
+    cp "$__corelib" $__frameworkpath
+fi
+
+# Add the new RID to Microsoft.NETCore.App.deps.json
+# Replace the linux-x64 RID in the target, runtimeTarget and runtimes by the new RID
+# and add the new RID to the list of runtimes.
+echo "**** Adding new rid to Microsoft.NETCore.App.deps.json ****"
+
+#TODO: add parameter with the parent RID sequence
+
+sed \
+    -e 's/runtime\.linux-x64/runtime.'$__runtime_id-$__build_arch'/g' \
+    -e 's/runtimes\/linux-x64/runtimes\/'$__runtime_id-$__build_arch'/g' \
+    -e 's/Version=v\([0-9].[0-9]\)\/linux-x64/Version=v\1\/'$__runtime_id-$__build_arch'/g' \
+    -e 's/"runtimes": {/&\n    "'$__runtime_id-$__build_arch'": [\n      "unix", "unix-x64", "any", "base"\n    ],/g' \
+$__seedclipath/shared/Microsoft.NETCore.App/$__frameworkversion/Microsoft.NETCore.App.deps.json \
+>$__frameworkpath/Microsoft.NETCore.App.deps.json
+
+echo "**** Bootstrap CLI was successfully built  ****"
+


### PR DESCRIPTION
This change adds a document on creating a bootstrap cli for a new
unsupported OS and a script that automates the whole process.
While there is still space for improvements in both the doc and the script, I think it is time to publish them. I have used them to bring up RHEL 6 and Alpine. I have tested it on FreeBSD for x64 and an Arm64 Linux. 