### PR TITLE
Update NuGet.Client submodule to latest from NuGet

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = https://www.github.com/dotnet/cli
 [submodule "src/nuget-client"]
 	path = src/nuget-client
-	url = https://github.com/dagood/NuGet.Client
+	url = https://github.com/NuGet/NuGet.Client
 [submodule "src/templating"]
 	path = src/templating
 	url = https://github.com/dotnet/templating


### PR DESCRIPTION
This removes the dependency on the dagood fork and brings in fixes.

/cc @mishra14 @omajid 

See https://github.com/dotnet/source-build/pull/94
Fixes https://github.com/dotnet/source-build/issues/107 (If this PR works without changes--I'm not planning on chasing down issues right now, e.g. potentially with patches.)