### PR TITLE
Fix nuget-client build for RC.

### DIFF
--- a/patches/nuget-client/0001-Add-XPlat-build-properties-to-NuGet.Credentials.patch
+++ b/patches/nuget-client/0001-Add-XPlat-build-properties-to-NuGet.Credentials.patch
@@ -1,0 +1,38 @@
+From 3563a04430b1e3d025300dcc0c8b7188b6df5120 Mon Sep 17 00:00:00 2001
+From: Chris Rummel <crummel@microsoft.com>
+Date: Mon, 23 Apr 2018 15:12:46 -0500
+Subject: [PATCH] Add XPlat build properties to NuGet.Credentials.
+
+Patch removal is tracked at https://github.com/NuGet/NuGet.Client/pull/2184.
+
+---
+ src/NuGet.Clients/NuGet.Credentials/NuGet.Credentials.csproj | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/NuGet.Clients/NuGet.Credentials/NuGet.Credentials.csproj b/src/NuGet.Clients/NuGet.Credentials/NuGet.Credentials.csproj
+index 284edb3bc..eb7e4130a 100644
+--- a/src/NuGet.Clients/NuGet.Credentials/NuGet.Credentials.csproj
++++ b/src/NuGet.Clients/NuGet.Credentials/NuGet.Credentials.csproj
+@@ -4,10 +4,12 @@
+ 
+   <PropertyGroup>
+     <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
++    <TargetFrameworks Condition="'$(IsBuildOnlyXPLATProjects)' == 'true'">netstandard1.6</TargetFrameworks>
+     <Shipping>true</Shipping>
+     <PackProject>true</PackProject>
+     <IncludeInVsix>true</IncludeInVsix>
+     <GenerateDocumentationFile>false</GenerateDocumentationFile>
++    <XPLATProject>true</XPLATProject>
+   </PropertyGroup>
+ 
+   <ItemGroup>
+@@ -40,4 +42,4 @@
+ 
+   <Import Project="$(BuildCommonDirectory)common.targets"/>
+   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+-</Project>
+\ No newline at end of file
++</Project>
+-- 
+2.14.1
+

--- a/repos/cli.proj
+++ b/repos/cli.proj
@@ -46,7 +46,7 @@
     <!--RepositoryReference Include="msbuild" /-->
     <RepositoryReference Include="netcorecli-fsc" />
     <!--RepositoryReference Include="newtonsoft-json" /-->
-    <!--RepositoryReference Include="nuget-client" /-->
+    <RepositoryReference Include="nuget-client" />
     <!--RepositoryReference Include="roslyn" /-->
     <!--RepositoryReference Include="sdk" /-->
     <!--RepositoryReference Include="templating" /-->

--- a/repos/known-good.proj
+++ b/repos/known-good.proj
@@ -24,7 +24,7 @@
     <!--RepositoryReference Include="roslyn" /-->
 
     <!-- Tier 2 -->
-    <!--RepositoryReference Include="nuget-client" /-->
+    <RepositoryReference Include="nuget-client" />
     <RepositoryReference Include="websdk" />
     <RepositoryReference Include="coreclr" />
 


### PR DESCRIPTION
Adds a patch to make NuGet.Credentials XPlat as it is now referenced from NuGet.Commands.  Patch removal submitted to https://github.com/NuGet/NuGet.Client/pull/2184.