### PR TITLE
Add CentOS7.1 online tarball CI leg

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -60,7 +60,7 @@ def addPushJob(String project, String branch, String os, String configuration)
 
 // Tarball builds that are not enforced to be offline
 [true, false].each { isPR ->
-  ["RHEL7.2"].each { os->
+  ["RHEL7.2", "CentOS7.1"].each { os ->
     ["Release", "Debug"].each { configuration ->
 
       def shortJobName = "${os}_Tarball_${configuration}";


### PR DESCRIPTION
This will hopefully let us get repro machines easier for this leg.

The *offline* tarball works fine as-is, since it actually uses Ubuntu with RHEL Docker containers. But it's possible for something to fail in the online leg that doesn't fail offline.