### PR TITLE
Update smoke test to allow local restore source testing

### DIFF
--- a/smoke-testNuGet.Config
+++ b/smoke-testNuGet.Config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="source-built-packages" value="SOURCE_BUILT_PACKAGES" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Updated the smoke-test to provide options for testing both local restore sources and online restore sources.

Also, added a --minimal option to run just the non-web tests with local restore source.