### PR TITLE
Uncomment fsharp's core-setup RepositoryReference

### DIFF
--- a/repos/fsharp.proj
+++ b/repos/fsharp.proj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- <RepositoryReference Include="core-setup" /> -->
+    <RepositoryReference Include="core-setup" />
     <RepositoryReference Include="symreader" />
     <RepositoryReference Include="symreader-portable" />
   </ItemGroup>


### PR DESCRIPTION
This will keep the build order intact once we switch the root project from known-good to cli.