### PR TITLE
Avoid running "git apply" with no arguments

### DIFF
--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -74,7 +74,8 @@
     </PropertyGroup>
 
     <Exec Command="$(PatchCommand) %(PatchesToApply.Identity)"
-          WorkingDirectory="$(ProjectDirectory)" />
+          WorkingDirectory="$(ProjectDirectory)"
+          Condition="'@(PatchesToApply)' != ''" />
   </Target>
 
   <Target Name="UpdateNuGetConfig"


### PR DESCRIPTION
Minor dev scenario fix.

`git apply` by itself takes input from stdin, which makes the build seem to hang. If the patches dir exists but no patches are inside it, skip the command. (This can happen if you delete all patches but don't delete the directory on a local build.)

FYI @weshaggard 