### PR TITLE
Fix build source tarball and enable CI for Red Hat Offline build

### DIFF
--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -59,7 +59,7 @@ rm -rf $TARBALL_ROOT/Tools/dotnetcli/additionalDeps
 cp $SCRIPT_ROOT/support/tarball/build.sh $TARBALL_ROOT/build.sh
 
 mkdir -p $TARBALL_ROOT/prebuilt/nuget-packages
-find $SCRIPT_ROOT/bin/obj/x64/Release/nuget-packages -name '*.nupkg' -exec cp {} $TARBALL_ROOT/prebuilt/nuget-packages/ \;
+find $SCRIPT_ROOT/packages -name '*.nupkg' -exec cp {} $TARBALL_ROOT/prebuilt/nuget-packages/ \;
 
 for built_package in $(find $SCRIPT_ROOT/bin/obj/x64/Release/blob-feed/packages/ -name '*.nupkg' | tr '[:upper:]' '[:lower:]')
 do

--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -21,6 +21,7 @@ if [ -e "$TARBALL_ROOT" ]; then
 fi
 
 SCRIPT_ROOT="$(cd -P "$( dirname "$0" )" && pwd)"
+SDK_VERSION=$(cat $SCRIPT_ROOT/DotnetCLIVersion.txt)
 
 if [ $SKIP_BUILD -ne 1 ]; then
 
@@ -32,30 +33,26 @@ if [ $SKIP_BUILD -ne 1 ]; then
     $SCRIPT_ROOT/build.sh /p:ArchiveDownloadedPackages=true /flp:v=detailed
 fi
 
-$SCRIPT_ROOT/clean.sh
+git submodule foreach --recursive git clean -xdf
+git submodule foreach --recursive git reset --hard
 
 mkdir -p "$TARBALL_ROOT"
 
