### PR TITLE
Fix roslyn-tools offline build

### DIFF
--- a/patches/roslyn-tools/0001-Add-solution-for-only-.NET-Core-projects.patch
+++ b/patches/roslyn-tools/0001-Add-solution-for-only-.NET-Core-projects.patch
@@ -1,7 +1,7 @@
-From 7ab23acb417e295be6208c5d62295de009590fe0 Mon Sep 17 00:00:00 2001
+From 1ebd5a2a76a4a563a5336b7fd8acde9326db095f Mon Sep 17 00:00:00 2001
 From: Chris Rummel <crummel@microsoft.com>
 Date: Tue, 6 Mar 2018 17:25:10 -0600
-Subject: [PATCH 1/2] Add solution for only .NET Core projects.
+Subject: [PATCH] Add solution for only .NET Core projects.
 
 ---
  RoslynToolsNetCore.sln | 58 ++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/patches/roslyn-tools/0002-Update-projects-to-only-build-and-pack-for-.NET-Core.patch
+++ b/patches/roslyn-tools/0002-Update-projects-to-only-build-and-pack-for-.NET-Core.patch
@@ -1,8 +1,8 @@
-From fd28824a72bdf705fb30ba8459d4e5ec391eb572 Mon Sep 17 00:00:00 2001
+From b258562f0bd6beff2f27ec9ca178ffd6a5487c9d Mon Sep 17 00:00:00 2001
 From: Chris Rummel <crummel@microsoft.com>
 Date: Tue, 6 Mar 2018 17:26:45 -0600
-Subject: [PATCH 2/2] Update projects to only build and pack for .NET Core
- under source-build
+Subject: [PATCH] Update projects to only build and pack for .NET Core under
+ source-build
 
 ---
  sdks/RepoToolset/RepoToolset.csproj          | 3 ++-

--- a/repos/known-good.proj
+++ b/repos/known-good.proj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <!-- Toolsets -->
-    <!--RepositoryReference Include="roslyn-tools" /-->
+    <RepositoryReference Include="roslyn-tools" />
 
     <!-- Tier 1 -->
     <RepositoryReference Include="application-insights" />

--- a/repos/roslyn-tools.proj
+++ b/repos/roslyn-tools.proj
@@ -2,7 +2,6 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
-    <BuildCommand>$(DotnetToolCommand) pack -c $(Configuration) $(ProjectDirectory)/RoslynToolsNetCore.sln</BuildCommand>
     <PackagesOutput>$(ProjectDirectory)/artifacts/$(Configuration)/packages</PackagesOutput>
     <RepoApiImplemented>false</RepoApiImplemented>
   </PropertyGroup>
@@ -11,15 +10,18 @@
     <EnvironmentVariables Include="UsingToolMicrosoftNetCompilers=false" />
     <!-- Match the version symreader wants - this is the highest among our client repos -->
     <EnvironmentVariables Include="BUILD_BUILDNUMBER=20180215.01" />
+    <EnvironmentVariables Include="ExternalRestoreSources=$(PrebuiltPackagesPath)" Condition="'$(DotNetBuildOffline)' == 'true'" />
+    <EnvironmentVariables Include="RestoreSources=$(SourceBuiltPackagesPath)" Condition="'$(DotNetBuildOffline)' == 'true'" />
   </ItemGroup>
 
-  <Target Name="RestoreTools"
-          BeforeTargets="Build">
-    <Exec Command="$(DotnetToolCommand) restore $(ProjectDirectory)/build/Toolset.proj $(RedirectRepoOutputToLog)"
-          WorkingDirectory="$(ProjectDirectory)"
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
+
+  <Target Name="RepoBuild">
+    <Exec Command="$(DotnetToolCommand) restore $(ProjectDirectory)/build/Toolset.proj  /p:Configuration=$(Configuration) $(RedirectRepoOutputToLog)"
+          EnvironmentVariables="@(EnvironmentVariables)" />
+
+    <Exec Command="$(DotnetToolCommand) pack -c $(Configuration) $(ProjectDirectory)/RoslynToolsNetCore.sln /p:Configuration=$(Configuration) $(RedirectRepoOutputToLog)"
           EnvironmentVariables="@(EnvironmentVariables)" />
   </Target>
 
-
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
 </Project>


### PR DESCRIPTION
- Add source-build sources to the environment variables roslyn-tools uses for extra feeds.
- Use RepoBuild instead of BuildCommand to propagate environment variables.
- Add roslyn-tools back to known-good.