### PR TITLE
Add fsharp to known-good

### DIFF
--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -78,16 +78,21 @@
 
   <Target Name="UpdateNuGetConfig"
           BeforeTargets="Build"
-          Condition="'$(NuGetConfigFile)' != ''">
-    <RemoveInternetSourcesFromNuGetConfig NuGetConfigFile="$(NuGetConfigFile)"
+          Condition="'$(NuGetConfigFile)' != '' OR '@(NuGetConfigFiles)' != ''">
+    <!-- Update the detected or manually specified NuGetConfigFile, but also allow multiple. -->
+    <ItemGroup>
+      <NuGetConfigFiles Include="$(NuGetConfigFile)" />
+    </ItemGroup>
+
+    <RemoveInternetSourcesFromNuGetConfig NuGetConfigFile="%(NuGetConfigFiles.Identity)"
                                           Condition="'$(OfflineBuild)' != ''" />
 
-    <AddSourceToNuGetConfig NuGetConfigFile="$(NuGetConfigFile)"
+    <AddSourceToNuGetConfig NuGetConfigFile="%(NuGetConfigFiles.Identity)"
                             SourceName="prebuilt"
                             SourcePath="$(PrebuiltPackagesPath)"
                             Condition="'$(OfflineBuild)' == 'true'" />
 
-    <AddSourceToNuGetConfig NuGetConfigFile="$(NuGetConfigFile)"
+    <AddSourceToNuGetConfig NuGetConfigFile="%(NuGetConfigFiles.Identity)"
                             SourceName="source-built"
                             SourcePath="$(SourceBuiltPackagesPath)" />
   </Target>

--- a/repos/fsharp.proj
+++ b/repos/fsharp.proj
@@ -5,9 +5,15 @@
     <PackagesOutput>$(ProjectDirectory)/BuildFromSource/Release/bin</PackagesOutput>
     <BuildRevision>171107</BuildRevision>
     <BuildCommand>$(ProjectDirectory)/src/buildfromsource$(ShellExtension)</BuildCommand>
-    <NuGetConfigFile>$(ProjectDirectory)/src/buildfromsource/NuGet.config</NuGetConfigFile>
     <RepoApiImplemented>false</RepoApiImplemented>
+    <!-- ProdCon is behind source-build: temporarily disable auto-update. -->
+    <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
   </PropertyGroup>
+
+  <!-- Auto-detect the root NuGet.Config, but also update the build-from-source-specific one. -->
+  <ItemGroup>
+    <NuGetConfigFiles Include="$(ProjectDirectory)/src/buildfromsource/NuGet.config" />
+  </ItemGroup>
 
   <PropertyGroup>
     <PathListSeparator>:</PathListSeparator>
@@ -18,11 +24,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <EnvironmentVariables Include="DotNetPackageVersionPropsPath=$(PackageVersionPropsPath)" />
     <EnvironmentVariables Include="BuildRevision=$(BuildRevision)" />
     <EnvironmentVariables Include="PATH=$(DotNetCliToolDir)$(PathListSeparator)$(CurrentPath)" />
-    <RepositoryReference Include="core-setup" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- <RepositoryReference Include="core-setup" /> -->
     <RepositoryReference Include="symreader" />
     <RepositoryReference Include="symreader-portable" />
   </ItemGroup>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
 </Project>

--- a/repos/known-good.proj
+++ b/repos/known-good.proj
@@ -45,7 +45,7 @@
     <!--RepositoryReference Include="sdk" /-->
     <!--RepositoryReference Include="vstest" /-->
     <!--RepositoryReference Include="cli-migrate" /-->
-    <!--RepositoryReference Include="fsharp" /-->
+    <RepositoryReference Include="fsharp" />
 
   </ItemGroup>
 


### PR DESCRIPTION
VisualFSharp changes are based on https://github.com/Microsoft/visualfsharp/pull/4674, which adds the `DotNetPackageVersionPropsPath` repo API.