-mkdir -p $TARBALL_ROOT/Tools
-cp -rf $SCRIPT_ROOT/Tools/* $TARBALL_ROOT/Tools/
-
-rm -f $TARBALL_ROOT/Tools/dotnetcli/dotnet.tar
-
-cp -r $SCRIPT_ROOT/build.proj $TARBALL_ROOT/
-cp -r $SCRIPT_ROOT/dir.props $TARBALL_ROOT/
+cp $SCRIPT_ROOT/build.proj $TARBALL_ROOT/
+cp $SCRIPT_ROOT/dir.props $TARBALL_ROOT/
+cp $SCRIPT_ROOT/DotnetCLIVersion.txt $TARBALL_ROOT/
 cp -r $SCRIPT_ROOT/keys $TARBALL_ROOT/
 cp -r $SCRIPT_ROOT/patches $TARBALL_ROOT/
-cp -r $SCRIPT_ROOT/repositories.props $TARBALL_ROOT/
 cp -r $SCRIPT_ROOT/scripts $TARBALL_ROOT/
 cp -r $SCRIPT_ROOT/src $TARBALL_ROOT/
-cp -r $SCRIPT_ROOT/targets $TARBALL_ROOT/
-cp -r $SCRIPT_ROOT/tasks $TARBALL_ROOT/
-cp -r $SCRIPT_ROOT/Tools $TARBALL_ROOT/
+cp -r $SCRIPT_ROOT/repos $TARBALL_ROOT/
+cp -r $SCRIPT_ROOT/tools-local $TARBALL_ROOT/
 
 find $TARBALL_ROOT/src -maxdepth 2 -name '.git' -exec rm {} \;
 
-rm -rf $TARBALL_ROOT/Tools/dotnetcli/dotnet.tar
-rm -rf $TARBALL_ROOT/Tools/dotnetcli/sdk/2.0.0-preview3-006845/nuGetPackagesArchive.lzma
+cp -r $SCRIPT_ROOT/Tools $TARBALL_ROOT/
+rm -f $TARBALL_ROOT/Tools/dotnetcli/dotnet.tar
+rm -f $TARBALL_ROOT/Tools/dotnetcli/sdk/$SDK_VERSION/nuGetPackagesArchive.lzma
 rm -rf $TARBALL_ROOT/Tools/dotnetcli/store
 rm -rf $TARBALL_ROOT/Tools/dotnetcli/additionalDeps
 
@@ -64,7 +61,7 @@ cp $SCRIPT_ROOT/support/tarball/build.sh $TARBALL_ROOT/build.sh
 mkdir -p $TARBALL_ROOT/prebuilt/nuget-packages
 find $SCRIPT_ROOT/bin/obj/x64/Release/nuget-packages -name '*.nupkg' -exec cp {} $TARBALL_ROOT/prebuilt/nuget-packages/ \;
 
-for built_package in $(find $SCRIPT_ROOT/bin/obj/x64/Release/source-built -name '*.nupkg' | tr '[:upper:]' '[:lower:]')
+for built_package in $(find $SCRIPT_ROOT/bin/obj/x64/Release/blob-feed/packages/ -name '*.nupkg' | tr '[:upper:]' '[:lower:]')
 do
     if [ -e $TARBALL_ROOT/prebuilt/nuget-packages/$(basename $built_package) ]; then
         rm $TARBALL_ROOT/prebuilt/nuget-packages/$(basename $built_package)

--- a/netci.groovy
+++ b/netci.groovy
@@ -68,14 +68,16 @@ def addPushJob(String project, String branch, String os, String configuration)
 
       def newJob = job(Utilities.getFullJobName(project, shortJobName, isPR)){
         steps{
-            shell("cd source-build")
+          dir('source-build'){
             shell("git submodule update --init --recursive");
             shell("./build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=${configuration} ${loggingOptions}");
             shell("./build-source-tarball.sh ../tarball-output --skip-build");
+          }
 
+          dir('tarball-output'){
             // For now, perform offline build up to corefx until we work through issues with other repos
-            shell('cd ../tarball-output');
-            shell("./tarball-output/build.sh /p:RootRepo=corefx /p:Configuration=${configuration} ${loggingOptions}")
+            shell("./build.sh /p:RootRepo=corefx /p:Configuration=${configuration} ${loggingOptions}")
+          }
         }
       }
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -63,7 +63,7 @@ def addPushJob(String project, String branch, String os, String configuration)
     ["Release", "Debug"].each { configuration ->
 
       def shortJobName = "${os}_Offline_${configuration}";
-      def contextString = "${os} ${configuration}";
+      def contextString = "${os} Offline ${configuration}";
       def triggerPhrase = "(?i).*test\\W+${contextString}.*";
 
       def newJob = job(Utilities.getFullJobName(project, shortJobName, isPR)){

--- a/netci.groovy
+++ b/netci.groovy
@@ -84,7 +84,12 @@ def addPushJob(String project, String branch, String os, String configuration)
       // Clone into the source-build directory
       Utilities.addScmInSubDirectory(newJob, project, isPR, 'source-build');
       if(isPR){
+        if(configuration == "Release"){
+          Utilities.addGithubPRTriggerForBranch(newJob, branch, contextString);
+        }
+        else{
           Utilities.addGithubPRTriggerForBranch(newJob, branch, contextString, triggerPhrase);
+        }
       }
       else{
         Utilities.addGithubPushTrigger(newJob);

--- a/netci.groovy
+++ b/netci.groovy
@@ -68,12 +68,12 @@ def addPushJob(String project, String branch, String os, String configuration)
 
       def newJob = job(Utilities.getFullJobName(project, shortJobName, isPR)){
         steps{
-            shell("pushd ./source-build;git submodule update --init --recursive;popd");
-            shell("./source-build/build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=${configuration} ${loggingOptions}");
-            shell("./source-build/build-source-tarball.sh ./tarball-output --skip-build");
+            shell("cd ./source-build;git submodule update --init --recursive");
+            shell("cd ./source-build;./build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=${configuration} ${loggingOptions}");
+            shell("cd ./source-build;./build-source-tarball.sh ../tarball-output --skip-build");
 
             // For now, perform offline build up to corefx until we work through issues with other repos
-            shell("./tarball-output/build.sh /p:RootRepo=corefx /p:Configuration=${configuration} ${loggingOptions}")
+            shell("cd ./tarball-output;./build.sh /p:RootRepo=corefx /p:Configuration=${configuration} ${loggingOptions}")
         }
       }
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -68,16 +68,12 @@ def addPushJob(String project, String branch, String os, String configuration)
 
       def newJob = job(Utilities.getFullJobName(project, shortJobName, isPR)){
         steps{
-          dir('source-build'){
-            shell("git submodule update --init --recursive");
-            shell("./build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=${configuration} ${loggingOptions}");
-            shell("./build-source-tarball.sh ../tarball-output --skip-build");
-          }
+            shell("pushd ./source-build;git submodule update --init --recursive;popd");
+            shell("./source-build/build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=${configuration} ${loggingOptions}");
+            shell("./source-build/build-source-tarball.sh ./tarball-output --skip-build");
 
-          dir('tarball-output'){
             // For now, perform offline build up to corefx until we work through issues with other repos
-            shell("./build.sh /p:RootRepo=corefx /p:Configuration=${configuration} ${loggingOptions}")
-          }
+            shell("./tarball-output/build.sh /p:RootRepo=corefx /p:Configuration=${configuration} ${loggingOptions}")
         }
       }
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -92,42 +92,43 @@ def addPushJob(String project, String branch, String os, String configuration)
 }
 
 [true, false].each { isPR ->
-["Linux_ARM"].each { os->
-  ["Release", "Debug"].each { configuration ->
+  ["Linux_ARM"].each { os->
+    ["Release", "Debug"].each { configuration ->
 
-    def shortJobName = "${os}_${configuration}";
-    def contextString = "${os} ${configuration}";
-    def triggerPhrase = "(?i).*test\\W+${contextString}.*";
+      def shortJobName = "${os}_${configuration}";
+      def contextString = "${os} ${configuration}";
+      def triggerPhrase = "(?i).*test\\W+${contextString}.*";
 
-    def newJob = job(Utilities.getFullJobName(project, shortJobName, isPR)){
-      steps{
-          shell("git submodule update --init --recursive");
-          shell("./init-tools.sh")
-          if(os == "Linux_ARM"){
-            shell("./arm-ci.sh arm ./build.sh /p:Platform=arm /p:Configuration=${configuration} ${loggingOptions}")
-          }
-          if(os == "Tizen"){
-            shell("./arm-ci.sh armel ./build.sh /p:Platform=armel /p:Configuration=${configuration} ${loggingOptions}")
-          }
+      def newJob = job(Utilities.getFullJobName(project, shortJobName, isPR)){
+        steps{
+            shell("git submodule update --init --recursive");
+            shell("./init-tools.sh")
+            if(os == "Linux_ARM"){
+              shell("./arm-ci.sh arm ./build.sh /p:Platform=arm /p:Configuration=${configuration} ${loggingOptions}")
+            }
+            if(os == "Tizen"){
+              shell("./arm-ci.sh armel ./build.sh /p:Platform=armel /p:Configuration=${configuration} ${loggingOptions}")
+            }
+        }
       }
-    }
 
-    Utilities.setMachineAffinity(newJob, 'Ubuntu', 'arm-cross-latest');
+      Utilities.setMachineAffinity(newJob, 'Ubuntu', 'arm-cross-latest');
 
-    Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}");
-    if(isPR){
-      //We run Tizen Release and Ubuntu ARM Release
-      if(configuration == "Release"){
-        Utilities.addGithubPRTriggerForBranch(newJob, branch, contextString);
+      Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}");
+      if(isPR){
+        //We run Tizen Release and Ubuntu ARM Release
+        if(configuration == "Release"){
+          Utilities.addGithubPRTriggerForBranch(newJob, branch, contextString);
+        }
+        else{
+          Utilities.addGithubPRTriggerForBranch(newJob, branch, contextString, triggerPhrase);
+        }
       }
       else{
-        Utilities.addGithubPRTriggerForBranch(newJob, branch, contextString, triggerPhrase);
+        Utilities.addGithubPushTrigger(newJob);
       }
-    }
-    else{
-      Utilities.addGithubPushTrigger(newJob);
-    }
 
+    }
   }
 }
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -89,45 +89,46 @@ def addPushJob(String project, String branch, String os, String configuration)
 
     }
   }
+}
 
-  [true, false].each { isPR ->
-  ["Linux_ARM"].each { os->
-    ["Release", "Debug"].each { configuration ->
+[true, false].each { isPR ->
+["Linux_ARM"].each { os->
+  ["Release", "Debug"].each { configuration ->
 
-      def shortJobName = "${os}_${configuration}";
-      def contextString = "${os} ${configuration}";
-      def triggerPhrase = "(?i).*test\\W+${contextString}.*";
+    def shortJobName = "${os}_${configuration}";
+    def contextString = "${os} ${configuration}";
+    def triggerPhrase = "(?i).*test\\W+${contextString}.*";
 
-      def newJob = job(Utilities.getFullJobName(project, shortJobName, isPR)){
-        steps{
-            shell("git submodule update --init --recursive");
-            shell("./init-tools.sh")
-            if(os == "Linux_ARM"){
-              shell("./arm-ci.sh arm ./build.sh /p:Platform=arm /p:Configuration=${configuration} ${loggingOptions}")
-            }
-            if(os == "Tizen"){
-              shell("./arm-ci.sh armel ./build.sh /p:Platform=armel /p:Configuration=${configuration} ${loggingOptions}")
-            }
-        }
+    def newJob = job(Utilities.getFullJobName(project, shortJobName, isPR)){
+      steps{
+          shell("git submodule update --init --recursive");
+          shell("./init-tools.sh")
+          if(os == "Linux_ARM"){
+            shell("./arm-ci.sh arm ./build.sh /p:Platform=arm /p:Configuration=${configuration} ${loggingOptions}")
+          }
+          if(os == "Tizen"){
+            shell("./arm-ci.sh armel ./build.sh /p:Platform=armel /p:Configuration=${configuration} ${loggingOptions}")
+          }
       }
+    }
 
-      Utilities.setMachineAffinity(newJob, 'Ubuntu', 'arm-cross-latest');
+    Utilities.setMachineAffinity(newJob, 'Ubuntu', 'arm-cross-latest');
 
-      Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}");
-      if(isPR){
-        //We run Tizen Release and Ubuntu ARM Release
-        if(configuration == "Release"){
-          Utilities.addGithubPRTriggerForBranch(newJob, branch, contextString);
-        }
-        else{
-          Utilities.addGithubPRTriggerForBranch(newJob, branch, contextString, triggerPhrase);
-        }
+    Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}");
+    if(isPR){
+      //We run Tizen Release and Ubuntu ARM Release
+      if(configuration == "Release"){
+        Utilities.addGithubPRTriggerForBranch(newJob, branch, contextString);
       }
       else{
-        Utilities.addGithubPushTrigger(newJob);
+        Utilities.addGithubPRTriggerForBranch(newJob, branch, contextString, triggerPhrase);
       }
-
     }
+    else{
+      Utilities.addGithubPushTrigger(newJob);
+    }
+
   }
 }
+
 

--- a/src/reference-assemblies/Directory.Build.props
+++ b/src/reference-assemblies/Directory.Build.props
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <DisableBuildToolsRoslynVersion>true</DisableBuildToolsRoslynVersion>
+    </PropertyGroup>
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
     <PropertyGroup>
         <ReferenceAssemblyPath>$(MSBuildProjectDirectoryNoRoot.Substring($(MSBuildThisFileDirectoryNoRoot.LastIndexOf("reference-assemblies"))))</ReferenceAssemblyPath>

--- a/src/reference-assemblies/Directory.Build.props
+++ b/src/reference-assemblies/Directory.Build.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
+        <!-- We use dotnet-cli to build reference-assemblies, so we need to disable BuildTools Roslyn properties. -->
         <DisableBuildToolsRoslynVersion>true</DisableBuildToolsRoslynVersion>
     </PropertyGroup>
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />

--- a/support/tarball/build.sh
+++ b/support/tarball/build.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 SCRIPT_ROOT="$(cd -P "$( dirname "$0" )" && pwd)"
-CLI_VERSION==$(cat $SCRIPT_ROOT/DotnetCLIVersion.txt)
+CLI_VERSION=$(cat $SCRIPT_ROOT/DotnetCLIVersion.txt)
 CLI_ROOT="$SCRIPT_ROOT/Tools/dotnetcli"
 
 export DOTNET_CLI_TELEMETRY_OPTOUT=1

--- a/support/tarball/build.sh
+++ b/support/tarball/build.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 SCRIPT_ROOT="$(cd -P "$( dirname "$0" )" && pwd)"
-CLI_VERSION="2.0.0-preview3-006845"
+CLI_VERSION==$(cat $SCRIPT_ROOT/DotnetCLIVersion.txt)
 CLI_ROOT="$SCRIPT_ROOT/Tools/dotnetcli"
 
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
@@ -12,5 +12,5 @@ export NUGET_PACKAGES="$SCRIPT_ROOT/packages/"
 
 MSBUILD_ARGUMENTS=("/p:OfflineBuild=true" "/flp:v=detailed" "/clp:v=detailed")
 
-$CLI_ROOT/dotnet $CLI_ROOT/sdk/$CLI_VERSION/MSBuild.dll $SCRIPT_ROOT/build.proj /t:WriteDynamicPropsToStaticPropsFiles /p:GeneratingStaticPropertiesFile=true ${MSBUILD_ARGUMENTS[@]} "$@"
+$CLI_ROOT/dotnet $CLI_ROOT/sdk/$CLI_VERSION/MSBuild.dll $SCRIPT_ROOT/tools-local/init-build.proj /t:WriteDynamicPropsToStaticPropsFiles /p:GeneratingStaticPropertiesFile=true ${MSBUILD_ARGUMENTS[@]} "$@"
 $CLI_ROOT/dotnet $CLI_ROOT/sdk/$CLI_VERSION/MSBuild.dll $SCRIPT_ROOT/build.proj ${MSBUILD_ARGUMENTS[@]} "$@"

--- a/tools-local/init-build.proj
+++ b/tools-local/init-build.proj
@@ -44,7 +44,7 @@
      <Exec Condition="'$(Platform)' == 'armel'" Command="$(ArmEnvironmentVariables) $(ProjectDir)cross/armel/tizen-build-rootfs.sh" />
   </Target>
 
-  <Target Name="BuildDummyPackages" Condition="'$(BuildOffline)' == 'true'">
+  <Target Name="BuildDummyPackages" Condition="'$(OfflineBuild)' == 'true'">
     <ItemGroup>
       <DummyPackage Include="Castle.Core" Version="3.3.3" />
       <DummyPackage Include="Castle.Core" Version="4.0.0-beta001" />
@@ -285,7 +285,7 @@
                         OutputPath="$(SourceBuiltPackagesPath)" />
   </Target>
 
-  <Target Name="BuildReferenceAssemblies" Condition="'$(BuildOffline)' == 'true'">
+  <Target Name="BuildReferenceAssemblies" Condition="'$(OfflineBuild)' == 'true'">
     <Exec Command="$(DotNetCliToolDir)/dotnet build $(SubmoduleDirectory)/reference-assemblies/build.proj" />
     <Exec Command="$(DotNetCliToolDir)/dotnet restore $(SubmoduleDirectory)/reference-assemblies/nuspecs/pack.csproj" />
     <Exec Command="$(DotNetCliToolDir)/dotnet pack $(SubmoduleDirectory)/reference-assemblies/nuspecs/PackAll.proj" />


### PR DESCRIPTION
Changes to enable building of the tarball from source-build and setting up CI for Offline build.  Offline build is building through corefx for now until other repos can get fixed.

Fixes dotnet/source-build#191