### PR TITLE
Add scripts to make working with submodules easier.

### DIFF
--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -20,7 +20,6 @@ if [ -e "$TARBALL_ROOT" ]; then
     echo "error '$TARBALL_ROOT' exists"
 fi
 
-
 SCRIPT_ROOT="$(cd -P "$( dirname "$0" )" && pwd)"
 
 if [ $SKIP_BUILD -ne 1 ]; then

--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -70,3 +70,8 @@ do
     fi
 done
 
+# Record commits for the source-build repo and all submodules, to aid in reproducibility.
+echo -e "path\tchecked-in\tactual" > $TARBALL_ROOT/commits.txt
+echo -e "source-build\t$(git rev-parse HEAD)\t$(git rev-parse HEAD)" >> $TARBALL_ROOT/commits.txt
+git submodule foreach --recursive 'actual=$(git rev-parse HEAD); echo "$toplevel/$path\t$sha1\t$actual" >> $TARBALL_ROOT/commits.txt'
+

--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -14,10 +14,12 @@ if [ "${2:-}" == "--skip-build" ]; then
 fi
 
 TARBALL_ROOT=$1
+FULL_TARBALL_ROOT=$(readlink -f $TARBALL_ROOT)
 
 if [ -e "$TARBALL_ROOT" ]; then
     echo "error '$TARBALL_ROOT' exists"
 fi
+
 
 SCRIPT_ROOT="$(cd -P "$( dirname "$0" )" && pwd)"
 
@@ -73,5 +75,5 @@ done
 # Record commits for the source-build repo and all submodules, to aid in reproducibility.
 echo -e "path\tchecked-in\tactual" > $TARBALL_ROOT/commits.txt
 echo -e "source-build\t$(git rev-parse HEAD)\t$(git rev-parse HEAD)" >> $TARBALL_ROOT/commits.txt
-git submodule foreach --recursive 'actual=$(git rev-parse HEAD); echo "$toplevel/$path\t$sha1\t$actual" >> $TARBALL_ROOT/commits.txt'
+git submodule foreach --quiet --recursive "actual=\$(git rev-parse HEAD); echo -e \"\$toplevel/\$path\t\$sha1\t\$actual\" >> $FULL_TARBALL_ROOT/commits.txt"
 

