### PR TITLE
Remove checked-in Git info: get during build

### DIFF
--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -67,6 +67,7 @@ cp -r $SCRIPT_ROOT/patches $TARBALL_ROOT/
 cp -r $SCRIPT_ROOT/scripts $TARBALL_ROOT/
 cp -r $SCRIPT_ROOT/repos $TARBALL_ROOT/
 cp -r $SCRIPT_ROOT/tools-local $TARBALL_ROOT/
+cp -r $SCRIPT_ROOT/bin/git-info $TARBALL_ROOT/
 
 cp -r $SCRIPT_ROOT/Tools $TARBALL_ROOT/
 rm -f $TARBALL_ROOT/Tools/dotnetcli/dotnet.tar

--- a/build.proj
+++ b/build.proj
@@ -11,6 +11,7 @@
   <Target Name="PrepareOutput">
     <MakeDir Directories="$(OutputPath)" />
     <MakeDir Directories="$(LoggingDir)" />
+    <MakeDir Directories="$(GitInfoOutputDir)" />
     <MakeDir Directories="$(IntermediatePath)" />
     <MakeDir Directories="$(SourceBuiltBlobFeedDir)" />
     <MakeDir Directories="$(SourceBuiltPackagesPath)" />

--- a/dir.props
+++ b/dir.props
@@ -60,6 +60,10 @@
     <RestoreSourcePropsPath>$(IntermediatePath)RestoreSources.props</RestoreSourcePropsPath>
     <PackageVersionPropsPath>$(IntermediatePath)PackageVersions.props</PackageVersionPropsPath>
     <LoggingDir>$(BaseOutputPath)logs/</LoggingDir>
+    <!-- Dir where git info is generated during online builds. -->
+    <GitInfoOutputDir>$(BaseOutputPath)git-info/</GitInfoOutputDir>
+    <!-- Dir where git info is placed inside the tarball. -->
+    <GitInfoOfflineDir>$(ProjectDir)git-info/</GitInfoOfflineDir>
   </PropertyGroup>
 
   <!-- Import Build tools common props file where repo-independent properties are found -->

--- a/repos/cli-migrate.proj
+++ b/repos/cli-migrate.proj
@@ -4,14 +4,13 @@
   <PropertyGroup>
     <BuildCommand>$(ProjectDirectory)\build$(ShellExtension) --restore --pack --configuration $(Configuration)</BuildCommand>
     <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
-    <LatestCommit>46f0d4f3f9e6ae4c1fc9bdc9e36b4523e79ee159</LatestCommit>
     <!-- NuGet SDK resolver only checks nuget.config files. https://github.com/Microsoft/msbuild/issues/2914 -->
     <NuGetConfigFile>$(ProjectDirectory)/nuget.config</NuGetConfigFile>
     <UsesRepoToolset>true</UsesRepoToolset>
   </PropertyGroup>
 
   <ItemGroup>
-    <EnvironmentVariables Include="GIT_COMMIT=$(LatestCommit)" />
+    <EnvironmentVariables Include="GIT_COMMIT=$(GitCommitHash)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/cli.proj
+++ b/repos/cli.proj
@@ -31,9 +31,6 @@
     <PackagesOutput>$(ProjectDirectory)bin/2/linux-x64/packages/</PackagesOutput>
     <TarBallOutput>$(PackagesOutput)</TarBallOutput>
 
-    <GitCommitCount>6908</GitCommitCount>
-    <GitCommitHash>38031f6e5c3e21fa39d82aca300f5ed769be10a0</GitCommitHash>
-
     <RepoApiImplemented>false</RepoApiImplemented>
     <SourceOverrideRepoApiImplemented>true</SourceOverrideRepoApiImplemented>
     <DependencyVersionInputRepoApiImplemented>true</DependencyVersionInputRepoApiImplemented>

--- a/repos/clicommandlineparser.proj
+++ b/repos/clicommandlineparser.proj
@@ -4,14 +4,13 @@
   <PropertyGroup>
     <BuildCommand>$(ProjectDirectory)\build$(ShellExtension) --restore --pack --configuration $(Configuration)</BuildCommand>
     <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
-    <LatestCommit>31a677abae466176d932c0d50f8bde52d7613bb9</LatestCommit>
     <!-- NuGet SDK resolver only checks nuget.config files. https://github.com/Microsoft/msbuild/issues/2914 -->
     <NuGetConfigFile>$(ProjectDirectory)/nuget.config</NuGetConfigFile>
     <UsesRepoToolset>true</UsesRepoToolset>
   </PropertyGroup>
 
   <ItemGroup>
