### PR TITLE
Update tarball commit info to include git describe

### DIFF
--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -74,5 +74,5 @@ source-build:
  $(git rev-parse HEAD) . ($(git describe --always HEAD))
 
 submodules:
-$(git submodule status)
+$(git submodule status --recursive)
 EOF

--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -69,7 +69,10 @@ do
 done
 
 # Record commits for the source-build repo and all submodules, to aid in reproducibility.
-echo -e "path\tchecked-in\tactual" > $TARBALL_ROOT/commits.txt
-echo -e "source-build\t$(git rev-parse HEAD)\t$(git rev-parse HEAD)" >> $TARBALL_ROOT/commits.txt
-git submodule foreach --quiet --recursive "actual=\$(git rev-parse HEAD); echo -e \"\$toplevel/\$path\t\$sha1\t\$actual\" >> $FULL_TARBALL_ROOT/commits.txt"
+cat >$TARBALL_ROOT/source-build-info.txt << EOF
+source-build:
+ $(git rev-parse HEAD) . ($(git describe --always HEAD))
 
+submodules:
+$(git submodule status)
+EOF


### PR DESCRIPTION
While looking to implement https://github.com/dotnet/source-build/issues/296 I saw it was already added in https://github.com/dotnet/source-build/pull/283.

This PR makes some minor modifications to the implementation.
The net result is previously a file was created `commits.txt`
```
path	checked-in	actual
source-build	e0c33c7e8e023cf581b8816cad1b85496d49c7b3	e0c33c7e8e023cf581b8816cad1b85496d49c7b3
/home/tmds/repos/source-build/src/application-insights	9b5b49f2a7697a2bf38f09ca2f2c97326c49d93b	9b5b49f2a7697a2bf38f09ca2f2c97326c49d93b
/home/tmds/repos/source-build/src/cli	b18db615946288f2f9028dfe333d775b7f180598	b18db615946288f2f9028dfe333d775b7f180598
/home/tmds/repos/source-build/src/cli-deps-satellites	6af7f37eddcc3efb47821535a9be7bda9134f4f0	6af7f37eddcc3efb47821535a9be7bda9134f4f0
/home/tmds/repos/source-build/src/cli-migrate	c3a335717f48005476fc79d47d4325d7bb643f35	c3a335717f48005476fc79d47d4325d7bb643f35
/home/tmds/repos/source-build/src/clicommandlineparser	1a822f37bc5b8e227e5bf8ded4918b7da63c47eb	1a822f37bc5b8e227e5bf8ded4918b7da63c47eb
/home/tmds/repos/source-build/src/common	be9aca0f20c979498298be47e843e3a7b8777dca	be9aca0f20c979498298be47e843e3a7b8777dca
/home/tmds/repos/source-build/src/core-setup	1732b0ab678f1460cfb94d8688077edcb7c8d0f1	1732b0ab678f1460cfb94d8688077edcb7c8d0f1
/home/tmds/repos/source-build/src/coreclr	0e39e2118f2a5bfd7d0c96e2d289e70823d6d1d4	0e39e2118f2a5bfd7d0c96e2d289e70823d6d1d4
/home/tmds/repos/source-build/src/corefx	091277427f67e2f9fc25c78d5640ea3a930ace72	091277427f67e2f9fc25c78d5640ea3a930ace72
/home/tmds/repos/source-build/src/fsharp	433b331eca288fd9d31160033a88aeea29fb2d85	433b331eca288fd9d31160033a88aeea29fb2d85
/home/tmds/repos/source-build/src/msbuild	c1de3014059ac4d72246a2a06e95026a3a701115	c1de3014059ac4d72246a2a06e95026a3a701115
/home/tmds/repos/source-build/src/newtonsoft-json	e5ac9a8473dfdefb8fe2cddae433a9aaa94a5b37	e5ac9a8473dfdefb8fe2cddae433a9aaa94a5b37
/home/tmds/repos/source-build/src/nuget-client	93d85237e4c21ade2376b2b49cc8822852c1b3c7	93d85237e4c21ade2376b2b49cc8822852c1b3c7
/home/tmds/repos/source-build/src/nuget-client/submodules/Common	e6fac8061686c18531e2621ccef97dd5e0687a65	e6fac8061686c18531e2621ccef97dd5e0687a65
/home/tmds/repos/source-build/src/nuget-client/submodules/FileSystem	f1f3f0820a573b96b2faaf5b7e6be9a036e4c7aa	f1f3f0820a573b96b2faaf5b7e6be9a036e4c7aa
/home/tmds/repos/source-build/src/nuget-client/submodules/NuGet.Build.Localization	f15db7b7c6f5affbea268632ef8333d2687c8031	f15db7b7c6f5affbea268632ef8333d2687c8031
/home/tmds/repos/source-build/src/roslyn	305e5abeb68156e1d07722df0fe0e84e5d339f94	305e5abeb68156e1d07722df0fe0e84e5d339f94
/home/tmds/repos/source-build/src/sdk	578d62c49eaddb17263a5c7e4f1eaaa24a1c8f94	578d62c49eaddb17263a5c7e4f1eaaa24a1c8f94
/home/tmds/repos/source-build/src/standard	f521a0ed6bcf6326bee829bc478c9e6529c2b0e2	f521a0ed6bcf6326bee829bc478c9e6529c2b0e2
/home/tmds/repos/source-build/src/symreader	9a17c48ac612ae8b49d2de5988a83d7d09798ad5	9a17c48ac612ae8b49d2de5988a83d7d09798ad5
/home/tmds/repos/source-build/src/symreader-portable	0b38450a75c9ea28b40020ac9b1a14a092ed1621	0b38450a75c9ea28b40020ac9b1a14a092ed1621
/home/tmds/repos/source-build/src/templating	238e130268b235be44641bff66d57d75214475d9	238e130268b235be44641bff66d57d75214475d9
/home/tmds/repos/source-build/src/vstest	1f13600aec5ef4c2aa08573f4c7391c12bf22b08	1f13600aec5ef4c2aa08573f4c7391c12bf22b08
/home/tmds/repos/source-build/src/websdk	afbcec9b0951d09088f26e98e6aca6114e0d32ee	afbcec9b0951d09088f26e98e6aca6114e0d32ee
/home/tmds/repos/source-build/src/xliff-tasks	27d43b762aa6dac3a0a6ba48fe55000942d75c1c	27d43b762aa6dac3a0a6ba48fe55000942d75c1c
```

