### PR TITLE
Generate prebuilt package usage reports

### DIFF
--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -90,7 +90,17 @@ do
     fi
 done
 
-# Record commits for the source-build repo and all submodules, to aid in reproducibility.
+if [ -z "${SOURCE_BUILD_SKIP_PREBUILT_REPORT:-}" ]; then
+    echo 'Creating prebuilt package usage report...'
+    (
+        # Don't clean up (or ask to clean up).
+        export SOURCE_BUILD_SKIP_SUBMODULE_CHECK=1
+        "$SCRIPT_ROOT/build.sh" /nologo /t:ReportTarballPrebuiltUsage /p:TarballPrebuiltPackagesPath="$FULL_TARBALL_ROOT/prebuilt/nuget-packages/"
+    )
+fi
+
+echo 'Recording commits for the source-build repo and all submodules, to aid in reproducibility...'
+
 cat >$TARBALL_ROOT/source-build-info.txt << EOF
 source-build:
  $(git rev-parse HEAD) . ($(git describe --always HEAD))

--- a/build.proj
+++ b/build.proj
@@ -27,6 +27,18 @@
     <RemoveDir Directories="$(BaseOutputPath)" />
   </Target>
 
+  <!-- After building offline, create a prebuilt usage report. -->
+  <Target Name="ReportPrebuiltUsageAfterOfflineBuild"
+          AfterTargets="Build"
+          Condition="'$(OfflineBuild)' == 'true' and '$(SkipReportPrebuiltUsageAfterOfflineBuild)' != 'true'">
+    <MSBuild Projects="repos\$(RootRepo).proj" Targets="ReportPrebuiltUsage" />
+  </Target>
+
+  <!-- After generating a tarball, check why/where the online build downloaded prebuilts. -->
+  <Target Name="ReportTarballPrebuiltUsage">
+    <MSBuild Projects="repos\$(RootRepo).proj" Targets="ReportPrebuiltUsage" />
+  </Target>
+
   <Import Project="$(ProjectDir)dependencies.targets" />
 
   <Import Project="$(ToolsDir)VersionTools.targets" />

--- a/dir.props
+++ b/dir.props
@@ -64,6 +64,7 @@
     <GitInfoOutputDir>$(BaseOutputPath)git-info/</GitInfoOutputDir>
     <!-- Dir where git info is placed inside the tarball. -->
     <GitInfoOfflineDir>$(ProjectDir)git-info/</GitInfoOfflineDir>
+    <PackageReportDir>$(BaseOutputPath)prebuilt-report</PackageReportDir>
   </PropertyGroup>
 
   <!-- Import Build tools common props file where repo-independent properties are found -->

--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -7,9 +7,11 @@
   </ItemGroup>
 
   <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="AddSourceToNuGetConfig" />
+  <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="ReadNuGetPackageInfos" />
   <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="RemoveInternetSourcesFromNuGetConfig" />
   <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="UpdateJson" />
   <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="WriteBuildOutputProps" />
+  <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="WritePackageUsageReportToFile" />
   <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="WriteRestoreSourceProps" />
   <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="WriteVersionsFile" />
   <UsingTask AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" TaskName="ZipFileExtractToDirectory" />
@@ -309,6 +311,37 @@
       <EnvironmentVariables Include="RESOLVE_REPO_TOOLSET_SDK_DIR=$(ToolPackageExtractDir)$(RepoToolsetPackageId)\sdk\" />
       <EnvironmentVariables Include="RESOLVE_REPO_TOOLSET_SDK_VERSION=1.0.0-source-built" />
     </ItemGroup>