-    <EnvironmentVariables Include="GIT_COMMIT=$(LatestCommit)" />
+    <EnvironmentVariables Include="GIT_COMMIT=$(GitCommitHash)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/core-setup.proj
+++ b/repos/core-setup.proj
@@ -6,7 +6,6 @@
     <BuildArguments Condition="$(Platform.Contains('arm'))">$(BuildArguments) -TargetArchitecture=$(Platform) -DisableCrossgen=true -CrossBuild=true</BuildArguments>
     <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments) -- /p:BuildDebPackage=false /p:BuildAllPackages=true</BuildCommand>
     <BuildCommand Condition="$(Platform.Contains('arm'))">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
-    <LatestCommit>82b22fa44e46d624ebeddf156f33e9cfb317bd57</LatestCommit>
     <OfficialBuildId>20180406-04</OfficialBuildId>
 
     <!-- Need to set $(PackagesOutput) so WriteVersions writes the versions file for cli, until cli respects auto-dependency flow -->

--- a/repos/coreclr.proj
+++ b/repos/coreclr.proj
@@ -9,7 +9,6 @@
     <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments) --</BuildCommand>
     <BuildCommand Condition="$(Platform.Contains('arm'))">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
     <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension)</CleanCommand>
-    <LatestCommit>36f70fa4be4bd37d4d76d06dd2cc433ff46351bd</LatestCommit>
     <OfficialBuildId>20180406-07</OfficialBuildId>
     <!-- ProdCon is behind source-build: temporarily disable auto-update. -->
     <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>

--- a/repos/corefx.proj
+++ b/repos/corefx.proj
@@ -7,7 +7,6 @@
     <BuildCommand Condition="$(Platform.Contains('arm'))">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
     <PackagesOutput>$(ProjectDirectory)/bin/packages/$(Configuration)</PackagesOutput>
     <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension)</CleanCommand>
-    <LatestCommit>8321c729934c0f8be754953439b88e6e1c120c24</LatestCommit>
     <OfficialBuildId>20180406-04</OfficialBuildId>
     <!-- ProdCon is behind source-build: temporarily disable auto-update. -->
     <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>

--- a/repos/dir.props
+++ b/repos/dir.props
@@ -14,6 +14,18 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <OutputGitInfoPropsFile>$(GitInfoOutputDir)$(RepositoryName).props</OutputGitInfoPropsFile>
+    <OfflineGitInfoPropsFile>$(GitInfoOfflineDir)$(RepositoryName).props</OfflineGitInfoPropsFile>
+  </PropertyGroup>
+
+  <Import Project="$(OutputGitInfoPropsFile)" Condition="Exists('$(OutputGitInfoPropsFile)')" />
+  <Import Project="$(OfflineGitInfoPropsFile)" Condition="Exists('$(OfflineGitInfoPropsFile)')" />
+
+  <PropertyGroup>
+    <GitCommitDateNoDashes>$(GitCommitDate.Replace('-', ''))</GitCommitDateNoDashes>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <VersionFilename>Latest_Packages.txt</VersionFilename>
     <VersionFileDirectory>$(LocalBuildInfoRoot)</VersionFileDirectory>
     <VersionFileLocation Condition="'$(VersionFileLocation)' == ''">$(VersionFileDirectory)$(RepositoryOrganization)/$(RepositoryName)/$(RepositoryBranch)/$(VersionFilename)</VersionFileLocation>

--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" InitialTargets="SetNuGetPackagesEnvironment" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition="'$(OfflineBuild)' == 'true'">
-    <EnvironmentVariables Include="LatestCommit=$(LatestCommit)" />
+    <EnvironmentVariables Include="LatestCommit=$(GitCommitHash)" />
     <EnvironmentVariables Include="OfficialBuildId=$(OfficialBuildId)" />
     <EnvironmentVariables Include="VersionSeedDate=$(OfficialBuildId)" />
   </ItemGroup>
@@ -76,6 +76,38 @@
     <Exec Command="$(PatchCommand) %(PatchesToApply.Identity)"
           WorkingDirectory="$(ProjectDirectory)"
           Condition="'@(PatchesToApply)' != ''" />
