### PR TITLE
Dont strip native debug symbols during build

### DIFF
--- a/repos/core-setup.proj
+++ b/repos/core-setup.proj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
-    <BuildArguments>-ConfigurationGroup=$(Configuration) -PortableBuild=false -strip-symbols -SkipTests=true </BuildArguments>
+    <BuildArguments>-ConfigurationGroup=$(Configuration) -PortableBuild=false -SkipTests=true </BuildArguments>
     <BuildArguments Condition="$(Platform.Contains('arm'))">$(BuildArguments) -TargetArchitecture=$(Platform) -DisableCrossgen=true -CrossBuild=true</BuildArguments>
     <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments) -- /p:BuildDebPackage=false</BuildCommand>
     <BuildCommand Condition="$(Platform.Contains('arm'))">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>

--- a/repos/coreclr.proj
+++ b/repos/coreclr.proj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <BuildArguments>$(Platform) $(Configuration) skiptests -PortableBuild=false </BuildArguments>
     <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) msbuildonunsupportedplatform</BuildArguments>
-    <BuildArguments Condition="$(Platform.Contains('arm'))">$(BuildArguments) skipnuget cross -skiprestore stripSymbols cmakeargs -DFEATURE_GDBJIT=TRUE</BuildArguments>
+    <BuildArguments Condition="$(Platform.Contains('arm'))">$(BuildArguments) skipnuget cross -skiprestore cmakeargs -DFEATURE_GDBJIT=TRUE</BuildArguments>
     <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments) --</BuildCommand>
     <BuildCommand Condition="$(Platform.Contains('arm'))">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
     <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension)</CleanCommand>


### PR DESCRIPTION
This patch makes coreclr and core-setup leave debug symbols in their built native code instead of stripping it out.

After this patch, native symbols are only missing in corefx. A separate PR in corefx will take care of that: https://github.com/dotnet/corefx/pull/24979. But this fix for core-setup and coreclr is independent and doesnt need that PR to work.

The final dotnet product, after both these fixes, should contain native debug symbols for all native binaries.

I used this to verify the final built product: https://gist.github.com/omajid/766aef59857de9fc1eab173119143abc

Resolves #267 