### PR TITLE
Update msbuild version info to use property expected by repotoolset

### DIFF
--- a/repos/msbuild.proj
+++ b/repos/msbuild.proj
@@ -4,9 +4,9 @@
 
   <PropertyGroup>
     <!-- Override value from commit to match expected build. -->
-    <GitCommitDateNoDashes>20180426</GitCommitDateNoDashes>
+    <OfficialBuildId>20180426.1</OfficialBuildId>
     <PackagesOutput>$(ProjectDirectory)/artifacts/$(Configuration)/packages</PackagesOutput>
-    <OutputVersionArgs>/p:VersionBase=15.6.82 /p:DisableNerdbankVersioning=true /p:PreReleaseVersionLabel="preview2" /p:BUILD_BUILDNUMBER=$(GitCommitDateNoDashes).01</OutputVersionArgs>
+    <OutputVersionArgs>/p:VersionPrefix=15.6.82 /p:DisableNerdbankVersioning=true /p:PreReleaseVersionLabel="rc" /p:BUILD_BUILDNUMBER=$(OfficialBuildId)</OutputVersionArgs>
     <BuildCommand>$(ProjectDirectory)build/build$(ShellExtension) build -DotNetBuildFromSource -DotNetCoreSdkDir $(DotNetCliToolDir) -bootstraponly -skiptests -pack -configuration $(Configuration) /p:GitHeadSha=$(GitCommitHash) $(OutputVersionArgs)</BuildCommand>
     <SourceOverrideRepoApiImplemented>true</SourceOverrideRepoApiImplemented>
     <RepoApiImplemented>false</RepoApiImplemented>


### PR DESCRIPTION
msbuild was updated to use a newer version of repotoolset.  It now expects VersionPrefix instead of VersionBase.