### PR TITLE
Make all tarball build timeouts 4 hours

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -81,6 +81,9 @@ def addPushJob(String project, String branch, String os, String configuration)
 
       Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}");
 
+      // Increase timeout. The tarball builds can take longer than the 2 hour default.
+      Utilities.setJobTimeout(newJob, 240);
+
       // Clone into the source-build directory
       Utilities.addScmInSubDirectory(newJob, project, isPR, 'source-build');
       if(isPR){


### PR DESCRIPTION
Putting this in a separate PR so we don't have to work with the jobs generated by https://github.com/dotnet/source-build/pull/445 while I work on fixing other things about #445.

If this looks ok, I'll merge before CI passes. (Already validated by running a bunch of successful jobs on the generated CI, IMO.)