### PR TITLE
Avoid cleaning submodules in build-source-tarball

### DIFF
--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -14,13 +14,13 @@ if [ "${2:-}" == "--skip-build" ]; then
 fi
 
 TARBALL_ROOT=$1
-FULL_TARBALL_ROOT=$(readlink -f $TARBALL_ROOT)
+export FULL_TARBALL_ROOT=$(readlink -f $TARBALL_ROOT)
 
 if [ -e "$TARBALL_ROOT" ]; then
     echo "error '$TARBALL_ROOT' exists"
 fi
 
-SCRIPT_ROOT="$(cd -P "$( dirname "$0" )" && pwd)"
+export SCRIPT_ROOT="$(cd -P "$( dirname "$0" )" && pwd)"
 SDK_VERSION=$(cat $SCRIPT_ROOT/DotnetCLIVersion.txt)
 
 if [ $SKIP_BUILD -ne 1 ]; then
@@ -33,10 +33,29 @@ if [ $SKIP_BUILD -ne 1 ]; then
     $SCRIPT_ROOT/build.sh /p:ArchiveDownloadedPackages=true /flp:v=detailed
 fi
 
-git submodule foreach --recursive git clean -xdf
-git submodule foreach --recursive git reset --hard
-
 mkdir -p "$TARBALL_ROOT"
+
+echo 'Copying sources to tarball...'
+
+# Use Git to put sources in the tarball. This ensure it's fresh, without having to clean and reset
+# the working dir. This helps preserve diagnostic information if the tarball build doesn't work.
+
+# Checkout non-submodule sources into tarball.
+git --work-tree="$TARBALL_ROOT" checkout HEAD -- src
+# Checkout submodule sources into tarball.
+git submodule foreach --quiet --recursive '
+    SCRIPT_SUBMODULE_PATH="$toplevel/$path"
+    TARBALL_SUBMODULE_PATH="$FULL_TARBALL_ROOT/${SCRIPT_SUBMODULE_PATH#$SCRIPT_ROOT/}"
+    mkdir -p "$TARBALL_SUBMODULE_PATH"
+    echo "Checking out $(pwd) => $TARBALL_SUBMODULE_PATH ..."
+    if [ "$(ls -A)" = ".git" ]; then
+        # Checkout fails for an empty tree. (E.g. nuget-client submodule NuGet.Build.Localization.)
+        echo "  Nothing to check out from $TARBALL_SUBMODULE_PATH"
+    else
+        git --work-tree="$TARBALL_SUBMODULE_PATH" checkout -- .
+    fi'
+
+echo 'Copying scripts and tools to tarball...'
 
 cp $SCRIPT_ROOT/*.proj $TARBALL_ROOT/
 cp $SCRIPT_ROOT/*.props $TARBALL_ROOT/
@@ -46,11 +65,8 @@ cp $SCRIPT_ROOT/DotnetCLIVersion.txt $TARBALL_ROOT/
 cp -r $SCRIPT_ROOT/keys $TARBALL_ROOT/
 cp -r $SCRIPT_ROOT/patches $TARBALL_ROOT/
 cp -r $SCRIPT_ROOT/scripts $TARBALL_ROOT/
-cp -r $SCRIPT_ROOT/src $TARBALL_ROOT/
 cp -r $SCRIPT_ROOT/repos $TARBALL_ROOT/
 cp -r $SCRIPT_ROOT/tools-local $TARBALL_ROOT/
-
-find $TARBALL_ROOT/src -maxdepth 2 -name '.git' -exec rm -rf {} \;
 
 cp -r $SCRIPT_ROOT/Tools $TARBALL_ROOT/
 rm -f $TARBALL_ROOT/Tools/dotnetcli/dotnet.tar
@@ -63,6 +79,8 @@ cp $SCRIPT_ROOT/support/tarball/build.sh $TARBALL_ROOT/build.sh
 mkdir -p $TARBALL_ROOT/prebuilt/nuget-packages
 find $SCRIPT_ROOT/packages -name '*.nupkg' -exec cp {} $TARBALL_ROOT/prebuilt/nuget-packages/ \;
 find $SCRIPT_ROOT/bin/obj/x64/Release/nuget-packages -name '*.nupkg' -exec cp {} $TARBALL_ROOT/prebuilt/nuget-packages/ \;
+
+echo 'Removing source-built packages from tarball prebuilts...'
 
 for built_package in $(find $SCRIPT_ROOT/bin/obj/x64/Release/blob-feed/packages/ -name '*.nupkg' | tr '[:upper:]' '[:lower:]')
 do
@@ -79,3 +97,5 @@ source-build:
 submodules:
 $(git submodule status --recursive)
 EOF
+
+echo "Done. Tarball created: $TARBALL_ROOT"


### PR DESCRIPTION
 * Instead of cleaning/resetting submodules, use "git checkout" to add clean submodule sources to the tarball.
 * Add a few status log echos.

The main reason to do this is to diagnose issues with a built tarball. There's a **lot** of useful information in the submodules.

This also makes it possible to do a partial rebuild of the repo, then make a new tarball, rather than having to build from scratch every time. This is still dangerous due to potential dirty repo, packages dir, and bin state, but better (IMO) than doing live edits to a tarball and mirroring them in the repo.

`git submodule foreach` runs in the context of a new shell, so I had to `export` the variables it uses.