+  </Target>
+
+  <Target Name="CreateGitInfoProps"
+          Condition="'$(OfflineBuild)' != 'true' AND Exists('$(ProjectDirectory).git')">
+    <Exec Command="git rev-parse HEAD" WorkingDirectory="$(ProjectDirectory)" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitCommitHash" />
+    </Exec>
+    <Exec Command="git rev-list --count HEAD" WorkingDirectory="$(ProjectDirectory)" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitCommitCount" />
+    </Exec>
+    <Exec Command="git log -1 --format=%25cd --date=short" WorkingDirectory="$(ProjectDirectory)" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitCommitDate" />
+    </Exec>
+
+    <PropertyGroup>
+      <GitInfoFileContents>
+        <![CDATA[<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- $(RepositoryName) submodule information. -->
+    <GitCommitHash>$(GitCommitHash)</GitCommitHash>
+    <GitCommitCount>$(GitCommitCount)</GitCommitCount>
+    <GitCommitDate>$(GitCommitDate)</GitCommitDate>
+  </PropertyGroup>
+</Project>
+]]>
+      </GitInfoFileContents>
+    </PropertyGroup>
+
+    <WriteLinesToFile File="$(OutputGitInfoPropsFile)"
+                      Lines="$(GitInfoFileContents)"
+                      Overwrite="true" />
   </Target>
 
   <Target Name="UpdateNuGetConfig"

--- a/repos/msbuild.proj
+++ b/repos/msbuild.proj
@@ -3,11 +3,11 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
-    <LatestCommit>d7690fb9d3d7b97917243ae63aed97dc3d146e85</LatestCommit>
-    <LatestCommitDate>20180227</LatestCommitDate>
+    <!-- Override value from commit to match expected build. -->
+    <GitCommitDateNoDashes>20180227</GitCommitDateNoDashes>
     <PackagesOutput>$(ProjectDirectory)/artifacts/$(Configuration)/packages</PackagesOutput>
-    <OutputVersionArgs>/p:VersionBase=15.6.82 /p:DisableNerdbankVersioning=true /p:PreReleaseVersionLabel="preview2" /p:BUILD_BUILDNUMBER=$(LatestCommitDate).01</OutputVersionArgs>
-    <BuildCommand>$(ProjectDirectory)build/build$(ShellExtension) build -DotNetBuildFromSource -DotNetCoreSdkDir $(DotNetCliToolDir) -bootstraponly -skiptests -pack -configuration $(Configuration) /p:GitHeadSha=$(LatestCommit) $(OutputVersionArgs)</BuildCommand>
+    <OutputVersionArgs>/p:VersionBase=15.6.82 /p:DisableNerdbankVersioning=true /p:PreReleaseVersionLabel="preview2" /p:BUILD_BUILDNUMBER=$(GitCommitDateNoDashes).01</OutputVersionArgs>
+    <BuildCommand>$(ProjectDirectory)build/build$(ShellExtension) build -DotNetBuildFromSource -DotNetCoreSdkDir $(DotNetCliToolDir) -bootstraponly -skiptests -pack -configuration $(Configuration) /p:GitHeadSha=$(GitCommitHash) $(OutputVersionArgs)</BuildCommand>
     <SourceOverrideRepoApiImplemented>true</SourceOverrideRepoApiImplemented>
     <RepoApiImplemented>false</RepoApiImplemented>
     <!--

--- a/repos/roslyn-tools.proj
+++ b/repos/roslyn-tools.proj
@@ -4,14 +4,13 @@
   <PropertyGroup>
     <BuildCommand>$(ProjectDirectory)\build$(ShellExtension) --pack --configuration $(Configuration)</BuildCommand>
     <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
-    <LatestCommit>47d48ec691032e35882a7f6c4c632d621f4f04a8</LatestCommit>
     <UsesRepoToolset>true</UsesRepoToolset>
     <BuiltToolPackageId>$(RepoToolsetPackageId)</BuiltToolPackageId>
   </PropertyGroup>
 
   <ItemGroup>
     <EnvironmentVariables Include="UsingToolMicrosoftNetCompilers=false" />
-    <EnvironmentVariables Include="GIT_COMMIT=$(LatestCommit)" />
+    <EnvironmentVariables Include="GIT_COMMIT=$(GitCommitHash)" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />

--- a/repos/roslyn.proj
+++ b/repos/roslyn.proj
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <NuGetPackageVersion>2.3.2-beta1-61921-05</NuGetPackageVersion>
     <BuildNumber>20170721.5</BuildNumber>
