### PR TITLE
Repair offline build

### DIFF
--- a/repos/common.proj
+++ b/repos/common.proj
@@ -12,5 +12,8 @@
     <RepoApiImplemented>false</RepoApiImplemented>
   </PropertyGroup>
 
+  <ItemGroup>
+    <RepositoryReference Include="newtonsoft-json" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
 </Project>

--- a/repos/known-good.proj
+++ b/repos/known-good.proj
@@ -26,7 +26,7 @@
     <!-- Tier 2 -->
     <RepositoryReference Include="nuget-client" />
     <RepositoryReference Include="websdk" />
-    <RepositoryReference Include="coreclr" />
+    <!--RepositoryReference Include="coreclr" /-->
 
     <!--RepositoryReference Include="symreader-portable" /-->
     <!--RepositoryReference Include="templating" /-->

--- a/repos/known-good.proj
+++ b/repos/known-good.proj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <!-- Toolsets -->
-    <RepositoryReference Include="roslyn-tools" />
+    <!--RepositoryReference Include="roslyn-tools" /-->
 
     <!-- Tier 1 -->
     <RepositoryReference Include="application-insights" />

--- a/repos/newtonsoft-json.proj
+++ b/repos/newtonsoft-json.proj
@@ -15,7 +15,7 @@
     <RepoApiImplemented>false</RepoApiImplemented>
   </PropertyGroup>
 
-  <Target Name="Restore" BeforeTargets="Build">
+  <Target Name="Restore" BeforeTargets="Build" DependsOnTargets="UpdateNuGetConfig">
     <Exec Command="$(DotnetToolCommand) restore $(NewtonsoftJsonProjectPath) $(DotnetToolCommandArguments) $(RedirectRepoOutputToLog)"
           WorkingDirectory="$(ProjectDirectory)"
           EnvironmentVariables="@(EnvironmentVariables)" />

--- a/repos/websdk.proj
+++ b/repos/websdk.proj
@@ -15,7 +15,7 @@
     <RepositoryReference Include="newtonsoft-json" />
   </ItemGroup>
 
-  <Target Name="MakeWritable" AfterTargets="ApplyPatches">
+  <Target Name="MakeExecutable" AfterTargets="ApplyPatches">
     <Exec Command="chmod +x $(ProjectDirectory)/build.sh"
           WorkingDirectory="$(ProjectDirectory)"
           EnvironmentVariables="@(EnvironmentVariables)"

--- a/repos/websdk.proj
+++ b/repos/websdk.proj
@@ -15,5 +15,12 @@
     <RepositoryReference Include="newtonsoft-json" />
   </ItemGroup>
 
+  <Target Name="MakeWritable" AfterTargets="ApplyPatches">
+    <Exec Command="chmod +x $(ProjectDirectory)/build.sh"
+          WorkingDirectory="$(ProjectDirectory)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          Condition="'$(OS)' == 'Unix'" />
+  </Target>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
 </Project>

--- a/tools-local/init-build.proj
+++ b/tools-local/init-build.proj
@@ -26,7 +26,10 @@
   </Target>
 
   <Target Name="BuildTasks">
-    <Exec Command="$(DotNetCliToolDir)dotnet build tasks\Microsoft.DotNet.SourceBuild.Tasks\Microsoft.DotNet.SourceBuild.Tasks.csproj" />
+    <PropertyGroup Condition="'$(OfflineBuild)' == 'true'">
+      <OfflineSources>$(PrebuiltPackagesPath)</OfflineSources>
+    </PropertyGroup>
+    <Exec Command="$(DotNetCliToolDir)dotnet build tasks\Microsoft.DotNet.SourceBuild.Tasks\Microsoft.DotNet.SourceBuild.Tasks.csproj /p:RestoreSources=$(OfflineSources)" />
   </Target>
 
   <Target Name="ApplyPatches">


### PR DESCRIPTION
Updates to known-good projects to make sure that they don't use network resources.  I removed roslyn-tools and coreclr from known-good because they had some larger issues and I want to get this going in CI now. 