### PR TITLE
Update msbuild for 2.1 RC

### DIFF
--- a/repos/known-good.proj
+++ b/repos/known-good.proj
@@ -19,7 +19,7 @@
     <RepositoryReference Include="standard" />
     <RepositoryReference Include="xliff-tasks" />
 
-    <!--RepositoryReference Include="msbuild" /-->
+    <RepositoryReference Include="msbuild" />
     <!--RepositoryReference Include="clicommandlineparser" /-->
     <RepositoryReference Include="roslyn" />
 


### PR DESCRIPTION
Move msbuild SHA to new branch and update known-good.

msbuild has not been updated to use common repotoolset, yet. 