### PR TITLE
Add patch to not reset output paths for templating.

### DIFF
--- a/patches/templating/0001-Add-source-build-exlusion-to-resetting-output-paths.patch
+++ b/patches/templating/0001-Add-source-build-exlusion-to-resetting-output-paths.patch
@@ -1,0 +1,152 @@
+From 86dad51a00cfff73b9510955c67e1891118f84a6 Mon Sep 17 00:00:00 2001
+From: Chris Rummel <crummel@microsoft.com>
+Date: Wed, 25 Apr 2018 15:43:36 -0500
+Subject: [PATCH] Add source-build exclusion to resetting output paths.
+
+---
+ template_feed/Microsoft.DotNet.Common.ItemTemplates/build.csproj      | 4 ++--
+ .../Microsoft.DotNet.Common.ProjectTemplates.1.x/build.csproj         | 4 ++--
+ .../Microsoft.DotNet.Common.ProjectTemplates.2.0/build.csproj         | 4 ++--
+ .../Microsoft.DotNet.Common.ProjectTemplates.2.1/build.csproj         | 4 ++--
+ template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/build.csproj | 4 ++--
+ template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/build.csproj | 4 ++--
+ template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/build.csproj | 4 ++--
+ 7 files changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/template_feed/Microsoft.DotNet.Common.ItemTemplates/build.csproj b/template_feed/Microsoft.DotNet.Common.ItemTemplates/build.csproj
+index b45c2bf4..ea19b5ec 100644
+--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/build.csproj
++++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/build.csproj
+@@ -10,7 +10,7 @@
+     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+     <OutputPath>$(TemplatesFolder)</OutputPath>
+     <EnableDefaultItems>False</EnableDefaultItems>
+-    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
++    <BaseIntermediateOutputPath Condition="'$(DotNetBuildFromSource)' != 'true'">$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
+   </PropertyGroup>
+   <ItemGroup>
+     <PackageReference Remove="Microsoft.NETCore.App" />
+@@ -18,4 +18,4 @@
+     <Compile Remove="$(MSBuildThisFileDirectory)../../src/GitInfo.cs" />
+     <None Remove="**/*.csproj" />
+   </ItemGroup>
+-</Project>
+\ No newline at end of file
++</Project>
+diff --git a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/build.csproj b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/build.csproj
+index 420344ce..711142e0 100644
+--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/build.csproj
++++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/build.csproj
+@@ -10,11 +10,11 @@
+     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+     <OutputPath>$(TemplatesFolder)</OutputPath>
+     <EnableDefaultItems>False</EnableDefaultItems>
+-    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
++    <BaseIntermediateOutputPath Condition="'$(DotNetBuildFromSource)' != 'true'">$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
+   </PropertyGroup>
+   <ItemGroup>
+     <PackageReference Remove="Microsoft.NETCore.App" />
+     <Compile Remove="$(GitInfoFile)" />
+     <Compile Remove="$(MSBuildThisFileDirectory)../../src/GitInfo.cs" />
+   </ItemGroup>
+-</Project>
+\ No newline at end of file
++</Project>
+diff --git a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/build.csproj b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/build.csproj
+index 420344ce..711142e0 100644
+--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/build.csproj
++++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/build.csproj
+@@ -10,11 +10,11 @@
+     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+     <OutputPath>$(TemplatesFolder)</OutputPath>
+     <EnableDefaultItems>False</EnableDefaultItems>
+-    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
++    <BaseIntermediateOutputPath Condition="'$(DotNetBuildFromSource)' != 'true'">$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
+   </PropertyGroup>
+   <ItemGroup>
+     <PackageReference Remove="Microsoft.NETCore.App" />
+     <Compile Remove="$(GitInfoFile)" />
+     <Compile Remove="$(MSBuildThisFileDirectory)../../src/GitInfo.cs" />
+   </ItemGroup>
+-</Project>
+\ No newline at end of file
++</Project>
+diff --git a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.1/build.csproj b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.1/build.csproj
+index 420344ce..711142e0 100644
+--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.1/build.csproj
++++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.1/build.csproj
+@@ -10,11 +10,11 @@
+     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+     <OutputPath>$(TemplatesFolder)</OutputPath>
+     <EnableDefaultItems>False</EnableDefaultItems>
+-    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
++    <BaseIntermediateOutputPath Condition="'$(DotNetBuildFromSource)' != 'true'">$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
+   </PropertyGroup>
+   <ItemGroup>
+     <PackageReference Remove="Microsoft.NETCore.App" />
+     <Compile Remove="$(GitInfoFile)" />
+     <Compile Remove="$(MSBuildThisFileDirectory)../../src/GitInfo.cs" />
+   </ItemGroup>
+-</Project>
+\ No newline at end of file
++</Project>
+diff --git a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/build.csproj b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/build.csproj
+index 420344ce..711142e0 100644
+--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/build.csproj
++++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/build.csproj
+@@ -10,11 +10,11 @@
+     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+     <OutputPath>$(TemplatesFolder)</OutputPath>
+     <EnableDefaultItems>False</EnableDefaultItems>
+-    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
++    <BaseIntermediateOutputPath Condition="'$(DotNetBuildFromSource)' != 'true'">$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
+   </PropertyGroup>
+   <ItemGroup>
+     <PackageReference Remove="Microsoft.NETCore.App" />
+     <Compile Remove="$(GitInfoFile)" />
+     <Compile Remove="$(MSBuildThisFileDirectory)../../src/GitInfo.cs" />
+   </ItemGroup>
+-</Project>
+\ No newline at end of file
++</Project>
+diff --git a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/build.csproj b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/build.csproj
+index 420344ce..711142e0 100644
+--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/build.csproj
++++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/build.csproj
+@@ -10,11 +10,11 @@
+     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+     <OutputPath>$(TemplatesFolder)</OutputPath>
+     <EnableDefaultItems>False</EnableDefaultItems>
+-    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
++    <BaseIntermediateOutputPath Condition="'$(DotNetBuildFromSource)' != 'true'">$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
+   </PropertyGroup>
+   <ItemGroup>
+     <PackageReference Remove="Microsoft.NETCore.App" />
+     <Compile Remove="$(GitInfoFile)" />
+     <Compile Remove="$(MSBuildThisFileDirectory)../../src/GitInfo.cs" />
+   </ItemGroup>
+-</Project>
+\ No newline at end of file
++</Project>
+diff --git a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/build.csproj b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/build.csproj
+index 420344ce..711142e0 100644
+--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/build.csproj
++++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/build.csproj
+@@ -10,11 +10,11 @@
+     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+     <OutputPath>$(TemplatesFolder)</OutputPath>
+     <EnableDefaultItems>False</EnableDefaultItems>
+-    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
++    <BaseIntermediateOutputPath Condition="'$(DotNetBuildFromSource)' != 'true'">$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
+   </PropertyGroup>
+   <ItemGroup>
+     <PackageReference Remove="Microsoft.NETCore.App" />
+     <Compile Remove="$(GitInfoFile)" />
+     <Compile Remove="$(MSBuildThisFileDirectory)../../src/GitInfo.cs" />
+   </ItemGroup>
+-</Project>
+\ No newline at end of file
++</Project>
+-- 
+2.14.1
+

--- a/repos/known-good.proj
+++ b/repos/known-good.proj
@@ -28,7 +28,7 @@
     <RepositoryReference Include="websdk" />
     <RepositoryReference Include="coreclr" />
 
-    <!--RepositoryReference Include="templating" /-->
+    <RepositoryReference Include="templating" />
 
     <!-- Tier 3 -->
 


### PR DESCRIPTION
Don't use the `scratch` directory as we aren't signing the templating packages.  Looking at this closer now to see what a good upstream fix looks like, trying this out to make sure it gets through the whole build.