### PR TITLE
Pass PortableBuild setting from top level build script to sub projects

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -6,6 +6,8 @@
 
     <!-- true if we have bootstrapped buildtools (usually on an unsupported platform -->
     <_IsBootstrapping Condition="'$(BootstrapBuildToolsDir)' != ''">true</_IsBootstrapping>
+
+    <PortableBuild Condition="'$(PortableBuild)' == ''">false</PortableBuild>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/repos/core-setup.proj
+++ b/repos/core-setup.proj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
-    <BuildArguments>-ConfigurationGroup=$(Configuration) -PortableBuild=false -SkipTests=true </BuildArguments>
+    <BuildArguments>-ConfigurationGroup=$(Configuration) -PortableBuild=$(PortableBuild) -SkipTests=true </BuildArguments>
     <BuildArguments Condition="$(Platform.Contains('arm'))">$(BuildArguments) -TargetArchitecture=$(Platform) -DisableCrossgen=true -CrossBuild=true</BuildArguments>
     <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments) -- /p:BuildDebPackage=false /p:BuildAllPackages=true</BuildCommand>
     <BuildCommand Condition="$(Platform.Contains('arm'))">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>

--- a/repos/coreclr.proj
+++ b/repos/coreclr.proj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
-    <BuildArguments>$(Platform) $(Configuration) skiptests -PortableBuild=false </BuildArguments>
+    <BuildArguments>$(Platform) $(Configuration) skiptests -PortableBuild=$(PortableBuild)</BuildArguments>
     <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) msbuildonunsupportedplatform</BuildArguments>
     <BuildArguments Condition="$(Platform.Contains('arm'))">$(BuildArguments) skipnuget cross -skiprestore cmakeargs -DFEATURE_GDBJIT=TRUE</BuildArguments>
     <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments) --</BuildCommand>

--- a/repos/corefx.proj
+++ b/repos/corefx.proj
@@ -2,9 +2,10 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
-    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) -$(Configuration) -buildArch=$(Platform) -portable=false -BuildTests=false -- /p:ILLinkTrimAssembly=false </BuildCommand>
+    <BuildArguments>-$(Configuration) -buildArch=$(Platform) -portable=$(PortableBuild) -BuildTests=false</BuildArguments>
+    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments) -- /p:ILLinkTrimAssembly=false</BuildCommand>
     <BuildCommand Condition="$(Platform.Contains('arm'))">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
-    <FrameworkBuildCommand>$(ProjectDirectory)/build$(ShellExtension) -$(Configuration) -buildArch=$(Platform) -Framework=netfx -OSGroup=Windows_NT -- /p:ILLinkTrimAssembly=false</FrameworkBuildCommand>
+    <FrameworkBuildCommand>$(ProjectDirectory)/build$(ShellExtension) -$(BuildArguments) -Framework=netfx -OSGroup=Windows_NT -- /p:ILLinkTrimAssembly=false</FrameworkBuildCommand>
     <PackagesOutput>$(ProjectDirectory)/bin/packages/$(Configuration)</PackagesOutput>
     <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension)</CleanCommand>
     <LatestCommit>8321c729934c0f8be754953439b88e6e1c120c24</LatestCommit>


### PR DESCRIPTION
This should cause any `p:PortableBuild=_X_` properties passed to the top level `build.sh` to also set the appropriate flags in the appropriate sub-projects, while leaving their defaults in place.

The default is still to produce non-portable builds.

This also fixes corefx to build both times with non-portable builds.

This is a manual port of https://github.com/dotnet/source-build/pull/302 to `dev/release/2.1` branch. I am going to need it for https://github.com/dotnet/source-build/issues/380

cc @aslicerh @dleeapho @weshaggard 