### PR TITLE
Enable CLI crossgen, add Microsoft.NETCore.Compilers

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -81,6 +81,9 @@ def addPushJob(String project, String branch, String os, String configuration)
 
       Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}");
 
+      // Increase timeout. The tarball builds can take longer than the 2 hour default.
+      Utilities.setJobTimeout(newJob, 240);
+
       // Clone into the source-build directory
       Utilities.addScmInSubDirectory(newJob, project, isPR, 'source-build');
       if(isPR){

--- a/patches/cli/0010-Roslyn-plat-assembly-paths-for-RemainingTargets.patch
+++ b/patches/cli/0010-Roslyn-plat-assembly-paths-for-RemainingTargets.patch
@@ -1,0 +1,26 @@
+From 0611d8e4d251b79ff3e2402f37cdad7926bc66e9 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Wed, 18 Apr 2018 11:46:00 -0500
+Subject: [PATCH] Roslyn plat assembly paths for RemainingTargets
+
+The crossgen of Microsoft.DotNet.ProjectJsonMigration.dll (a RemainingTargets item) requires Microsoft.CodeAnalysis.CSharp.dll, which is in the RoslynFolders item "Roslyn/bincore/".
+---
+ src/redist/redist.csproj | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/redist/redist.csproj b/src/redist/redist.csproj
+index 04b9a7496..8a94089be 100644
+--- a/src/redist/redist.csproj
++++ b/src/redist/redist.csproj
+@@ -347,7 +347,7 @@
+         ReadyToRun="True"
+         CreateSymbols="$(CreateCrossgenSymbols)"
+         DiasymReaderPath="@(DiasymReaderPath)"
+-        PlatformAssemblyPaths="@(PlatformAssemblies);@(RemainingFolders);$(SharedFrameworkNameVersionPath)" />
++        PlatformAssemblyPaths="@(PlatformAssemblies);@(RemainingFolders);@(RoslynFolders);$(SharedFrameworkNameVersionPath)" />
+   </Target>
+ 
+   <Target Name="ChmodPublishDir"
+-- 
+2.16.1.windows.4
+

--- a/patches/roslyn/0002-Add-VBCSCompiler-to-SourceBuild.sln.patch
+++ b/patches/roslyn/0002-Add-VBCSCompiler-to-SourceBuild.sln.patch
@@ -1,0 +1,54 @@
+From da00e2f1d9f24eaf33459cfea42677b0f887edfb Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Mon, 16 Apr 2018 15:16:02 -0500
+Subject: [PATCH] Add VBCSCompiler to SourceBuild.sln
+
+---
+ SourceBuild.sln | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/SourceBuild.sln b/SourceBuild.sln
+index f7a5c2d41a..5f914cce20 100644
+--- a/SourceBuild.sln
++++ b/SourceBuild.sln
+@@ -24,6 +24,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "vbc", "src\Compilers\Visual
+ EndProject
+ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSBuildTask", "src\Compilers\Core\MSBuildTask\MSBuildTask.csproj", "{7AD4FE65-9A30-41A6-8004-AA8F89BCB7F3}"
+ EndProject
++Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VBCSCompiler", "src\Compilers\Server\VBCSCompiler\VBCSCompiler.csproj", "{649CE05A-529C-40D7-A501-CA9BCFEE40DC}"
++EndProject
++Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Server", "Server", "{B57E7F86-EB16-4F60-A47C-F9D170F54400}"
++EndProject
+ Global
+ 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+ 		Debug|Any CPU = Debug|Any CPU
+@@ -106,6 +110,18 @@ Global
+ 		{7AD4FE65-9A30-41A6-8004-AA8F89BCB7F3}.Release|x64.Build.0 = Release|x64
+ 		{7AD4FE65-9A30-41A6-8004-AA8F89BCB7F3}.Release|x86.ActiveCfg = Release|x86
+ 		{7AD4FE65-9A30-41A6-8004-AA8F89BCB7F3}.Release|x86.Build.0 = Release|x86
++		{649CE05A-529C-40D7-A501-CA9BCFEE40DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
++		{649CE05A-529C-40D7-A501-CA9BCFEE40DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
++		{649CE05A-529C-40D7-A501-CA9BCFEE40DC}.Debug|x64.ActiveCfg = Debug|Any CPU
++		{649CE05A-529C-40D7-A501-CA9BCFEE40DC}.Debug|x64.Build.0 = Debug|Any CPU
++		{649CE05A-529C-40D7-A501-CA9BCFEE40DC}.Debug|x86.ActiveCfg = Debug|Any CPU
++		{649CE05A-529C-40D7-A501-CA9BCFEE40DC}.Debug|x86.Build.0 = Debug|Any CPU
++		{649CE05A-529C-40D7-A501-CA9BCFEE40DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
++		{649CE05A-529C-40D7-A501-CA9BCFEE40DC}.Release|Any CPU.Build.0 = Release|Any CPU
++		{649CE05A-529C-40D7-A501-CA9BCFEE40DC}.Release|x64.ActiveCfg = Release|Any CPU
++		{649CE05A-529C-40D7-A501-CA9BCFEE40DC}.Release|x64.Build.0 = Release|Any CPU
++		{649CE05A-529C-40D7-A501-CA9BCFEE40DC}.Release|x86.ActiveCfg = Release|Any CPU
++		{649CE05A-529C-40D7-A501-CA9BCFEE40DC}.Release|x86.Build.0 = Release|Any CPU
+ 	EndGlobalSection
+ 	GlobalSection(NestedProjects) = preSolution
+ 		{DDFAE591-7414-4CC9-AD99-427C2D153893} = {6D173F59-562E-4BAA-8D98-9A8F4901D99A}
+@@ -118,5 +134,7 @@ Global
+ 		{E3CD2895-76A8-4D11-A316-EA67CB5EA42C} = {9EECE6A3-C098-44D0-8ACD-0D8691EC8C3F}
+ 		{8CE3A581-2969-4864-A803-013E9D977C3A} = {11F63FDD-6EB7-4993-8769-8C8DC5DA29C3}
+ 		{7AD4FE65-9A30-41A6-8004-AA8F89BCB7F3} = {5DC491BA-E836-47C1-A4AA-3C770742718B}
++		{649CE05A-529C-40D7-A501-CA9BCFEE40DC} = {B57E7F86-EB16-4F60-A47C-F9D170F54400}
++		{B57E7F86-EB16-4F60-A47C-F9D170F54400} = {DDFAE591-7414-4CC9-AD99-427C2D153893}
+ 	EndGlobalSection
+ EndGlobal
+-- 
+2.16.1.windows.4
+

--- a/patches/roslyn/0002-Add-VBCSCompiler-to-SourceBuild.sln.patch
+++ b/patches/roslyn/0002-Add-VBCSCompiler-to-SourceBuild.sln.patch
@@ -3,6 +3,7 @@ From: Davis Goodin <dagood@microsoft.com>
 Date: Mon, 16 Apr 2018 15:16:02 -0500
 Subject: [PATCH] Add VBCSCompiler to SourceBuild.sln
 
+Removal tracked by https://github.com/dotnet/roslyn/issues/26209.
 ---
  SourceBuild.sln | 18 ++++++++++++++++++
  1 file changed, 18 insertions(+)

--- a/repos/cli.proj
+++ b/repos/cli.proj
@@ -63,14 +63,6 @@
     <EnvironmentVariables Include="GitInfoCommitHash=$(GitCommitHash)" />
 
     <!--
-      Disable crossgen until we can figure out:
-
-      CROSSGEN : error : Could not load file or assembly 'Microsoft.CodeAnalysis.CSharp, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified.
-      CROSSGEN : error : compilation failed for "/work/tarball/src/cli/bin/2/linux-x64/dotnet/sdk/2.1.300-preview2-000001/Microsoft.DotNet.ProjectJsonMigration.dll" (0x80131621)
-    -->
-    <EnvironmentVariables Include="DISABLE_CROSSGEN=true" />
-
-    <!--
       Disable bundled tools until we can figure out:
 
       Unable to find package dotnet-dev-certs.

--- a/repos/roslyn.proj
+++ b/repos/roslyn.proj
@@ -26,6 +26,7 @@
     <NuSpecFiles Include="$(ProjectDirectory)/src/NuGet/Microsoft.CodeAnalysis.Common.nuspec" />
     <NuSpecFiles Include="$(ProjectDirectory)/src/NuGet/Microsoft.CodeAnalysis.Compilers.nuspec" />
     <NuSpecFiles Include="$(ProjectDirectory)/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.nuspec" />
+    <NuSpecFiles Include="$(ProjectDirectory)/src/NuGet/Microsoft.NETCore.Compilers.nuspec" />
   </ItemGroup>
 
   <Target Name="Restore" BeforeTargets="Build">
@@ -43,7 +44,22 @@
   </Target>
 
   <Target Name="Package" AfterTargets="Build">
+    <ItemGroup>
+      <!--
+        "Publish the CoreClr projects (CscCore and VbcCore) and dependencies for later NuGet packaging."
+        https://github.com/dotnet/roslyn/blob/94e73792cfec399f8e1ab3e9246703cbddabbcd4/build/scripts/build.ps1#L280-L288
+      -->
+      <PublishWithoutBuildingProject Include="$(ProjectDirectory)src\Compilers\CSharp\csc\csc.csproj" />
+      <PublishWithoutBuildingProject Include="$(ProjectDirectory)src\Compilers\VisualBasic\vbc\vbc.csproj" />
+      <PublishWithoutBuildingProject Include="$(ProjectDirectory)src\Compilers\Server\VBCSCompiler\VBCSCompiler.csproj" />
+      <PublishWithoutBuildingProject Include="$(ProjectDirectory)src\Compilers\Core\MSBuildTask\MSBuildTask.csproj" />
+    </ItemGroup>
+
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Packaging 'roslyn'" />
+    <!-- Publish MSBuild project so that Microsoft.NETCore.Compilers.nuspec can find runtimes. -->
+    <Exec Command="$(DotnetToolCommand) msbuild %(PublishWithoutBuildingProject.Identity) /p:Configuration=$(Configuration) /p:TargetFramework=netcoreapp2.0 /t:PublishWithoutBuilding $(RedirectRepoOutputToLog)"
+          WorkingDirectory="$(ProjectDirectory)"
+          EnvironmentVariables="@(EnvironmentVariables)" />
     <Exec Command="$(DotnetToolCommand) pack --no-build $(ProjectDirectory)/src/NuGet/NuGetProjectPackUtil.csproj -p:Configuration=$(Configuration) -p:NuspecFile=%(NuSpecFiles.Identity) -p:NuspecBasePath=$(ProjectDirectory)/Binaries/$(Configuration) -p:PackageOutputPath=$(PackagesOutput) -p:NuGetPackageKind=release $(RedirectRepoOutputToLog)"
           WorkingDirectory="$(ProjectDirectory)"
           EnvironmentVariables="@(EnvironmentVariables)" />


### PR DESCRIPTION
Start building the Microsoft.NETCore.Compilers package so that CLI can uptake it and crossgen it.

This is https://github.com/dotnet/source-build/pull/444 plus enabling CLI's crossgen step.

Fixes https://github.com/dotnet/source-build/issues/427