### PR TITLE
Fix smoke test for OSX

### DIFF
--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -62,6 +62,7 @@ cp $SCRIPT_ROOT/*.props $TARBALL_ROOT/
 cp $SCRIPT_ROOT/*.targets $TARBALL_ROOT/
 cp $SCRIPT_ROOT/init-tools.msbuild $TARBALL_ROOT/
 cp $SCRIPT_ROOT/DotnetCLIVersion.txt $TARBALL_ROOT/
+cp $SCRIPT_ROOT/smoke-test* $TARBALL_ROOT/
 cp -r $SCRIPT_ROOT/keys $TARBALL_ROOT/
 cp -r $SCRIPT_ROOT/patches $TARBALL_ROOT/
 cp -r $SCRIPT_ROOT/scripts $TARBALL_ROOT/

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -4,10 +4,7 @@ set -e
 SCRIPT_ROOT="$(cd -P "$( dirname "$0" )" && pwd)"
 TARBALL_PREFIX=dotnet-sdk-
 VERSION_PREFIX=2.1
-OUTPUT_DIR="$SCRIPT_ROOT/bin/x64/Release/"
 SOURCE_BUILT_PKGS_PATH="$SCRIPT_ROOT/bin/obj/x64/Release/blob-feed/packages/"
-DOTNET_TARBALL_REL=$(ls ${OUTPUT_DIR}dotnet-sdk-${VERSION_PREFIX}*)
-DOTNET_TARBALL=$(readlink -e ${DOTNET_TARBALL_REL})
 
 projectOutput=false
 keepProjects=false
@@ -182,6 +179,10 @@ cd "$testingDir"
 
 # Unzip dotnet if the dotnetDir is not specified
 if [ "$dotnetDir" == "" ]; then
+    OUTPUT_DIR="$SCRIPT_ROOT/bin/x64/Release/"
+    DOTNET_TARBALL_REL=$(ls ${OUTPUT_DIR}dotnet-sdk-${VERSION_PREFIX}*)
+    DOTNET_TARBALL=$(readlink -e ${DOTNET_TARBALL_REL})
+
     mkdir -p "$cliDir"
     tar xzf "$DOTNET_TARBALL" -C "$cliDir"
     dotnetDir="$cliDir"
@@ -199,7 +200,7 @@ if [ "$excludeLocalTests" == "false" ]; then
     # Setup NuGet.Config with local restore source
     if [ -e "$SCRIPT_ROOT/smoke-testNuGet.Config" ]; then
         cp "$SCRIPT_ROOT/smoke-testNuGet.Config" "$testingDir/NuGet.Config"
-        sed -i "s|SOURCE_BUILT_PACKAGES|$SOURCE_BUILT_PKGS_PATH|g" "$testingDir/NuGet.Config"
+        sed -i.bak "s|SOURCE_BUILT_PACKAGES|$SOURCE_BUILT_PKGS_PATH|g" "$testingDir/NuGet.Config"
     fi
     echo "RUN ALL TESTS - LOCAL RESTORE SOURCE"
     runAllTests
@@ -213,7 +214,7 @@ if [ "$excludeOnlineTests" == "false" ]; then
     # Setup NuGet.Config to use online restore sources
     if [ -e "$SCRIPT_ROOT/smoke-testNuGet.Config" ]; then
         cp "$SCRIPT_ROOT/smoke-testNuGet.Config" "$testingDir/NuGet.Config"
-        sed -i "/SOURCE_BUILT_PACKAGES/d" "$testingDir/NuGet.Config"
+        sed -i.bak "/SOURCE_BUILT_PACKAGES/d" "$testingDir/NuGet.Config"
     fi
     echo "RUN ALL TESTS - ONLINE RESTORE SOURCE"
     runAllTests

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -180,7 +180,7 @@ cd "$testingDir"
 # Unzip dotnet if the dotnetDir is not specified
 if [ "$dotnetDir" == "" ]; then
     OUTPUT_DIR="$SCRIPT_ROOT/bin/x64/Release/"
-    DOTNET_TARBALL=$(ls ${OUTPUT_DIR}dotnet-sdk-${VERSION_PREFIX}*)
+    DOTNET_TARBALL="$(ls ${OUTPUT_DIR}dotnet-sdk-${VERSION_PREFIX}*)"
 
     mkdir -p "$cliDir"
     tar xzf "$DOTNET_TARBALL" -C "$cliDir"

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -180,8 +180,7 @@ cd "$testingDir"
 # Unzip dotnet if the dotnetDir is not specified
 if [ "$dotnetDir" == "" ]; then
     OUTPUT_DIR="$SCRIPT_ROOT/bin/x64/Release/"
-    DOTNET_TARBALL_REL=$(ls ${OUTPUT_DIR}dotnet-sdk-${VERSION_PREFIX}*)
-    DOTNET_TARBALL=$(readlink -e ${DOTNET_TARBALL_REL})
+    DOTNET_TARBALL=$(ls ${OUTPUT_DIR}dotnet-sdk-${VERSION_PREFIX}*)
 
     mkdir -p "$cliDir"
     tar xzf "$DOTNET_TARBALL" -C "$cliDir"


### PR DESCRIPTION
Update sed command, since OSX expects an extension on the -i command.
Remove usage of readlink, since path is already absolute.