-    <CommitHash>ad0efbb6975c74e3e19051896be7ffcbb70d2122</CommitHash>
     <BuildCommand>$(DotnetToolCommand) build $(ProjectDirectory)/SourceBuild.sln /p:Configuration=$(Configuration) /p:OfficialBuild=true /p:BuildNumber=$(BuildNumber)</BuildCommand>
     <PackagesOutput>$(ProjectDirectory)/Binaries/packages</PackagesOutput>
     <RepoApiImplemented>false</RepoApiImplemented>
@@ -13,7 +12,7 @@
 
   <ItemGroup>
     <EnvironmentVariables Include="DOTNET_RUNTIME_ID=$(TargetRid)" />
-    <EnvironmentVariables Include="COMMIT_SHA=$(CommitHash)" />
+    <EnvironmentVariables Include="COMMIT_SHA=$(GitCommitHash)" />
     <EnvironmentVariables Include="NUGET_PACKAGE_VERSION=$(NuGetPackageVersion)" />
   </ItemGroup>
 

--- a/repos/sdk.proj
+++ b/repos/sdk.proj
@@ -6,14 +6,13 @@
     <OutputVersionArgs>/p:BUILD_BUILDNUMBER=$(OfficialBuildId)</OutputVersionArgs>
     <BuildCommand>$(ProjectDirectory)\build$(ShellExtension) --pack --configuration $(Configuration) $(OutputVersionArgs)</BuildCommand>
     <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
-    <LatestCommit>dd10bc7fd4a0046d0e27242d7e558dbc34d9fbbd</LatestCommit>
     <!-- NuGet SDK resolver only checks nuget.config files. https://github.com/Microsoft/msbuild/issues/2914 -->
     <NuGetConfigFile>$(ProjectDirectory)/nuget.config</NuGetConfigFile>
     <UsesRepoToolset>true</UsesRepoToolset>
   </PropertyGroup>
 
   <ItemGroup>
-    <EnvironmentVariables Include="GIT_COMMIT=$(LatestCommit)" />
+    <EnvironmentVariables Include="GIT_COMMIT=$(GitCommitHash)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/standard.proj
+++ b/repos/standard.proj
@@ -6,7 +6,6 @@
     <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) -$(Configuration) --</BuildCommand>
     <BuildPackagesCommand></BuildPackagesCommand>
     <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension)</CleanCommand>
-    <LatestCommit>d318b764a689cfe285d8484bda918646905664e7</LatestCommit>
     <VersionSeedDate>2017-07-19</VersionSeedDate>
     <OfficialBuildId>20170719-03</OfficialBuildId>
     <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>

--- a/repos/symreader-portable.proj
+++ b/repos/symreader-portable.proj
@@ -4,14 +4,13 @@
   <PropertyGroup>
     <BuildCommand>$(ProjectDirectory)\build$(ShellExtension) --pack --configuration $(Configuration)</BuildCommand>
     <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
-    <LatestCommit>6b4292f99164b6e7815eb25937771b4071079eaa</LatestCommit>
     <!-- NuGet SDK resolver only checks nuget.config files. https://github.com/Microsoft/msbuild/issues/2914 -->
     <NuGetConfigFile>$(ProjectDirectory)/nuget.config</NuGetConfigFile>
     <UsesRepoToolset>true</UsesRepoToolset>
   </PropertyGroup>
 
   <ItemGroup>
-    <EnvironmentVariables Include="GIT_COMMIT=$(LatestCommit)" />
+    <EnvironmentVariables Include="GIT_COMMIT=$(GitCommitHash)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/symreader.proj
+++ b/repos/symreader.proj
@@ -4,14 +4,13 @@
   <PropertyGroup>
     <BuildCommand>$(ProjectDirectory)\build$(ShellExtension) --pack --configuration $(Configuration)</BuildCommand>
     <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
-    <LatestCommit>9bb9aec2fdfd165eef3776fd3ff2f1bb9b63e46d</LatestCommit>
     <!-- NuGet SDK resolver only checks nuget.config files. https://github.com/Microsoft/msbuild/issues/2914 -->
     <NuGetConfigFile>$(ProjectDirectory)/nuget.config</NuGetConfigFile>
     <UsesRepoToolset>true</UsesRepoToolset>
   </PropertyGroup>
 
   <ItemGroup>
-    <EnvironmentVariables Include="GIT_COMMIT=$(LatestCommit)" />
+    <EnvironmentVariables Include="GIT_COMMIT=$(GitCommitHash)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/templating.proj
+++ b/repos/templating.proj
@@ -3,7 +3,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <PackagesOutput>$(ProjectDirectory)artifacts/packages</PackagesOutput>
-    <CommitHash>2bc0ba26d890223a9874dee0f0233ded8bd7a39a</CommitHash>
     <BuildNumber>301</BuildNumber>
     <PackageDateTime>20170727</PackageDateTime>
     <PackageBuildQuality>beta2</PackageBuildQuality>
