### PR TITLE
Update appInsights, common and vstest to place output correctly.

### DIFF
--- a/repos/application-insights.proj
+++ b/repos/application-insights.proj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
-    <PackagesOutput>$(ProjectDirectory)/bin/$(Configuration)</PackagesOutput>
+    <PackagesOutput>$(SubmoduleDirectory)/bin/$(Configuration)</PackagesOutput>
     <RepoApiImplemented>false</RepoApiImplemented>
   </PropertyGroup>
 

--- a/repos/common.proj
+++ b/repos/common.proj
@@ -9,7 +9,7 @@
     <BuildArguments>/p:Configuration=$(Configuration)</BuildArguments>
     <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) -NoTest $(BuildArguments)</BuildCommand>
     <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension) $(BuildArguments)</CleanCommand>
-    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
+    <RepoApiImplemented>false</RepoApiImplemented>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />

--- a/repos/common.proj
+++ b/repos/common.proj
@@ -9,6 +9,7 @@
     <BuildArguments>/p:Configuration=$(Configuration)</BuildArguments>
     <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) -NoTest $(BuildArguments)</BuildCommand>
     <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension) $(BuildArguments)</CleanCommand>
+    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />

--- a/repos/vstest.proj
+++ b/repos/vstest.proj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) -DotnetBuildFromSource -DotnetCoreSdkDir $(DotNetCliToolDir) -c $(Configuration) -r $(TargetRid) -v 15.3.0 -vs preview-20170628-02</BuildCommand>
     <PackagesOutput>$(ProjectDirectory)/artifacts/$(Configuration)/packages</PackagesOutput>
-    <RepoApiImplemented>true</RepoApiImplemented>
+    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
   </PropertyGroup>
 
   <ItemGroup>

--- a/repos/vstest.proj
+++ b/repos/vstest.proj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) -DotnetBuildFromSource -DotnetCoreSdkDir $(DotNetCliToolDir) -c $(Configuration) -r $(TargetRid) -v 15.3.0 -vs preview-20170628-02</BuildCommand>
     <PackagesOutput>$(ProjectDirectory)/artifacts/$(Configuration)/packages</PackagesOutput>
-    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
+    <RepoApiImplemented>false</RepoApiImplemented>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
appInsights output is in a different location than where source-build was looking.  common and vstest don't implement outputPlacementRepoApi, so turn that off.

Fixes dotnet/source-build#318