### PR TITLE
Add unshared build to Jenkins.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -119,9 +119,6 @@ def addPushJob(String project, String branch, String os, String configuration)
             shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/code/home --network none -v \$(pwd)/source-build:/opt/code -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build-source-tarball.sh /opt/tarball --skip-build");
             // now build from the tarball offline and without access to the regular non-tarball build
             shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/tarball/home --network none -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/tarball/build.sh /p:Configuration=${configuration} ${loggingOptions}");
-            // do cleanup - Jenkins can't because we sudo'd
-            shell("cd ./source-build; sudo git clean -fxd")
-            shell("sudo rm -rf tarball-output")
         }
       }
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -118,7 +118,7 @@ def addPushJob(String project, String branch, String os, String configuration)
             // now build the tarball
             shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/code/home --network none -v \$(pwd)/source-build:/opt/code -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build-source-tarball.sh /opt/tarball --skip-build");
             // now build from the tarball offline and without access to the regular non-tarball build
-            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/code/home --network none -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/tarball/build.sh /p:Configuration=${configuration} ${loggingOptions}");
+            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/tarball/home --network none -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/tarball/build.sh /p:Configuration=${configuration} ${loggingOptions}");
             // do cleanup - Jenkins can't because we sudo'd
             shell("cd ./source-build; sudo git clean -fxd")
             shell("sudo rm -rf tarball-output")