+  </Target>
+
+  <Target Name="ReportPrebuiltUsage">
+    <ItemGroup>
+      <AllRepoProjects Include="$(ProjectDir)repos\*.proj" />
+    </ItemGroup>
+
+    <Message Importance="High" Text="Finding project directories..." />
+
+    <MSBuild Projects="@(AllRepoProjects)"
+             Targets="GetProjectDirectory">
+      <Output TaskParameter="TargetOutputs" ItemName="ProjectDirectories" />
+    </MSBuild>
+
+    <ItemGroup>
+      <PrebuiltPackages Include="$(PrebuiltPackagesPath)*.nupkg" />
+      <PrebuiltPackages Include="$(TarballPrebuiltPackagesPath)*.nupkg" Condition="'$(TarballPrebuiltPackagesPath)' != ''"/>
+      <ProjectDirectories Include="$(ToolsDir);$(TaskDirectory);$(BaseIntermediatePath)" />
+      <!-- Scan the entire project, in case project.assets.json ends up in an unexpected place. -->
+      <ProjectDirectories Include="$(ProjectDir)" />
+    </ItemGroup>
+
+    <Message Importance="High" Text="Reading prebuilt nupkg identities..." />
+
+    <ReadNuGetPackageInfos PackagePaths="@(PrebuiltPackages)">
+      <Output TaskParameter="PackageInfoItems" ItemName="PrebuiltPackageInfoItems" />
+    </ReadNuGetPackageInfos>
+
+    <WritePackageUsageReportToFile NuGetPackageInfos="@(PrebuiltPackageInfoItems)"
+                                   ProjectDirectories="@(ProjectDirectories)"
+                                   OutputDirectory="$(PackageReportDir)" />
   </Target>
 
   <Target Name="GetProjectDirectory" Outputs="$(ProjectDirectory)" />

--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -87,7 +87,15 @@
     <Exec Command="git rev-list --count HEAD" WorkingDirectory="$(ProjectDirectory)" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="GitCommitCount" />
     </Exec>
-    <Exec Command="git log -1 --format=%25cd --date=short" WorkingDirectory="$(ProjectDirectory)" ConsoleToMSBuild="true">
+
+    <PropertyGroup>
+      <GitLogFormatArg>--format=</GitLogFormatArg>
+      <!-- Escape the % with another % on Windows. -->
+      <GitLogFormatArg Condition="'$(OS)' == 'Windows_NT'">$(GitLogFormatArg)%25</GitLogFormatArg>
+      <GitLogFormatArg>$(GitLogFormatArg)%25cd</GitLogFormatArg>
+    </PropertyGroup>
+
+    <Exec Command="git log -1 $(GitLogFormatArg) --date=short" WorkingDirectory="$(ProjectDirectory)" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="GitCommitDate" />
     </Exec>
 

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/Microsoft.DotNet.SourceBuild.Tasks.csproj
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/Microsoft.DotNet.SourceBuild.Tasks.csproj
@@ -34,6 +34,8 @@
     found when the task is loaded by the SDK's MSBuild.
   -->
   <PropertyGroup>