--- a/build.ps1
+++ b/build.ps1
@@ -24,6 +24,8 @@ function Exec-Block([scriptblock]$cmd) {
 $SCRIPT_ROOT = "$PSScriptRoot"
 $SdkVersion = Get-Content (Join-Path $SCRIPT_ROOT "DotnetCLIVersion.txt")
 
+Exec-Block { & $SCRIPT_ROOT\check-submodules.ps1 } | Out-Host
+
 $env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
 $env:DOTNET_MULTILEVEL_LOOKUP = '0'

--- a/build.ps1
+++ b/build.ps1
@@ -24,7 +24,10 @@ function Exec-Block([scriptblock]$cmd) {
 $SCRIPT_ROOT = "$PSScriptRoot"
 $SdkVersion = Get-Content (Join-Path $SCRIPT_ROOT "DotnetCLIVersion.txt")
 
-Exec-Block { & $SCRIPT_ROOT\check-submodules.ps1 } | Out-Host
+if ([string]::IsNullOrWhiteSpace($env:SOURCE_BUILD_SKIP_SUBMODULE_CHECK) -or $env:SOURCE_BUILD_SKIP_SUBMODULE_CHECK -eq "0" -or $env:SOURCE_BUILD_SKIP_SUBMODULE_CHECK -eq "false")
+{
+  Exec-Block { & $SCRIPT_ROOT\check-submodules.ps1 } | Out-Host
+}
 
 $env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,11 @@ if [ -z "${HOME:-}" ]; then
     mkdir "$HOME"
 fi
 
-source "$SCRIPT_ROOT/check-submodules.sh"
+if [[ "${SOURCE_BUILD_SKIP_SUBMODULE_CHECK:-default}" == "default" || $SOURCE_BUILD_SKIP_SUBMODULE_CHECK == "0" || $SOURCE_BUILD_SKIP_SUBMODULE_CHECK == "false" ]]; then
+  source "$SCRIPT_ROOT/check-submodules.sh"
+fi
+
+exit 0
 
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1

--- a/build.sh
+++ b/build.sh
@@ -14,8 +14,6 @@ if [[ "${SOURCE_BUILD_SKIP_SUBMODULE_CHECK:-default}" == "default" || $SOURCE_BU
   source "$SCRIPT_ROOT/check-submodules.sh"
 fi
 
-exit 0
-
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_MULTILEVEL_LOOKUP=0

--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,8 @@ if [ -z "${HOME:-}" ]; then
     mkdir "$HOME"
 fi
 
+source "$SCRIPT_ROOT/check-submodules.sh"
+
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_MULTILEVEL_LOOKUP=0

--- a/check-submodules.ps1
+++ b/check-submodules.ps1
@@ -52,6 +52,7 @@ function fix_submodule($Path, $ExpectedSha, $ActualSha, $Message, $Prompt) {
       git cat-file -e $expectedSha^`{commit`} 2>&1 | Out-Null
       if ($LastExitCode -ne 0) {
         Write-Error "commit $expectedSha was not found in $path"
+        Write-Host "The remote may have changed in source-build; run 'git submodule sync' and retry."
         Write-Host "Are you using a custom remote for this submodule?  You may need to pick up changes from upstream."
         Write-Host "Canceling remainder of checks."
         exit 1
@@ -95,8 +96,8 @@ function clean_submodule($Path, $Message, $Prompt) {
 # We use the same script for checking the super-repo and the submodules.
 # Having the first argument be "in-submodule" triggers this submodule behavior.
 if ($args[0] -ieq "in-submodule") {
-  $expectedSha = $args[1]
-  $path = $args[2]
+  $path = $args[1]
+  $expectedSha = $args[2]
   $subcommit = git rev-parse HEAD
   if ($subcommit -ne $expectedSha) {
     # merge-base fails if the commit is missing, so check for that first.
@@ -143,5 +144,5 @@ else {
   }
   $ProjectRoot = $ProjectRoot.Replace('\', '/')
   # kick off the submodule behavior for each repo
-  git submodule foreach --quiet --recursive "powershell $ProjectRoot/check-submodules.ps1 in-submodule `$sha1 `$path"
+  git submodule foreach --quiet --recursive "powershell $ProjectRoot/check-submodules.ps1 in-submodule `$path `$sha1"
 }

--- a/check-submodules.ps1
+++ b/check-submodules.ps1
@@ -1,0 +1,147 @@
+$answeredAll = $false   # has the user answered "yes to all" to init'ing submodules?
+$ProjectRoot = $PSScriptRoot
+
+# ask for confirmation and initialize a submodule if approved.
+function init_submodule($Path) {
+  $done = $false
+  while (-Not $done) {
+    Write-Warning "submodule $Path does not appear to be initialized."
+    Write-Host "Should I initialize it for you [Yes/no/all/quit]"
+    $answer = [Console]::ReadKey()
+    if ($answer.KeyChar -ieq "a") {
+      $script:answeredAll = $true
+      $done = $true
+      git submodule update --init --recursive $Path
+    }
+    elseif ($answer.KeyChar -ieq "q") {
+      exit 1
+    }
+    elseif ($answer.KeyChar -ieq "y" -or $answer.Key -eq [System.ConsoleKey]::Spacebar -or $answer.Key -eq [System.ConsoleKey]::Enter) {
+      $done = $true
+      git submodule update --init --recursive $Path
+    }
+    elseif ($answer.KeyChar -ieq "n") {
+      $done = $true
+    }
+    else {
+      Write-Host "Didn't understand that ($($answer.KeyChar))"
+    }
+  }
+}
+
+# update a submodule to an expected commit.  We give different messages
+# for being ahead vs being behind or diverged from the expected commit,
+# so this function is parameterized.
+function fix_submodule($Path, $ExpectedSha, $ActualSha, $Message, $Prompt) {
+  $done = $false
+  while (-Not $done) {
+    Write-Warning $Message
+    Write-Host $Prompt
+    $answer = [Console]::ReadKey()
+    if ($answer.KeyChar -ieq "q") {
+      exit 1
+    }
+    elseif ($answer.KeyChar -ieq "y") {
+      # check if we have this commit locally and can skip the fetch
+      git cat-file -e $expectedSha^`{commit`} 2>&1 | Out-Null
+      if ($LastExitCode -ne 0) {
+        git fetch
+      }
+      # double-check, we should have the commit now unless something
+      # weird is going on.
+      git cat-file -e $expectedSha^`{commit`} 2>&1 | Out-Null
+      if ($LastExitCode -ne 0) {
+        Write-Error "commit $expectedSha was not found in $path"
+        Write-Host "Are you using a custom remote for this submodule?  You may need to pick up changes from upstream."
+        Write-Host "Canceling remainder of checks."
+        exit 1
+      }
+      git checkout $expectedSha
+      $done = $true
+    }
+    elseif ($answer.KeyChar -ieq "n" -or $answer.Key -eq [System.ConsoleKey]::Spacebar -or $answer.Key -eq [System.ConsoleKey]::Enter) {
+      $done = $true
+    }
+    else {
+      Write-Host "Didn't understand that ($($answer.KeyChar))"
+    }
+  }
+}
+
+# clean a submodule if the user approves.
+function clean_submodule($Path, $Message, $Prompt) {
+  $done = $false
+  while (-Not $done) {
+    Write-Warning $Message
+    Write-Host $Prompt
+    $answer = [Console]::ReadKey()
+    if ($answer.KeyChar -ieq "q") {
+      exit 1
+    }
+    elseif ($answer.KeyChar -ieq "y") {
+      git clean -fxd
+      git reset --hard HEAD
+      $done = $true
+    }
+    elseif ($answer.KeyChar -ieq "n" -or $answer.Key -eq [System.ConsoleKey]::Spacebar -or $answer.Key -eq [System.ConsoleKey]::Enter) {
+      $done = $true
+    }
+    else {
+      Write-Host "Didn't understand that ($($answer.KeyChar))"
+    }
+  }
+}
+
+# We use the same script for checking the super-repo and the submodules.
+# Having the first argument be "in-submodule" triggers this submodule behavior.
+if ($args[0] -ieq "in-submodule") {
+  $expectedSha = $args[1]
+  $path = $args[2]
+  $subcommit = git rev-parse HEAD
+  if ($subcommit -ne $expectedSha) {
+    # merge-base fails if the commit is missing, so check for that first.
+    git cat-file -e $expectedSha^`{commit`} 2>&1 | Out-Null
+    if ($LastExitCode -ne 0) {
+      $mergeBase = "missing commit"
+    }
+    else {
+      $mergeBase = git merge-base HEAD $expectedSha
+    }
+    if ($mergeBase -ne $expectedSha) {
+      fix_submodule -Path $path -ExpectedSha $expectedSha -ActualSha $subcommit -Message "submodule $path, currently at $subcommit, has diverged from checked-in version $expectedSha" -Prompt "If you are changing a submodule branch or moving a submodule backwards, this is expected.`r`nShould I checkout $path to the expected commit $expectedSha [No/yes/quit]"
+    }
+    else {
+      fix_submodule -Path $path -ExpectedSha $expectedSha -ActualSha $subcommit -Message "submodule $path, currently at $subcommit, is ahead of checked-in version $expectedSha" -Prompt "If you are updating a submodule, this is expected.`r`nShould I checkout $path to the expected commit $expectedSha [No/yes/quit]"
+    }
+  }
+  $dirty = $false
+  # check for staged changes and unstaged modifications
+  git diff-index --quiet HEAD --
+  $dirty = $dirty -or $LastExitCode
+  # check for untracked new files
+  $untracked = git ls-files --others --exclude-standard
+  $dirty = $dirty -or (-Not [string]::IsNullOrWhitespace($untracked))
+  if ($dirty) {
+    clean_submodule -Path $path -Message "submodule $path has uncommitted changes" -Prompt "Should I clean and reset $path (this will lose ALL uncommitted changes)? [No/yes/quit]"
+  }
+}
+# Main branch for super-repo behavior
+else {
+  # submodule foreach doesn't work until submodules are init'd, read the modules manually
+  $modules = git config --file $ProjectRoot\.gitmodules --get-regexp path
+  foreach ($m in $modules) {
+    $m = $m.Split(' ')[1]
+    $mWin = $m.Replace('/', '\')
+    if (-Not (Test-Path "$ProjectRoot\$mWin\.git")) {
+      if ($script:answeredAll) {
+        git submodule update --init --recursive $m
+      }
+      else {
+        init_submodule -Path $m
+      }
+    }
+  }
+  $ProjectRoot = $ProjectRoot.Replace('\', '/')
+  # kick off the submodule behavior for each repo
+  git submodule foreach --quiet --recursive "powershell $ProjectRoot/check-submodules.ps1 in-submodule `$sha1 `$path"
+}

--- a/check-submodules.sh
+++ b/check-submodules.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_ROOT="$(cd -P "$( dirname "$0" )" && pwd)"
+SUBMODULES=$SCRIPT_ROOT/.gitmodules
+
+# has the user answered "yes to all" to init'ing submodules?
+answered_all=0
+
+# ask for confirmation and initialize a submodule if approved.
+init_submodule () {
+  module=$1
+  done=0
+  while [ $done == 0 ]; do
+    echo "warning: submodules $module does not appear to be initialized."
+    read -p "Should I initialize it for you? [Yes/no/all/quit] " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Aa]$ ]]; then
+      answered_all=1
+      done=1
+      git submodule update --init --recursive $module
+    elif [[ $REPLY =~ ^[Qq]$ ]]; then
+      exit 0
+    elif [[ $REPLY =~ ^[Nn]$ ]]; then
+      done=1
+    elif [[ $REPLY == "" || $REPLY == " " || $REPLY =~ ^[Yy]$ ]]; then
+      done=1
+      git submodule update --init --recursive $module
+    else
+      echo "didn't understand that ($REPLY)"
+    fi
+  done
+}
+
+# update a submodule to an expected commit.  We give different messages
+# for being ahead vs being behind or diverged from the expected commit,
+# so this function is parameterized.
+fix_submodule () {
+  path=$1
+  expected=$2
+  actual=$3
+  msg=$4
+  prompt=$5
+  done=0
+  while [ $done == 0 ]; do
+    echo -e "$msg"
+    read -p "$prompt " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Qq]$ ]]; then
+      exit 1
+    elif [[ $REPLY =~ ^[Yy]$ ]]; then
+	  # check if we have this commit locally and can skip the fetch
+      git cat-file -e $expected^{commit} 2>/dev/null || exitCode=$?
+      if [ $exitCode != 0 ]; then
+        git fetch
+      fi
+      exitCode=0
+	  # double-check, we should have the commit now unless something
+	  # weird is going on.
+      git cat-file -e $expected^{commit} 2>/dev/null || exitCode=$?
+      if [ $exitCode != 0 ]; then
+        echo "error: commit $expected was not found in $path"
+        echo "Are you using a custom remote for this submodule?  You may need to pick up changes from upstream."
+        echo "Canceling remainder of checks."
+        exit 1
+      fi
+      git checkout $expected
+      done=1
+    elif [[ $REPLY == "" || $REPLY == " " || $REPLY =~ ^[Nn]$ ]]; then
+      done=1
+    else
+      echo "didn't understand that ($REPLY)"
+    fi
+  done
+}
+
+# clean a submodule if the user approves.
+clean_submodule() {
+  path=$1
+  msg=$2
+  prompt=$3
+  done=0
+  while [ $done == 0 ]; do
+    echo -e "$msg"
+    read -p "$prompt " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Qq]$ ]]; then
+      exit 1
+    elif [[ $REPLY =~ ^[Yy]$ ]]; then
+      git clean -fxd
+      git reset --hard HEAD
+      done=1
+    elif [[ $REPLY == "" || $REPLY == " " || $REPLY =~ ^[Nn]$ ]]; then
+      done=1
+    else
+      echo "didn't understand that ($REPLY)"
+    fi
+  done
+}
+
+# We use the same script for checking the super-repo and the submodules.
+# Having the first argument be "in-submodule" triggers this submodule behavior.
+if [ ${1:-default} == "in-submodule" ]; then
+  expected_sha=$2
+  path=$3
+  subcommit=`git rev-parse HEAD`
+  if [ "$subcommit" != "$expected_sha" ]; then
+    exitCode=0
+	# merge-base fails if the commit is missing, so check for that first.
+    git cat-file -e $expected_sha^{commit} 2>/dev/null || exitCode=$?
+    if [ $exitCode != 0 ]; then
+      mergeBase="missing commit"
+    else
+      mergeBase=$(git merge-base HEAD $expected_sha)
+    fi
+    if [ "$mergeBase" != "$expected_sha" ]; then
+      fix_submodule $path $expected_sha $subcommit "warning: submodule $path, currently at $subcommit, has diverged from checked-in version $expected_sha\nif you are changing a submodule branch or moving a submodule backwards, this is expected.\nShould I checkout $path to the expected commit $expected_sha?" "[No/yes/quit]"
+    else
+      fix_submodule $path $expected_sha $subcommit "warning: submodule $path, currently at $subcommit, is ahead of checked-in version $expected_sha\nif you are updating a submodule, this is expected.\nShould I checkout $path to the expected commit $expected_sha?" "[No/yes/quit]"
+    fi
+  fi
+  # check for staged changes and unstaged modifications
+  git diff-index --quiet HEAD -- || exit_code=$?
+  # check for untracked new files
+  untracked="$(git ls-files --others --exclude-standard)"
+  if [[ ${exit_code:-0} != 0 || ! -z "$untracked" ]]; then
+    clean_submodule $path "warning: submodule $path has uncommitted changes\nShould I clean and reset $path (this will lose ALL uncommitted changes)?" "[No/yes/quit]"
+  fi
+# Main branch for super-repo behavior
+else
+  # submodule foreach doesn't work until submodules are init'd, read the modules manually
+  for module in `git config --file .gitmodules --get-regexp path | awk '{ print $2 }'`
+  do
+    if [ ! -e "$SCRIPT_ROOT/$module/.git" ]; then
+      if [ $answered_all == 1 ]; then
+        git submodule update --init --recursive $module
+      else
+        init_submodule $module
+     fi
+    fi
+  done
+  # kick off the submodule behavior for each repo
+  git submodule foreach --quiet --recursive "$SCRIPT_ROOT/check-submodules.sh in-submodule \$sha1 \$path"
+fi
+

