### PR TITLE
Set AspNetCoreApp version to final

### DIFF
--- a/patches/cli/0010-Set-AspNetCore-version-to-final.patch
+++ b/patches/cli/0010-Set-AspNetCore-version-to-final.patch
@@ -1,0 +1,25 @@
+From 70393591c1572827d29815b4f25912665431e82a Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Wed, 18 Apr 2018 17:55:29 +0000
+Subject: [PATCH] Set AspNetCore version to final
+
+---
+ build/DependencyVersions.props | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build/DependencyVersions.props b/build/DependencyVersions.props
+index 4a8c941..869b2a3 100644
+--- a/build/DependencyVersions.props
++++ b/build/DependencyVersions.props
+@@ -1,7 +1,7 @@
+ <?xml version="1.0" encoding="utf-8"?>
+ <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+   <PropertyGroup>
+-    <MicrosoftAspNetCoreAppPackageVersion>2.1.0-preview2-30475</MicrosoftAspNetCoreAppPackageVersion>
++    <MicrosoftAspNetCoreAppPackageVersion>2.1.0-preview2-final</MicrosoftAspNetCoreAppPackageVersion>
+     <MicrosoftNETCoreAppPackageVersion>2.1.0-preview2-26403-06</MicrosoftNETCoreAppPackageVersion>
+     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
+     <MicrosoftBuildPackageVersion>15.7.0-preview-000144</MicrosoftBuildPackageVersion>
+-- 
+1.8.3.1
+


### PR DESCRIPTION
Update the version of AspNetCoreApp in CLI to point to the final build, since source-build doesn't build this and it doesn't get placed in the PackageVersionsProps file.