+    <!-- Read SDK_VERSION if not passed in. Enables Visual Studio builds. -->
+    <SDK_VERSION Condition="'$(SDK_VERSION)' == ''">$([System.IO.File]::ReadAllText('$(ProjectDir)DotnetCLIVersion.txt').Trim())</SDK_VERSION>
     <SdkReferenceDir>$(ToolsDir)dotnetcli/sdk/$(SDK_VERSION)/</SdkReferenceDir>
   </PropertyGroup>
 

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/ReadNuGetPackageInfos.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/ReadNuGetPackageInfos.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.SourceBuild.Tasks
+{
+    public class ReadNuGetPackageInfos : Task
+    {
+        [Required]
+        public string[] PackagePaths { get; set; }
+
+        /// <summary>
+        /// %(Identity): Path to the original nupkg.
+        /// %(PackageId): Identity of the package.
+        /// %(PackageVersion): Version of the package.
+        /// </summary>
+        [Output]
+        public ITaskItem[] PackageInfoItems { get; set; }
+
+        public override bool Execute()
+        {
+            PackageInfoItems = PackagePaths
+                .Select(p =>
+                {
+                    using (var reader = new PackageArchiveReader(p))
+                    {
+                        PackageIdentity identity = reader.GetIdentity();
+                        return new TaskItem(
+                            p,
+                            new Dictionary<string, string>
+                            {
+                                ["PackageId"] = identity.Id,
+                                ["PackageVersion"] = identity.Version.OriginalVersion
+                            });
+                    }
+                })
+                .ToArray();
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/WritePackageUsageReportToFile.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/WritePackageUsageReportToFile.cs
@@ -1,0 +1,207 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Task = Microsoft.Build.Utilities.Task;
+
+namespace Microsoft.DotNet.SourceBuild.Tasks
+{
+    public class WritePackageUsageReportToFile : Task
+    {
+        /// <summary>
+        /// %(PackageId): Identity of the package.
+        /// %(PackageVersion): Version of the package.
+        /// </summary>
+        [Required]
+        public ITaskItem[] NuGetPackageInfos { get; set; }
+
+        /// <summary>
+        /// Project directories to scan for project.assets.json files. If these directories contain
+        /// one another, the project.assets.json files is reported as belonging to the first project
+        /// directory that contains it. For useful results, put the leafmost directories first.
+        /// </summary>
+        [Required]
+        public string[] ProjectDirectories { get; set; }
+
+        [Required]
+        public string OutputDirectory { get; set; }
+
+        public override bool Execute()
+        {
+            string[] packageIdentities = NuGetPackageInfos
+                .Select(item => $"{item.GetMetadata("PackageId")}/{item.GetMetadata("PackageVersion")}")
+                .ToArray();
+
+            // Remove trailing slash from dir to avoid EnumerateFiles method adding slash twice,
+            // which would cause multiple unique paths per file and break the hash set.
+            ProjectDirectories = ProjectDirectories
+                .Where(Directory.Exists)
+                .Select(dir => dir.TrimEnd('/', '\\'))
+                .ToArray();
+
+            Log.LogMessage(MessageImportance.High, "Finding project.assets.json files...");
+
+            Dictionary<string, IEnumerable<string>> projectDirAssetFiles = ProjectDirectories
+                .ToDictionary(
+                    dir => dir,
+                    dir => Directory.EnumerateFiles(
+                        dir,
+                        "project.assets.json",
+                        SearchOption.AllDirectories));
+
+            Log.LogMessage(MessageImportance.High, "Reading usage info...");
+
+            var assetFileUsages = new ConcurrentDictionary<string, Usage[]>();
+
+            Parallel.ForEach(
+                projectDirAssetFiles.Values.SelectMany(v => v).Distinct(),
+                assetsFile =>
+                {
+                    string contents = File.ReadAllText(assetsFile);
+
+                    assetFileUsages.TryAdd(
+                        assetsFile,
+                        packageIdentities
+                            .Where(id => IsIdentityInText(id, contents))
+                            .Select(id => new Usage
+                            {
+                                AssetsFile = assetsFile,
+                                PackageIdentity = id
+                            })
+                            .ToArray());
+                });
+
+            Log.LogMessage(MessageImportance.High, "Associating usage info with projects...");
+
+            var usedAssetFiles = new HashSet<string>();
+            var usages = new List<Usage>();
+
+            foreach (string dir in ProjectDirectories)
+            {
+                foreach (string assetsFile in projectDirAssetFiles[dir])
+                {
+                    if (usedAssetFiles.Add(assetsFile))
+                    {
+                        foreach (var usage in assetFileUsages[assetsFile])
+                        {
+                            usage.ProjectDirectory = dir;
+                            usages.Add(usage);
+                        }
+                    }
+                }
+            }
+
+            Log.LogMessage(MessageImportance.High, $"Creating report XML in '{OutputDirectory}'...");
+
+            Directory.CreateDirectory(OutputDirectory);
+
+            File.WriteAllText(Path.Combine(OutputDirectory, "UsageSummary.xml"), new XElement(
+                "Usage",
+                GroupsToElements(usages, Grouping.Package, Grouping.Project)).ToString());
+
+            IEnumerable<XElement> unused = packageIdentities
+                .Where(id => !usages.Any(u => IsIdentityEqual(id, u.PackageIdentity)))
+                .Select(id => Node("Package", id, null));
+
+            File.WriteAllText(Path.Combine(OutputDirectory, "UsageDetails.xml"), new XElement(
+                "UsageReport",
+                new XElement(
+                    "Unknown",
+                    unused),
+                new XElement(
+                    "PackageUsages",
+                    GroupsToElements(usages, Grouping.Package, Grouping.Project, Grouping.AssetsFile)),
+                new XElement(
+                    "ProjectUsages",
+                    GroupsToElements(usages, Grouping.Project, Grouping.Package, Grouping.AssetsFile))).ToString());
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private static IEnumerable<XElement> GroupsToElements(
+            IEnumerable<Usage> usages,
+            params Grouping[] groupings)
+        {
+            return GroupsToElementsCore(usages, groupings);
+        }
+
+        private static IEnumerable<XElement> GroupsToElementsCore(
+            IEnumerable<Usage> usages,
+            IEnumerable<Grouping> groupings)
+        {
+            if (!groupings.Any())
+            {
+                return null;
+            }
+            Grouping grouping = groupings.First();
+            return usages
+                .GroupBy(grouping.GetKey)
+                .OrderBy(g => g.Key)
+                .Select(g => Node(
+                    grouping.Type,
+                    g.Key,
+                    GroupsToElementsCore(g, groupings.Skip(1))));
+        }
+
+        private static XElement Node(string type, string name, IEnumerable<XElement> children)
+        {
+            var node = new XElement(type, children);
+
+            if (!string.IsNullOrEmpty(name))
+            {
+                node.Add(new XAttribute("Name", name));
+            }
+
+            return node;
+        }
+
+        private static bool IsIdentityEqual(string identity, string other)
+        {
+            return string.Equals(identity, other, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsIdentityInText(string identity, string text)
+        {
+            return text.IndexOf(identity, StringComparison.OrdinalIgnoreCase) != -1;
+        }
+
+        private class Grouping
+        {
+            public static readonly Grouping Package = new Grouping
+            {
+                Type = nameof(Package),
+                GetKey = u => u.PackageIdentity
+            };
+
+            public static readonly Grouping AssetsFile = new Grouping
+            {
+                Type = nameof(AssetsFile),
+                GetKey = u => u.AssetsFile
+            };
+
+            public static readonly Grouping Project = new Grouping
+            {
+                Type = nameof(Project),
+                GetKey = u => u.ProjectDirectory
+            };
+
+            public string Type { get; set; }
+            public Func<Usage, string> GetKey { get; set; }
+        }
+
+        private class Usage
+        {
+            public string ProjectDirectory { get; set; }
+            public string AssetsFile { get; set; }
+            public string PackageIdentity { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
These reports look in the source tree for `project.assets.json` files that contain any of the prebuilt packages. The report runs in two parts of the build:

 * When running `build-source-tarball.sh`. This helps figure out why a prebuilt package was downloaded, and target efforts to remove them.
   * To disable this report, `export SOURCE_BUILD_SKIP_PREBUILT_REPORT=1`
 * After building the tarball (offline), see what was restored from the prebuilt dir in practice. This will likely be smaller than the online build. The diff between the online and offline report might show us some packages that are easy to get rid of.
   * To disable this report, pass `/p:SkipReportPrebuiltUsageAfterOfflineBuild=true`

(The reports take a minute, so I included skips in case they slow down a dev loop at some point.)

The report is two xml files:
 * [`UsageSummary.xml` (ex)](https://gist.github.com/dagood/dbbfc3ca129b9feb290063bc61976647): a list of prebuilt package id/versions and the project they were restored for.
 * [`UsageDetails.xml` (ex, (large!))](https://gist.github.com/dagood/40c15df3fcae1693a5a26448c50b8156): package identity, project, and `project.assets.json` file paths grouped in two ways for different types or drill-down. Also includes a list of prebuilt packages that weren't found in any `project.assets.json` file.

https://github.com/dotnet/source-build/issues/461