@@ -12,7 +11,7 @@
 
   <ItemGroup>
     <MSBuildProperties Include="Configuration=$(Configuration)" />
-    <MSBuildProperties Include="COMMIT_HASH=$(CommitHash)" />
+    <MSBuildProperties Include="COMMIT_HASH=$(GitCommitHash)" />
     <MSBuildProperties Include="COMMIT_COUNT=$(BuildNumber)" />
     <MSBuildProperties Include="BUILD_NUMBER=$(BuildNumber)" />
     <MSBuildProperties Include="PackageDateTime=$(PackageDateTime)" />

--- a/repos/xliff-tasks.proj
+++ b/repos/xliff-tasks.proj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <PackagesOutput>$(ProjectDirectory)/bin/$(Configuration)</PackagesOutput>
     <BuildNumber>48</BuildNumber>
-    <CommitHash>27d43b762aa6dac3a0a6ba48fe55000942d75c1c</CommitHash>
     <RepoApiImplemented>false</RepoApiImplemented>
     <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
   </PropertyGroup>

--- a/tools-local/init-build.proj
+++ b/tools-local/init-build.proj
@@ -18,7 +18,7 @@
     Inputs="$(TargetInfoProps)"
     Outputs="$(BuildCompetedSuccessSemaphore)"
     >
-    <CallTarget Targets="BuildTasks;InstallSourceBuildSdkResolver;WriteDynamicPropsToStaticPropsFiles;GenerateRootFs;ApplyPatches;BuildDummyPackages;BuildReferenceAssemblies" />
+    <CallTarget Targets="BuildTasks;InstallSourceBuildSdkResolver;WriteDynamicPropsToStaticPropsFiles;GenerateRootFs;CreateAllGitInfoProps;ApplyPatches;BuildDummyPackages;BuildReferenceAssemblies" />
     <Touch Files="$(BuildCompetedSuccessSemaphore)" AlwaysCreate="true" />
   </Target>
 
@@ -38,14 +38,28 @@
     <Exec Command="$(DotNetCliToolDir)dotnet build tasks\Microsoft.DotNet.SourceBuild.Tasks\Microsoft.DotNet.SourceBuild.Tasks.csproj /p:RestoreSources=$(OfflineSources)" />
   </Target>
 
-  <Target Name="ApplyPatches">
-    <Message Text="Applying patches only" />
-
+  <Target Name="GetRepoProjects">
     <ItemGroup>
-      <_RepoProjects Include="$(ProjectDir)repos/*.proj" />
+      <RepoProjects Include="$(ProjectDir)repos/*.proj" />
     </ItemGroup>
+  </Target>
 
-    <MSBuild Projects="@(_RepoProjects)" Targets="ApplyPatches" BuildInParallel="$(BuildInParallel)" />
+  <Target Name="CreateAllGitInfoProps">
+    <!--
+      Create the files in a new process to avoid MSBuild remembering the static properties/items.
+      Using the MSBuild task here would cause, for example, GIT_COMMIT EnvironmentVariables items to
+      be created that don't contain any commit, and they would stick around until the real build.
+    -->
+    <Exec Command="$(DotNetCliToolDir)dotnet msbuild /v:Quiet /nologo $(MSBuildThisFileFullPath) /t:CreateGitInfoProps" />
+  </Target>
+
+  <Target Name="CreateGitInfoProps" DependsOnTargets="GetRepoProjects">
+    <MSBuild Projects="@(RepoProjects)" Targets="CreateGitInfoProps" BuildInParallel="$(BuildInParallel)" />
+  </Target>
+
+  <Target Name="ApplyPatches" DependsOnTargets="GetRepoProjects">
+    <Message Text="Applying patches only" />
+    <MSBuild Projects="@(RepoProjects)" Targets="ApplyPatches" BuildInParallel="$(BuildInParallel)" />
   </Target>
 
   <Target Name="GenerateRootFs" Condition="'$(OS)' != 'Windows_NT'">


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/385.

The generated files go into `bin/git-info/{repo}.props`, and that `git-info` dir gets copied into the tarball at the root. The props files are used in the main build and tarball build to keep them as similar as possible, rather than only generating them for the tarball build.