### PR TITLE
Auto-update submodules to the commits used in latest ProdCon build

### DIFF
--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -38,8 +38,9 @@ git submodule foreach --recursive git reset --hard
 
 mkdir -p "$TARBALL_ROOT"
 
-cp $SCRIPT_ROOT/build.proj $TARBALL_ROOT/
-cp $SCRIPT_ROOT/dir.props $TARBALL_ROOT/
+cp $SCRIPT_ROOT/*.proj $TARBALL_ROOT/
+cp $SCRIPT_ROOT/*.props $TARBALL_ROOT/
+cp $SCRIPT_ROOT/*.targets $TARBALL_ROOT/
 cp $SCRIPT_ROOT/init-tools.msbuild $TARBALL_ROOT/
 cp $SCRIPT_ROOT/DotnetCLIVersion.txt $TARBALL_ROOT/
 cp -r $SCRIPT_ROOT/keys $TARBALL_ROOT/

--- a/build.proj
+++ b/build.proj
@@ -26,6 +26,8 @@
     <RemoveDir Directories="$(BaseOutputPath)" />
   </Target>
 
+  <Import Project="$(ProjectDir)dependencies.targets" />
+
   <Import Project="$(ToolsDir)VersionTools.targets" />
 
 </Project>

--- a/dependencies.props
+++ b/dependencies.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
     A CurrentRef is a commit on the dotnet/versions master branch. It is the single source of truth
     for which dotnet/versions commit was last used to update the dependency.

--- a/dependencies.props
+++ b/dependencies.props
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    A CurrentRef is a commit on the dotnet/versions master branch. It is the single source of truth
+    for which dotnet/versions commit was last used to update the dependency.
+  -->
+  <PropertyGroup>
+    <ProdConCurrentRef>7daa2e55de668c4c8ee832059aab04917153881e</ProdConCurrentRef>
+    <BuildToolsCurrentRef>af030b25653d53483b0200ff81d89209bd30549a</BuildToolsCurrentRef>
+  </PropertyGroup>
+
+  <!-- Package dependency verification/auto-upgrade configuration. -->
+  <PropertyGroup>
+    <BaseDotNetBuildInfo>build-info/dotnet/</BaseDotNetBuildInfo>
+    <DependencyBranch>release/2.1</DependencyBranch>
+    <CurrentRefXmlPath>$(MSBuildThisFileFullPath)</CurrentRefXmlPath>
+  </PropertyGroup>
+
+  <!-- ILLink.Tasks package version -->
+  <PropertyGroup>
+    <ILLinkTasksPackage>ILLink.Tasks</ILLinkTasksPackage>
+    <ILLinkTasksPackageVersion>0.1.5-preview-1461378</ILLinkTasksPackageVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <RemoteDependencyBuildInfo Include="BuildTools">
+      <BuildInfoPath>$(BaseDotNetBuildInfo)buildtools/$(DependencyBranch)</BuildInfoPath>
+      <CurrentRef>$(BuildToolsCurrentRef)</CurrentRef>
+    </RemoteDependencyBuildInfo>
+
+    <DependencyBuildInfo Include="@(RemoteDependencyBuildInfo)">
+      <RawVersionsBaseUrl>https://raw.githubusercontent.com/dotnet/versions</RawVersionsBaseUrl>
+    </DependencyBuildInfo>
+
+    <DependencyInfo Include="ProdCon">
+      <DependencyType>Orchestrated build</DependencyType>
+      <BasePath>build-info/dotnet/product/cli/release/2.1</BasePath>
+      <CurrentRef>$(ProdConCurrentRef)</CurrentRef>
+      <VersionsRepoOwner>dotnet</VersionsRepoOwner>
+      <VersionsRepo>versions</VersionsRepo>
+    </DependencyInfo>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(SkipBuildToolsUpdate)' != 'true'">
+    <UpdateStep Include="BuildTools">
+      <UpdaterType>File</UpdaterType>
+      <Path>$(MSBuildThisFileDirectory)BuildToolsVersion.txt</Path>
+      <PackageId>Microsoft.DotNet.BuildTools</PackageId>
+    </UpdateStep>
+  </ItemGroup>
+</Project>

--- a/dependencies.targets
+++ b/dependencies.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="CreateOrchestratedBuildSubmoduleUpdaters"
           BeforeTargets="CreateDefaultDependencyInfos"
           Condition="'$(SkipOrchestratedBuildSubmoduleUpdate)' != 'true'">

--- a/dependencies.targets
+++ b/dependencies.targets
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="CreateOrchestratedBuildSubmoduleUpdaters"
+          BeforeTargets="CreateDefaultDependencyInfos"
+          Condition="'$(SkipOrchestratedBuildSubmoduleUpdate)' != 'true'">
+
+    <ItemGroup>
+      <OrchestratedBuildRepoProjects Include="$(ProjectDir)repos\*.proj" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(OrchestratedBuildRepoProjects)"
+             Targets="GetOrchestratedManifestBuildName">
+      <Output TaskParameter="TargetOutputs" ItemName="OrchestratedManifestBuildNames" />
+    </MSBuild>
+
+    <MSBuild Projects="@(OrchestratedBuildRepoProjects)"
+             Targets="GetProjectDirectory">
+      <Output TaskParameter="TargetOutputs" ItemName="ProjectDirectories" />
+    </MSBuild>
+
+    <ReadGitConfigFile File="$(GitModulesPath)">
+      <Output TaskParameter="SubmoduleConfiguration" ItemName="SubmoduleConfigurations" />
+    </ReadGitConfigFile>
+
+    <!--
+      Perform joins to gather information about each repo into a single item each. Each A-B join
+      first creates all A*B "candidate" combinations. The candidate items are then filtered down to
+      the combinations where the desired metadata from A and B match.
+    -->
+    <ItemGroup>
+      <!-- Join manifest build name to project directory. -->
+      <BuildNamePathCandidate Include="@(OrchestratedManifestBuildNames)">
+        <Path>%(ProjectDirectories.Identity)</Path>
+        <ProjectDirectorySourceProjectFile>%(ProjectDirectories.MSBuildSourceProjectFile)</ProjectDirectorySourceProjectFile>
+      </BuildNamePathCandidate>
+
+      <BuildNamePath Include="@(BuildNamePathCandidate)"
+                     Condition="'%(MSBuildSourceProjectFile)' == '%(ProjectDirectorySourceProjectFile)' AND
+                                '%(Identity)' != 'N/A'" />
+      
+      <!-- Join project directory to submodule URL. -->
+      <BuildNamePathGitUrlCandidate Include="@(BuildNamePath)">
+        <Submodule>$(ProjectDir)%(SubmoduleConfigurations.Path)/</Submodule>
+        <GitUrl>%(SubmoduleConfigurations.Url)</GitUrl>
+      </BuildNamePathGitUrlCandidate>
+
+      <BuildNamePathGitUrl Include="@(BuildNamePathGitUrlCandidate)"
+                           Condition="'%(Path)' == '%(Submodule)'" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <UpdateStep Include="@(BuildNamePathGitUrl)">
+        <UpdaterType>Submodule from orchestrated build</UpdaterType>
+        <BuildName>%(BuildNamePathGitUrl.Identity)</BuildName>
+      </UpdateStep>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/dir.props
+++ b/dir.props
@@ -65,6 +65,8 @@
 
    <Import Project="$(TargetInfoProps)" Condition="$(GeneratingStaticPropertiesFile) != 'true' AND Exists('$(TargetInfoProps)')" />
 
+  <Import Project="$(ProjectDir)dependencies.props" />
+
   <PropertyGroup>
     <!--
         Temporarily update RootRepo to known-good

--- a/init-tools.msbuild
+++ b/init-tools.msbuild
@@ -5,11 +5,12 @@
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)Tools/$(BuildToolsPackageVersion)</BaseIntermediateOutputPath>
   </PropertyGroup>
+  <Import Project="$(MSBuildThisFileDirectory)dependencies.props" />
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.BuildTools"
                       Condition="'$(BuildToolsPackageVersion)' != ''"
                       Version="$(BuildToolsPackageVersion)" />
     <PackageReference Include="Microsoft.DotNet.BuildTools.Coreclr" Version="1.0.4-prerelease" />
-    <PackageReference Include="ILLink.Tasks" Version="0.1.5-preview-1461378" />
+    <PackageReference Include="$(ILLinkTasksPackage)" Version="$(ILLinkTasksPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/repos/application-insights.proj
+++ b/repos/application-insights.proj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <PackagesOutput>$(SubmoduleDirectory)/bin/$(Configuration)</PackagesOutput>
     <RepoApiImplemented>false</RepoApiImplemented>
+    <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />

--- a/repos/cli-migrate.proj
+++ b/repos/cli-migrate.proj
@@ -5,6 +5,7 @@
     <PackagesOutput>$(ProjectDirectory)artifacts/packages</PackagesOutput>
     <CommitCount>2133</CommitCount>
     <RepoApiImplemented>false</RepoApiImplemented>
+    <OrchestratedManifestBuildName>dotnet/cli-migrate</OrchestratedManifestBuildName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/repos/clicommandlineparser.proj
+++ b/repos/clicommandlineparser.proj
@@ -5,6 +5,7 @@
     <CommitCount>167</CommitCount>
     <PackagesOutput>$(ProjectDirectory)/CommandLine/bin/$(Configuration)/</PackagesOutput>
     <RepoApiImplemented>false</RepoApiImplemented>
+    <OrchestratedManifestBuildName>dotnet/CliCommandLineParser</OrchestratedManifestBuildName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/repos/common.proj
+++ b/repos/common.proj
@@ -10,6 +10,7 @@
     <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) -NoTest $(BuildArguments)</BuildCommand>
     <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension) $(BuildArguments)</CleanCommand>
     <RepoApiImplemented>false</RepoApiImplemented>
+    <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/repos/dir.props
+++ b/repos/dir.props
@@ -18,6 +18,10 @@
     <VersionFileLocation Condition="'$(VersionFileLocation)' == ''">$(VersionFileDirectory)$(RepositoryOrganization)/$(RepositoryName)/$(RepositoryBranch)/$(VersionFilename)</VersionFileLocation>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <OrchestratedManifestBuildName Condition="'$(OrchestratedManifestBuildName)' == ''">$(RepositoryName)</OrchestratedManifestBuildName>
+  </PropertyGroup>
+
   <ItemGroup>
     <EnvironmentVariables Include="DOTNET_RUNTIME_ID=$(TargetRid)" />
     <EnvironmentVariables Include="DOTNET_TOOL_DIR=$(DotNetCliToolDir)" />

--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -216,5 +216,8 @@
          DestinationFolder="$(ProjectDirectory)" />
   </Target>
 
+  <Target Name="GetProjectDirectory" Outputs="$(ProjectDirectory)" />
+  <Target Name="GetOrchestratedManifestBuildName" Outputs="$(OrchestratedManifestBuildName)" />
+
   <Import Project="$(ToolsDir)VersionTools.targets" />
 </Project>

--- a/repos/javascriptservices.proj
+++ b/repos/javascriptservices.proj
@@ -5,6 +5,7 @@
     <BuildCommand>$(DotnetToolCommand) pack -c $(Configuration) --output $(SourceBuiltPackagesPath) --no-build Microsoft.DotNet.Web.Spa.ProjectTemplates.csproj /p:NuspecFile=Microsoft.DotNet.Web.Spa.ProjectTemplates.nuspec /p:OutputPath=$(OutputPath)$(RepositoryName)/ /p:BaseIntermediateOutputPath=$(IntermediatePath)$(RepositoryName)</BuildCommand>
     <PackagesOutput>$(SourceBuiltPackagesPath)</PackagesOutput>
     <RepoApiImplemented>false</RepoApiImplemented>
+    <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
 </Project>

--- a/repos/known-good.proj
+++ b/repos/known-good.proj
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <RepoApiImplemented>false</RepoApiImplemented>
+    <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/repos/msbuild.proj
+++ b/repos/msbuild.proj
@@ -6,6 +6,7 @@
     <PackagesOutput>$(ProjectDirectory)/bin/$(Configuration)/packages</PackagesOutput>
     <BuildCommand>$(DotnetToolCommand) pack $(SolutionToBuild) /p:Configuration=$(Configuration) /p:PackageOutputPath=$(PackagesOutput)</BuildCommand>
     <RepoApiImplemented>false</RepoApiImplemented>
+    <OrchestratedManifestBuildName>Microsoft/msbuild</OrchestratedManifestBuildName>
   </PropertyGroup>
 
   <Target Name="RestoreSolution"

--- a/repos/netcorecli-fsc.proj
+++ b/repos/netcorecli-fsc.proj
@@ -5,6 +5,7 @@
     <BuildCommand>$(DotnetToolCommand) pack -c $(Configuration) --output $(SourceBuiltPackagesPath) --no-build FSharp.NET.Sdk.csproj /p:NuspecFile=FSharp.NET.Sdk.nuspec /p:OutputPath=$(OutputPath)$(RepositoryName)/ /p:BaseIntermediateOutputPath=$(IntermediatePath)$(RepositoryName)</BuildCommand>
     <PackagesOutput>$(SourceBuiltPackagesPath)</PackagesOutput>
     <RepoApiImplemented>false</RepoApiImplemented>
+    <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
 </Project>

--- a/repos/newtonsoft-json.proj
+++ b/repos/newtonsoft-json.proj
@@ -13,6 +13,7 @@
     <CleanCommand>$(DotnetToolCommand) clean $(NewtonsoftJsonProjectPath) $(DotnetToolCommandArguments)</CleanCommand>
     <PackagesOutput>$(NewtonsoftJsonDirectory)bin/$(Configuration)/</PackagesOutput>
     <RepoApiImplemented>false</RepoApiImplemented>
+    <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
   </PropertyGroup>
 
   <Target Name="Restore" BeforeTargets="Build" DependsOnTargets="UpdateNuGetConfig">

--- a/repos/nuget-client.proj
+++ b/repos/nuget-client.proj
@@ -8,6 +8,7 @@
     <NuGetKeyFilePath>$(KeysDir)NuGet.Client.snk</NuGetKeyFilePath>
     <NuGetClientBuildNumber>4324</NuGetClientBuildNumber>
     <RepoApiImplemented>false</RepoApiImplemented>
+    <OrchestratedManifestBuildName>nuget.client</OrchestratedManifestBuildName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/repos/roslyn-tools.proj
+++ b/repos/roslyn-tools.proj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <PackagesOutput>$(ProjectDirectory)/artifacts/$(Configuration)/packages</PackagesOutput>
     <RepoApiImplemented>false</RepoApiImplemented>
+    <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/repos/sdk.proj
+++ b/repos/sdk.proj
@@ -7,6 +7,7 @@
     <CommitHash>e27eeed9161ec9249b329181ab8de036e1ebf106</CommitHash>
     <BuildCommand>$(DotnetToolCommand) msbuild /t:BuildForCli /p:Configuration=$(Configuration) /p:BuildNumber=$(BuildNumber) /p:BUILD_SOURCEVERSION=$(CommitHash) $(ProjectDirectory)/build/build.proj</BuildCommand>
     <RepoApiImplemented>false</RepoApiImplemented>
+    <OrchestratedManifestBuildName>dotnet/sdk</OrchestratedManifestBuildName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/repos/standard.proj
+++ b/repos/standard.proj
@@ -9,6 +9,7 @@
     <LatestCommit>d318b764a689cfe285d8484bda918646905664e7</LatestCommit>
     <VersionSeedDate>2017-07-19</VersionSeedDate>
     <OfficialBuildId>20170719-03</OfficialBuildId>
+    <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />

--- a/repos/symreader-portable.proj
+++ b/repos/symreader-portable.proj
@@ -5,6 +5,7 @@
     <BuildCommand>$(DotnetToolCommand) pack -c $(Configuration) $(ProjectDirectory)/src/Microsoft.DiaSymReader.PortablePdb/Microsoft.DiaSymReader.PortablePdb.csproj</BuildCommand>
     <PackagesOutput>$(ProjectDirectory)/src/Microsoft.DiaSymReader.PortablePdb/bin/$(Configuration)</PackagesOutput>
     <RepoApiImplemented>false</RepoApiImplemented>
+    <OrchestratedManifestBuildName>dotnet/symreader-portable</OrchestratedManifestBuildName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/repos/symreader.proj
+++ b/repos/symreader.proj
@@ -5,6 +5,7 @@
     <BuildCommand>$(DotnetToolCommand) pack -c $(Configuration) $(ProjectDirectory)/src/Microsoft.DiaSymReader/NetCore/Microsoft.DiaSymReader.csproj</BuildCommand>
     <PackagesOutput>$(ProjectDirectory)/src/Microsoft.DiaSymReader/NetCore/bin/$(Configuration)</PackagesOutput>
     <RepoApiImplemented>false</RepoApiImplemented>
+    <OrchestratedManifestBuildName>dotnet/symreader</OrchestratedManifestBuildName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/repos/vstest.proj
+++ b/repos/vstest.proj
@@ -5,6 +5,7 @@
     <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) -DotnetBuildFromSource -DotnetCoreSdkDir $(DotNetCliToolDir) -c $(Configuration) -r $(TargetRid) -v 15.3.0 -vs preview-20170628-02</BuildCommand>
     <PackagesOutput>$(ProjectDirectory)/artifacts/$(Configuration)/packages</PackagesOutput>
     <RepoApiImplemented>false</RepoApiImplemented>
+    <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/repos/xliff-tasks.proj
+++ b/repos/xliff-tasks.proj
@@ -6,6 +6,7 @@
     <BuildNumber>48</BuildNumber>
     <CommitHash>27d43b762aa6dac3a0a6ba48fe55000942d75c1c</CommitHash>
     <RepoApiImplemented>false</RepoApiImplemented>
+    <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
   </PropertyGroup>
   <ItemGroup>
     <EnvironmentVariables Include="CommitCount=$(BuildNumber)" />


### PR DESCRIPTION
To try it out, use `build.cmd /t:UpdateDependencies` to update based on the `ProdConCurrentRef` source of truth (e.g. if you want to pin to a specific ProdCon build) and `build.cmd /t:UpdateToRemoteDependencies` to update to the latest manifest on dotnet/versions master.

Uses new updater and dependency info from https://github.com/dotnet/buildtools/pull/1968.

There's some metadata checked into the project files that this updater won't change. I have a followup issue for that: https://github.com/dotnet/source-build/issues/370.

https://github.com/dotnet/source-build/issues/342

Also adds a BuildTools updater: https://github.com/dotnet/source-build/issues/270