### PR TITLE
Remove unused Item

### DIFF
--- a/repos/cli.proj
+++ b/repos/cli.proj
@@ -36,7 +36,6 @@
   <ItemGroup>
     <EnvironmentVariables Include="GitInfoCommitCount=$(GitCommitCount)" />
     <EnvironmentVariables Include="GitInfoCommitHash=$(GitCommitHash)" />
-    <EnvironemntVariables Include="DropSuffix=true" />
   </ItemGroup>
 
   <Target Name="CopyTarBall" AfterTargets="CopyPackage">


### PR DESCRIPTION
This environment variable is obviously not necessary since it doesn't use the right name, meaning it isn't doing anything currently.

We can add this back later, if we need it.