While the file is now named `source-build-info.txt` and it looks like this:
```
source-build:
 e0c33c7e8e023cf581b8816cad1b85496d49c7b3 . (e0c33c7)

submodules:
 9b5b49f2a7697a2bf38f09ca2f2c97326c49d93b src/application-insights (v2.0.0)
 b18db615946288f2f9028dfe333d775b7f180598 src/cli (v2.0.2-141-gb18db61)
 6af7f37eddcc3efb47821535a9be7bda9134f4f0 src/cli-deps-satellites (heads/master-1-g6af7f37)
 c3a335717f48005476fc79d47d4325d7bb643f35 src/cli-migrate (c3a3357)
 1a822f37bc5b8e227e5bf8ded4918b7da63c47eb src/clicommandlineparser (1a822f3)
 be9aca0f20c979498298be47e843e3a7b8777dca src/common (rel/1.0.1-1-gbe9aca0)
 1732b0ab678f1460cfb94d8688077edcb7c8d0f1 src/core-setup (v2.0.1-51-g1732b0a)
 0e39e2118f2a5bfd7d0c96e2d289e70823d6d1d4 src/coreclr (v2.0.1-56-g0e39e21)
 091277427f67e2f9fc25c78d5640ea3a930ace72 src/corefx (v2.0.3-72-g0912774)
 433b331eca288fd9d31160033a88aeea29fb2d85 src/fsharp (Visual-Studio-2017-Preview-1-Version-15.5-219-g433b331)
 c1de3014059ac4d72246a2a06e95026a3a701115 src/msbuild (v15.1.0-preview-000370-00-513-gc1de301)
 e5ac9a8473dfdefb8fe2cddae433a9aaa94a5b37 src/newtonsoft-json (9.0.1)
 93d85237e4c21ade2376b2b49cc8822852c1b3c7 src/nuget-client (4.5.0.4529-14-g93d8523)
 305e5abeb68156e1d07722df0fe0e84e5d339f94 src/roslyn (version-2.3.0-beta3-193-g305e5ab)
 578d62c49eaddb17263a5c7e4f1eaaa24a1c8f94 src/sdk (dev15.0.0-694-g578d62c)
 f521a0ed6bcf6326bee829bc478c9e6529c2b0e2 src/standard (v2.0.0-34-gf521a0e)
 9a17c48ac612ae8b49d2de5988a83d7d09798ad5 src/symreader (dev15)
 0b38450a75c9ea28b40020ac9b1a14a092ed1621 src/symreader-portable (dev15)
 238e130268b235be44641bff66d57d75214475d9 src/templating (CLI-Templates-2.0.0)
 1f13600aec5ef4c2aa08573f4c7391c12bf22b08 src/vstest (v15.3.0-preview-20170618-03-3-g1f13600)
 afbcec9b0951d09088f26e98e6aca6114e0d32ee src/websdk (remotes/origin/rel-2.0.0-24-gafbcec9)
 27d43b762aa6dac3a0a6ba48fe55000942d75c1c src/xliff-tasks (27d43b7)
```

In case the checked-in and actual don't match. The actual sha is printed and the line starts with a '+'.

CC @crummel 