### PR TITLE
Update AspNetCore package version used by CLI to 2.1.0-rc1-final

### DIFF
--- a/patches/cli/0011-Set-AspNetCore-version-to-final.patch
+++ b/patches/cli/0011-Set-AspNetCore-version-to-final.patch
@@ -16,7 +16,7 @@ index 169f6163f..ca9d6bd80 100644
  <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
    <PropertyGroup>
 -    <MicrosoftAspNetCoreAllPackageVersion>2.1.0-rc1-30661</MicrosoftAspNetCoreAllPackageVersion>
-+    <MicrosoftAspNetCoreAllPackageVersion>2.1.0-preview2-final</MicrosoftAspNetCoreAllPackageVersion>
++    <MicrosoftAspNetCoreAllPackageVersion>2.1.0-rc1-final</MicrosoftAspNetCoreAllPackageVersion>
      <MicrosoftAspNetCoreAppPackageVersion>$(MicrosoftAspNetCoreAllPackageVersion)</MicrosoftAspNetCoreAppPackageVersion>
      <MicrosoftNETCoreAppPackageVersion>2.1.0-rc1-26423-06</MicrosoftNETCoreAppPackageVersion>
      <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>

--- a/patches/cli/0011-Set-AspNetCore-version-to-final.patch
+++ b/patches/cli/0011-Set-AspNetCore-version-to-final.patch
@@ -16,7 +16,7 @@ index 169f6163f..ca9d6bd80 100644
  <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
    <PropertyGroup>
 -    <MicrosoftAspNetCoreAllPackageVersion>2.1.0-rc1-30661</MicrosoftAspNetCoreAllPackageVersion>
-+    <MicrosoftAspNetCoreAllPackageVersion>2.1.0-rc1-final</MicrosoftAspNetCoreAllPackageVersion>
++    <MicrosoftAspNetCoreAllPackageVersion>2.1.0-rc1-30682</MicrosoftAspNetCoreAllPackageVersion>
      <MicrosoftAspNetCoreAppPackageVersion>$(MicrosoftAspNetCoreAllPackageVersion)</MicrosoftAspNetCoreAppPackageVersion>
      <MicrosoftNETCoreAppPackageVersion>2.1.0-rc1-26423-06</MicrosoftNETCoreAppPackageVersion>
      <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>


### PR DESCRIPTION
Update `2.1.0-preview2-final` to `2.1.0-rc1-final`.

I'm not sure how well this will work with `Microsoft.AspNetCore.All` `2.1.0-rc1-final` not being released yet.