### PR TITLE
(WIP) Reduce CLI build verbosity to minimal

### DIFF
--- a/repos/cli.proj
+++ b/repos/cli.proj
@@ -24,7 +24,7 @@
     <BuildCommandArgs Condition="'$(OS)' == 'Windows_NT'">$(BuildCommandArgs) '/p:CLITargets=\&quot;\&quot;\&quot;Prepare;Compile;Package\&quot;\&quot;\&quot;'</BuildCommandArgs>
     <BuildCommandArgs Condition="'$(OS)' != 'Windows_NT'">$(BuildCommandArgs) '/p:CLITargets=&quot;Prepare;Compile;Package&quot;'</BuildCommandArgs>
 
-    <BuildCommandArgs>$(BuildCommandArgs) /v:detailed</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /v:minimal</BuildCommandArgs>
 
     <BuildCommand>$(ProjectDirectory)build$(ShellExtension) $(BuildCommandArgs)</BuildCommand>
 


### PR DESCRIPTION
I'm curious how much this will reduce CI time (if significant at all). https://github.com/dotnet/source-build/issues/448.

It looks like `/v:detailed` makes CLI output `/v:diagnostic` output, not sure why. Maybe the nested MSBuild calls are all `/v:diagnostic`, and `/v:detailed` is enough to let their output through.