### PR TITLE
Force corefx to build identity and runtime packages

### DIFF
--- a/repos/corefx.proj
+++ b/repos/corefx.proj
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <BuildArguments>-$(Configuration) -buildArch=$(Platform) -portable=$(PortableBuild) -BuildTests=false</BuildArguments>
-    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments) -- /p:ILLinkTrimAssembly=false</BuildCommand>
+    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments) -- /p:ILLinkTrimAssembly=false /p:BuildingAnOfficialBuildLeg=false</BuildCommand>
     <BuildCommand Condition="$(Platform.Contains('arm'))">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
     <PackagesOutput>$(ProjectDirectory)/bin/packages/$(Configuration)</PackagesOutput>
     <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension)</CleanCommand>


### PR DESCRIPTION
@dseefeld this should fix the issue you are seeing with corefx not publishing packages.

Looks like when we tried to fix the corefx/coreclr package builds we based it off the wrong property.

https://github.com/dotnet/corefx/pull/28607
https://github.com/dotnet/coreclr/pull/17323

In those PR's we based it on DotNetBuildOffline but that is only set in the tarball not the source-build. We should instead update corefx and coreclr to use DotNetBuildFromSource for these conditions. I will submit a PR to change them. 

Note that I'm only workaround the corefx in this PR because we don't actually use the identity packages from coreclr in our other builds. 
