### PR TITLE
Fix roslyn and nuget client output problems

### DIFF
--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -149,7 +149,7 @@
     <OnError ExecuteTargets="ReportRepoError" />
   </Target>
 
-  <Target Name="GatherBuiltPackages" AfterTargets="Package">
+  <Target Name="GatherBuiltPackages">
     <ItemGroup>
       <!-- Filter out packages for WriteVersions -->
       <_BuiltPackages Include="$(PackagesOutput)/*.nupkg" Exclude="$(PackagesOutput)/*.symbols.nupkg"/>
@@ -166,7 +166,7 @@
   </Target>
 
   <Target Name="WriteVersions"
-          AfterTargets="Build;CopyPackage"
+          AfterTargets="CopyPackage"
           DependsOnTargets="GatherBuiltPackages">
     <WriteVersionsFile NugetPackages="@(_BuiltPackages)"
                        OutputPath="$(VersionFileLocation)"

--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -149,7 +149,7 @@
     <OnError ExecuteTargets="ReportRepoError" />
   </Target>
 
-  <Target Name="GatherBuiltPackages">
+  <Target Name="GatherBuiltPackages" AfterTargets="Package">
     <ItemGroup>
       <!-- Filter out packages for WriteVersions -->
       <_BuiltPackages Include="$(PackagesOutput)/*.nupkg" Exclude="$(PackagesOutput)/*.symbols.nupkg"/>

--- a/repos/nuget-client.proj
+++ b/repos/nuget-client.proj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
-    <PackagesOutput>$(ProjectDirectory)Nupkgs/</PackagesOutput>
+    <PackagesOutput>$(ProjectDirectory)artifacts/nupkgs/</PackagesOutput>
     <NuGetCoreSourceDirectory>$(ProjectDirectory)src/NuGet.Core/</NuGetCoreSourceDirectory>
     <ToolsDirectory>$(ProjectDirectory)cli/</ToolsDirectory>
     <NuGetKeyFilePath>$(KeysDir)NuGet.Client.snk</NuGetKeyFilePath>


### PR DESCRIPTION
Having "Build" as an AfterTargets on WriteVersions caused it to run right after build, which also caused GatherBuiltPackages to run early.  This resulted in GatherBuiltPackages being called before Package in Roslyn, so no output was being copied.  Removing the "Build" from AfterTargets causes all the targets to run in the right order.

Also, the nuget-client packagesOutput was incorrect, causing no output for that as well.

Fixes #308 & #309 
