### PR TITLE
WIP Add CliCommandLineParser to known-good

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -39,7 +39,7 @@
 	url = https://github.com/Microsoft/ApplicationInsights-dotnet
 [submodule "src/clicommandlineparser"]
 	path = src/clicommandlineparser
-	url = https://github.com/dotnet/clicommandlineparser
+	url = https://github.com/dagood/clicommandlineparser
 [submodule "src/cli-migrate"]
 	path = src/cli-migrate
 	url = https://github.com/dotnet/cli-migrate

--- a/repos/clicommandlineparser.proj
+++ b/repos/clicommandlineparser.proj
@@ -2,26 +2,23 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
-    <CommitCount>167</CommitCount>
-    <PackagesOutput>$(ProjectDirectory)/CommandLine/bin/$(Configuration)/</PackagesOutput>
+    <BuildCommand>$(ProjectDirectory)\build$(ShellExtension) --pack --configuration $(Configuration) -DotNetBuildFromSource true -dotnetcoresdkdir $(DotNetCliToolDir)</BuildCommand>
+    <PackagesOutput>$(ProjectDirectory)\artifacts\$(Configuration)\packages\</PackagesOutput>
     <RepoApiImplemented>false</RepoApiImplemented>
-    <OrchestratedManifestBuildName>dotnet/CliCommandLineParser</OrchestratedManifestBuildName>
+    <SourceOverrideRepoApiImplemented>true</SourceOverrideRepoApiImplemented>
+    <!-- The source override parameter are accepted, but don't replace the nuget.config. -->
+    <NuGetConfigFile>$(ProjectDirectory)/nuget.config</NuGetConfigFile>
+    <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
+    <LatestCommit>df4b5344974fe274f64b312bbad6a8591fc16bd9</LatestCommit>
   </PropertyGroup>
 
   <ItemGroup>
-    <RepositoryReference Include="roslyn-tools" />
+    <EnvironmentVariables Include="GIT_COMMIT=$(LatestCommit)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- <RepositoryReference Include="roslyn-tools" /> -->
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
-
-  <Target Name="RepoBuild">
-    <Exec Command="$(DotnetToolCommand) msbuild /t:MakeVersionProps /p:CommitCount=$(CommitCount) $(ProjectDirectory)/build.proj $(RedirectRepoOutputToLog)"
-          EnvironmentVariables="@(EnvironmentVariables)" />
-
-    <Exec Command="$(DotnetToolCommand) restore $(ProjectDirectory)/CommandLine/CommandLine-netcore.csproj $(RedirectRepoOutputToLog)"
-          EnvironmentVariables="@(EnvironmentVariables)" />
-
-    <Exec Command="$(DotnetToolCommand) pack /p:Configuration=$(Configuration) $(ProjectDirectory)/CommandLine/CommandLine-netcore.csproj $(RedirectRepoOutputToLog)"
-          EnvironmentVariables="@(EnvironmentVariables)" />
-  </Target>
 </Project>

--- a/repos/known-good.proj
+++ b/repos/known-good.proj
@@ -20,7 +20,7 @@
     <RepositoryReference Include="xliff-tasks" />
 
     <!--RepositoryReference Include="msbuild" /-->
-    <!--RepositoryReference Include="clicommandlineparser" /-->
+    <RepositoryReference Include="clicommandlineparser" />
     <!--RepositoryReference Include="roslyn" /-->
 
     <!-- Tier 2 -->


### PR DESCRIPTION
I upgraded the version of roslyn-tools that clicommandlineparser uses in my fork to use `global.json` rather than the older style, and I want to know if it will pass CI. It works through the tarball on my own machine using RHEL docker images and `docker run --network none ...`.

I referenced these commits to upgrade the repo toolset:
https://github.com/dotnet/symreader-portable/commit/120942ad77759fecd5e2e091ab0a860d11720bd3
https://github.com/dotnet/roslyn-tools/commit/1cc8e10cb9802de80c0fd613d4681b451b0b8306