--- a/check-submodules.sh
+++ b/check-submodules.sh
@@ -50,17 +50,18 @@ fix_submodule () {
     if [[ $REPLY =~ ^[Qq]$ ]]; then
       exit 1
     elif [[ $REPLY =~ ^[Yy]$ ]]; then
-	  # check if we have this commit locally and can skip the fetch
+      # check if we have this commit locally and can skip the fetch
       git cat-file -e $expected^{commit} 2>/dev/null || exitCode=$?
       if [ $exitCode != 0 ]; then
         git fetch
       fi
       exitCode=0
-	  # double-check, we should have the commit now unless something
-	  # weird is going on.
+      # double-check, we should have the commit now unless something
+      # weird is going on.
       git cat-file -e $expected^{commit} 2>/dev/null || exitCode=$?
       if [ $exitCode != 0 ]; then
         echo "error: commit $expected was not found in $path"
+        echo "The remote may have changed in source-build; run 'git submodule sync' and retry."
         echo "Are you using a custom remote for this submodule?  You may need to pick up changes from upstream."
         echo "Canceling remainder of checks."
         exit 1
@@ -102,12 +103,12 @@ clean_submodule() {
 # We use the same script for checking the super-repo and the submodules.
 # Having the first argument be "in-submodule" triggers this submodule behavior.
 if [ ${1:-default} == "in-submodule" ]; then
-  expected_sha=$2
-  path=$3
+  path=$2
+  expected_sha=$3
   subcommit=`git rev-parse HEAD`
   if [ "$subcommit" != "$expected_sha" ]; then
     exitCode=0
-	# merge-base fails if the commit is missing, so check for that first.
+    # merge-base fails if the commit is missing, so check for that first.
     git cat-file -e $expected_sha^{commit} 2>/dev/null || exitCode=$?
     if [ $exitCode != 0 ]; then
       mergeBase="missing commit"
@@ -141,6 +142,6 @@ else
     fi
   done
   # kick off the submodule behavior for each repo
-  git submodule foreach --quiet --recursive "$SCRIPT_ROOT/check-submodules.sh in-submodule \$sha1 \$path"
+  git submodule foreach --quiet --recursive "$SCRIPT_ROOT/check-submodules.sh in-submodule \$path \$sha1"
 fi
 


### PR DESCRIPTION
Fixes #137.
- Make sure submodules are initialized and optionally do this for you.
- Check if submodules match their checked-in hash and optionally update them if they don't.
- Check for untracked changes in submodules and optionally clean them.
- Put which submodule versions we're using into the tarball.