--- a/netci.groovy
+++ b/netci.groovy
@@ -112,13 +112,13 @@ def addPushJob(String project, String branch, String os, String configuration)
         steps{
             shell("cd ./source-build;git submodule update --init --recursive");
             // First build the product itself
-            shell("docker run -u=\"\$(id -u):\$(id -g)\" -v \$(pwd)/source-build:/opt/code --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=${configuration} ${loggingOptions}");
+            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -v \$(pwd)/source-build:/opt/code --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=${configuration} ${loggingOptions}");
             // Have to make this directory before volume-sharing it unlike non-docker build - existing directory is really only a warning in build-source-tarball.sh
             shell("mkdir tarball-output");
             // now build the tarball
-            shell("docker run -u=\"\$(id -u):\$(id -g)\" -v \$(pwd)/source-build:/opt/code -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build-source-tarball.sh /opt/tarball --skip-build");
+            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -v \$(pwd)/source-build:/opt/code -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build-source-tarball.sh /opt/tarball --skip-build");
             // now build from the tarball offline and without access to the regular non-tarball build
-            shell("docker run -u=\"\$(id -u):\$(id -g)\" -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 unshare -n /opt/tarball/build.sh /p:Configuration=${configuration} ${loggingOptions}");
+            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 unshare -n /opt/tarball/build.sh /p:Configuration=${configuration} ${loggingOptions}");
             // do cleanup - Jenkins can't because we sudo'd
             shell("cd ./source-build; sudo git clean -fxd")
             shell("sudo rm -rf tarball-output")

--- a/netci.groovy
+++ b/netci.groovy
@@ -112,13 +112,13 @@ def addPushJob(String project, String branch, String os, String configuration)
         steps{
             shell("cd ./source-build;git submodule update --init --recursive");
             // First build the product itself
-            shell("docker run -v ./source-build:/opt/code --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=${configuration} ${loggingOptions}");
+            shell("docker run -v $(pwd)/source-build:/opt/code --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=${configuration} ${loggingOptions}");
             // Have to make this directory before volume-sharing it unlike non-docker build - existing directory is really only a warning in build-source-tarball.sh
             shell("mkdir tarball-output");
             // now build the tarball
-            shell("docker run -v ./source-build:/opt/code -v ./tarball-output:/opt/tarball --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build-source-tarball.sh /opt/tarball --skip-build");
+            shell("docker run -v $(pwd)/source-build:/opt/code -v $(pwd)/tarball-output:/opt/tarball --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build-source-tarball.sh /opt/tarball --skip-build");
             // now build from the tarball offline and without access to the regular non-tarball build
-            shell("sudo docker run --privileged -v ./tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 unshare -n /opt/tarball/build.sh /p:Configuration=${configuration} ${loggingOptions}");
+            shell("sudo docker run --privileged -v $(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 unshare -n /opt/tarball/build.sh /p:Configuration=${configuration} ${loggingOptions}");
         }
       }
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -112,13 +112,13 @@ def addPushJob(String project, String branch, String os, String configuration)
         steps{
             shell("cd ./source-build;git submodule update --init --recursive");
             // First build the product itself
-            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME= -v \$(pwd)/source-build:/opt/code --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=${configuration} ${loggingOptions}");
+            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/code/home -v \$(pwd)/source-build:/opt/code --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=${configuration} ${loggingOptions}");
             // Have to make this directory before volume-sharing it unlike non-docker build - existing directory is really only a warning in build-source-tarball.sh
             shell("mkdir tarball-output");
             // now build the tarball
-            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME= -v \$(pwd)/source-build:/opt/code -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build-source-tarball.sh /opt/tarball --skip-build");
+            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/code/home -v \$(pwd)/source-build:/opt/code -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build-source-tarball.sh /opt/tarball --skip-build");
             // now build from the tarball offline and without access to the regular non-tarball build
-            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME= -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 unshare -n /opt/tarball/build.sh /p:Configuration=${configuration} ${loggingOptions}");
+            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/code/home -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 unshare -n /opt/tarball/build.sh /p:Configuration=${configuration} ${loggingOptions}");
             // do cleanup - Jenkins can't because we sudo'd
             shell("cd ./source-build; sudo git clean -fxd")
             shell("sudo rm -rf tarball-output")

--- a/netci.groovy
+++ b/netci.groovy
@@ -112,13 +112,13 @@ def addPushJob(String project, String branch, String os, String configuration)
         steps{
             shell("cd ./source-build;git submodule update --init --recursive");
             // First build the product itself
-            shell("docker run -v $(pwd)/source-build:/opt/code --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=${configuration} ${loggingOptions}");
+            shell("docker run -v \$(pwd)/source-build:/opt/code --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=${configuration} ${loggingOptions}");
             // Have to make this directory before volume-sharing it unlike non-docker build - existing directory is really only a warning in build-source-tarball.sh
             shell("mkdir tarball-output");
             // now build the tarball
-            shell("docker run -v $(pwd)/source-build:/opt/code -v $(pwd)/tarball-output:/opt/tarball --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build-source-tarball.sh /opt/tarball --skip-build");
+            shell("docker run -v \$(pwd)/source-build:/opt/code -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build-source-tarball.sh /opt/tarball --skip-build");
             // now build from the tarball offline and without access to the regular non-tarball build
-            shell("sudo docker run --privileged -v $(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 unshare -n /opt/tarball/build.sh /p:Configuration=${configuration} ${loggingOptions}");
+            shell("sudo docker run --privileged -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 unshare -n /opt/tarball/build.sh /p:Configuration=${configuration} ${loggingOptions}");
         }
       }
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -112,7 +112,7 @@ def addPushJob(String project, String branch, String os, String configuration)
         steps{
             shell("cd ./source-build;git submodule update --init --recursive");
             // First build the product itself
-            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/code/home --network none -v \$(pwd)/source-build:/opt/code --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=${configuration} ${loggingOptions}");
+            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/code/home -v \$(pwd)/source-build:/opt/code --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=${configuration} ${loggingOptions}");
             // Have to make this directory before volume-sharing it unlike non-docker build - existing directory is really only a warning in build-source-tarball.sh
             shell("mkdir tarball-output");
             // now build the tarball

--- a/netci.groovy
+++ b/netci.groovy
@@ -112,13 +112,13 @@ def addPushJob(String project, String branch, String os, String configuration)
         steps{
             shell("cd ./source-build;git submodule update --init --recursive");
             // First build the product itself
-            shell("docker run -v \$(pwd)/source-build:/opt/code --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=${configuration} ${loggingOptions}");
+            shell("docker run -u=\"\$(id -u):\$(id -g)\" -v \$(pwd)/source-build:/opt/code --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=${configuration} ${loggingOptions}");
             // Have to make this directory before volume-sharing it unlike non-docker build - existing directory is really only a warning in build-source-tarball.sh
             shell("mkdir tarball-output");
             // now build the tarball
-            shell("docker run -v \$(pwd)/source-build:/opt/code -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build-source-tarball.sh /opt/tarball --skip-build");
+            shell("docker run -u=\"\$(id -u):\$(id -g)\" -v \$(pwd)/source-build:/opt/code -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build-source-tarball.sh /opt/tarball --skip-build");
             // now build from the tarball offline and without access to the regular non-tarball build
-            shell("sudo docker run --privileged -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 unshare -n /opt/tarball/build.sh /p:Configuration=${configuration} ${loggingOptions}");
+            shell("docker run -u=\"\$(id -u):\$(id -g)\" -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 unshare -n /opt/tarball/build.sh /p:Configuration=${configuration} ${loggingOptions}");
             // do cleanup - Jenkins can't because we sudo'd
             shell("cd ./source-build; sudo git clean -fxd")
             shell("sudo rm -rf tarball-output")

--- a/netci.groovy
+++ b/netci.groovy
@@ -112,13 +112,13 @@ def addPushJob(String project, String branch, String os, String configuration)
         steps{
             shell("cd ./source-build;git submodule update --init --recursive");
             // First build the product itself
-            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/code/home -v \$(pwd)/source-build:/opt/code --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=${configuration} ${loggingOptions}");
+            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/code/home --network none -v \$(pwd)/source-build:/opt/code --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=${configuration} ${loggingOptions}");
             // Have to make this directory before volume-sharing it unlike non-docker build - existing directory is really only a warning in build-source-tarball.sh
             shell("mkdir tarball-output");
             // now build the tarball
-            shell("sudo docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/code/home --privileged -v \$(pwd)/source-build:/opt/code -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 unshare -n /opt/code/build-source-tarball.sh /opt/tarball --skip-build");
+            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/code/home --network none -v \$(pwd)/source-build:/opt/code -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build-source-tarball.sh /opt/tarball --skip-build");
             // now build from the tarball offline and without access to the regular non-tarball build
-            shell("sudo docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/code/home --privileged -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 unshare -n /opt/tarball/build.sh /p:Configuration=${configuration} ${loggingOptions}");
+            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/code/home --network none -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/tarball/build.sh /p:Configuration=${configuration} ${loggingOptions}");
             // do cleanup - Jenkins can't because we sudo'd
             shell("cd ./source-build; sudo git clean -fxd")
             shell("sudo rm -rf tarball-output")

--- a/netci.groovy
+++ b/netci.groovy
@@ -112,13 +112,13 @@ def addPushJob(String project, String branch, String os, String configuration)
         steps{
             shell("cd ./source-build;git submodule update --init --recursive");
             // First build the product itself
-            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -v \$(pwd)/source-build:/opt/code --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=${configuration} ${loggingOptions}");
+            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME= -v \$(pwd)/source-build:/opt/code --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=${configuration} ${loggingOptions}");
             // Have to make this directory before volume-sharing it unlike non-docker build - existing directory is really only a warning in build-source-tarball.sh
             shell("mkdir tarball-output");
             // now build the tarball
-            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -v \$(pwd)/source-build:/opt/code -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build-source-tarball.sh /opt/tarball --skip-build");
+            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME= -v \$(pwd)/source-build:/opt/code -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build-source-tarball.sh /opt/tarball --skip-build");
             // now build from the tarball offline and without access to the regular non-tarball build
-            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 unshare -n /opt/tarball/build.sh /p:Configuration=${configuration} ${loggingOptions}");
+            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME= -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 unshare -n /opt/tarball/build.sh /p:Configuration=${configuration} ${loggingOptions}");
             // do cleanup - Jenkins can't because we sudo'd
             shell("cd ./source-build; sudo git clean -fxd")
             shell("sudo rm -rf tarball-output")

--- a/netci.groovy
+++ b/netci.groovy
@@ -116,9 +116,9 @@ def addPushJob(String project, String branch, String os, String configuration)
             // Have to make this directory before volume-sharing it unlike non-docker build - existing directory is really only a warning in build-source-tarball.sh
             shell("mkdir tarball-output");
             // now build the tarball
-            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/code/home -v \$(pwd)/source-build:/opt/code -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build-source-tarball.sh /opt/tarball --skip-build");
+            shell("sudo docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/code/home --privileged -v \$(pwd)/source-build:/opt/code -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 unshare -n /opt/code/build-source-tarball.sh /opt/tarball --skip-build");
             // now build from the tarball offline and without access to the regular non-tarball build
-            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/code/home -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 unshare -n /opt/tarball/build.sh /p:Configuration=${configuration} ${loggingOptions}");
+            shell("sudo docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/code/home --privileged -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 unshare -n /opt/tarball/build.sh /p:Configuration=${configuration} ${loggingOptions}");
             // do cleanup - Jenkins can't because we sudo'd
             shell("cd ./source-build; sudo git clean -fxd")
             shell("sudo rm -rf tarball-output")

--- a/netci.groovy
+++ b/netci.groovy
@@ -119,6 +119,9 @@ def addPushJob(String project, String branch, String os, String configuration)
             shell("docker run -v \$(pwd)/source-build:/opt/code -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/code microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/code/build-source-tarball.sh /opt/tarball --skip-build");
             // now build from the tarball offline and without access to the regular non-tarball build
             shell("sudo docker run --privileged -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 unshare -n /opt/tarball/build.sh /p:Configuration=${configuration} ${loggingOptions}");
+            // do cleanup - Jenkins can't because we sudo'd
+            shell("cd ./source-build; sudo git clean -fxd")
+            shell("sudo rm -rf tarball-output")
         }
       }
 


### PR DESCRIPTION
- Change existing "Offline" builds to be called "Tarball" instead since it was inaccurate.
- Add new "Unshared" builds that work similarly to the tarball build, but build in Docker for two reasons:
    - We can use `--network none` to take the machines offline.
    - We can guarantee we won't have anything in the NuGet cache to pick up.