### PR TITLE
Enable legs that have been fixed.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -46,13 +46,13 @@ def addPushJob(String project, String branch, String os, String configuration)
     Utilities.addGithubPushTrigger(newJob);
 }
 
-["Ubuntu14.04", "Ubuntu16.04", "Ubuntu16.10", "Fedora24", "Debian8.4", "RHEL7.2", "Windows_NT", "CentOS7.1", "OSX10.12"].each { os ->
+["Ubuntu16.04", "Fedora24", "Debian8.4", "RHEL7.2", "Windows_NT", "CentOS7.1", "OSX10.12"].each { os ->
   addPullRequestJob(project, branch, os, "Release", true);
   addPullRequestJob(project, branch, os, "Debug", false);
 };
 
 // Per push, run all the jobs
-["Ubuntu14.04", "Ubuntu16.04", "Ubuntu16.10", "Fedora24", "Debian8.4", "RHEL7.2", "Windows_NT", "CentOS7.1", "OSX10.12"].each { os ->
+["Ubuntu16.04", "Fedora24", "Debian8.4", "RHEL7.2", "Windows_NT", "CentOS7.1", "OSX10.12"].each { os ->
   ["Release", "Debug"].each { configuration ->
     addPushJob(project, branch, os, configuration);
   };

--- a/netci.groovy
+++ b/netci.groovy
@@ -46,13 +46,13 @@ def addPushJob(String project, String branch, String os, String configuration)
     Utilities.addGithubPushTrigger(newJob);
 }
 
-["RHEL7.2", "Windows_NT", "CentOS7.1"].each { os ->
+["Ubuntu14.04", "Ubuntu16.04", "Ubuntu16.10", "Fedora24", "Debian8.4", "RHEL7.2", "Windows_NT", "CentOS7.1", "OSX10.12"].each { os ->
   addPullRequestJob(project, branch, os, "Release", true);
   addPullRequestJob(project, branch, os, "Debug", false);
 };
 
 // Per push, run all the jobs
-["Ubuntu14.04", "RHEL7.2", "Windows_NT", "CentOS7.1", "OSX10.12"].each { os ->
+["Ubuntu14.04", "Ubuntu16.04", "Ubuntu16.10", "Fedora24", "Debian8.4", "RHEL7.2", "Windows_NT", "CentOS7.1", "OSX10.12"].each { os ->
   ["Release", "Debug"].each { configuration ->
     addPushJob(project, branch, os, configuration);
   };


### PR DESCRIPTION
One of these commits fixed build legs that we turned off early on:
- https://github.com/dotnet/source-build/commit/1419ce26d185aedf52f8e05c448404eb5c3d9619
- https://github.com/dotnet/source-build/commit/11e7c09c7d2d3f58c49434088f167bfd62241769
- https://github.com/dotnet/source-build/commit/64a17297999f9a3102c6a42d621be40f23256708
- https://github.com/dotnet/source-build/commit/14d33dc2af2be062d842ff93c8410e34b6b89a93
- https://github.com/dotnet/source-build/commit/393b117dbf586562af74ca2370055808c783ef19

However, the build failed on these for other reasons so it's hard to determine exactly which one it was.  The output from these builds does appear to be correct, so this change turns the legs back on so we can track if we break them again.