### PR TITLE
Improve prebuilt package report

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -31,11 +31,19 @@
   <Target Name="ReportPrebuiltUsageAfterOfflineBuild"
           AfterTargets="Build"
           Condition="'$(OfflineBuild)' == 'true' and '$(SkipReportPrebuiltUsageAfterOfflineBuild)' != 'true'">
-    <MSBuild Projects="repos\$(RootRepo).proj" Targets="ReportPrebuiltUsage" />
+    <MSBuild Projects="repos\$(RootRepo).proj" Targets="WritePrebuiltUsageData;ReportPrebuiltUsage" />
   </Target>
 
   <!-- After generating a tarball, check why/where the online build downloaded prebuilts. -->
   <Target Name="ReportTarballPrebuiltUsage">
+    <MSBuild Projects="repos\$(RootRepo).proj" Targets="WritePrebuiltUsageData;ReportPrebuiltUsage" />
+  </Target>
+
+  <!--
+    Dev scenario: regenerate a prebuilt-report. This makes it easy to add data to an existing
+    prebuilt report without performing another full build.
+  -->
+  <Target Name="CreatePrebuiltUsageReport">
     <MSBuild Projects="repos\$(RootRepo).proj" Targets="ReportPrebuiltUsage" />
   </Target>
 

--- a/dir.props
+++ b/dir.props
@@ -64,7 +64,10 @@
     <GitInfoOutputDir>$(BaseOutputPath)git-info/</GitInfoOutputDir>
     <!-- Dir where git info is placed inside the tarball. -->
     <GitInfoOfflineDir>$(ProjectDir)git-info/</GitInfoOfflineDir>
-    <PackageReportDir>$(BaseOutputPath)prebuilt-report</PackageReportDir>
+    <PackageReportDir>$(BaseOutputPath)prebuilt-report/</PackageReportDir>
+    <PackageReportDataFile>$(PackageReportDir)prebuilt-usage.json</PackageReportDataFile>
+    <ProdConManifestFile>$(PackageReportDir)prodcon-build.xml</ProdConManifestFile>
+    <PoisonedReportFile>$(PackageReportDir)poisoned.txt</PoisonedReportFile>
   </PropertyGroup>
 
   <!-- Import Build tools common props file where repo-independent properties are found -->

--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -11,8 +11,9 @@
   <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="RemoveInternetSourcesFromNuGetConfig" />
   <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="UpdateJson" />
   <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="WriteBuildOutputProps" />
-  <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="WritePackageUsageReportToFile" />
+  <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="WritePackageUsageData" />
   <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="WriteRestoreSourceProps" />
+  <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="WriteUsageReports" />
   <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="WriteVersionsFile" />
   <UsingTask AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" TaskName="ZipFileExtractToDirectory" />
 
@@ -158,6 +159,9 @@
     </ItemGroup>
     <WriteBuildOutputProps NuGetPackages="@(_PreviouslySourceBuiltPackages)"
                            OutputPath="$(PackageVersionPropsPath)" />
+
+    <WriteBuildOutputProps NuGetPackages="@(_PreviouslySourceBuiltPackages)"
+                           OutputPath="$(PackageVersionPropsPath).pre.$(RepositoryName).xml" />
 
     <ReadLinesFromFile File="$(PackageVersionPropsPath)">
       <Output TaskParameter="Lines" ItemName="VersionProperties" />
@@ -313,7 +317,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="ReportPrebuiltUsage">
+  <Target Name="WritePrebuiltUsageData">
     <ItemGroup>
       <AllRepoProjects Include="$(ProjectDir)repos\*.proj" />
     </ItemGroup>
@@ -328,10 +332,15 @@
     <ItemGroup>
       <PrebuiltPackages Include="$(PrebuiltPackagesPath)*.nupkg" />
       <PrebuiltPackages Include="$(TarballPrebuiltPackagesPath)*.nupkg" Condition="'$(TarballPrebuiltPackagesPath)' != ''"/>
+
+      <PackageVersionPropsSnapshotSourceFiles Include="$(IntermediatePath)PackageVersions.props.pre.*.xml" />
+
       <ProjectDirectories Include="$(ToolsDir);$(TaskDirectory);$(BaseIntermediatePath)" />
       <!-- Scan the entire project, in case project.assets.json ends up in an unexpected place. -->
       <ProjectDirectories Include="$(ProjectDir)" />
     </ItemGroup>
+
+    <Copy SourceFiles="@(PackageVersionPropsSnapshotSourceFiles)" DestinationFolder="$(PackageReportDir)" />
 
     <Message Importance="High" Text="Reading prebuilt nupkg identities..." />
 
@@ -339,10 +348,25 @@
       <Output TaskParameter="PackageInfoItems" ItemName="PrebuiltPackageInfoItems" />
     </ReadNuGetPackageInfos>
 
-    <WritePackageUsageReportToFile NuGetPackageInfos="@(PrebuiltPackageInfoItems)"
-                                   ProjectDirectories="@(ProjectDirectories)"
-                                   OutputDirectory="$(PackageReportDir)" />
+    <WritePackageUsageData NuGetPackageInfos="@(PrebuiltPackageInfoItems)"
+                           ProjectDirectories="@(ProjectDirectories)"
+                           DataFile="$(PackageReportDataFile)" />
   </Target>
+
+  <Target Name="ReportPrebuiltUsage"
+          DependsOnTargets="GetPreviousReleasePrebuiltPackageInfos">
+    <ItemGroup>
+      <PackageVersionPropsSnapshotFiles Include="$(PackageReportDir)PackageVersions.props.pre.*.xml" />
+    </ItemGroup>
+    <WriteUsageReports DataFile="$(PackageReportDataFile)"
+                       PackageVersionPropsSnapshots="@(PackageVersionPropsSnapshotFiles)"
+                       ProdConBuildManifestFile="$(ProdConManifestFile)"
+                       PoisonedReportFile="$(PoisonedReportFile)"
+                       PreviousReleasePrebuiltPackageInfos="@(PreviousReleasePrebuiltPackageInfos)"
+                       OutputDirectory="$(PackageReportDir)" />
+  </Target>
+
+  <Import Project="$(ProjectDir)tools-local/earlier-prebuilts.targets" />
 
   <Target Name="GetProjectDirectory" Outputs="$(ProjectDirectory)" />
   <Target Name="GetOrchestratedManifestBuildName" Outputs="$(OrchestratedManifestBuildName)" />

--- a/tools-local/earlier-prebuilts.targets
+++ b/tools-local/earlier-prebuilts.targets
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="GetPreviousReleasePrebuiltPackageInfos">
+    <ItemGroup>
+      <_PrebuiltIn20 Include="Microsoft.Build.Localization" PackageVersion="15.4.8" />
+      <_PrebuiltIn20 Include="Microsoft.DotNet.Build.Tasks.Feed" PackageVersion="2.1.0-prerelease-02221-02" />
+      <_PrebuiltIn20 Include="Microsoft.DotNet.PlatformAbstractions" PackageVersion="1.0.3" />
+      <_PrebuiltIn20 Include="Microsoft.DotNet.PlatformAbstractions" PackageVersion="1.1.1" />
+      <_PrebuiltIn20 Include="Microsoft.DotNet.PlatformAbstractions" PackageVersion="2.0.0" />
+      <_PrebuiltIn20 Include="Microsoft.DotNet.Web.ItemTemplates" PackageVersion="1.0.0-beta2-20170810-304" />
+      <_PrebuiltIn20 Include="Microsoft.DotNet.Web.ProjectTemplates.2.0" PackageVersion="1.0.0-beta2-20170810-304" />
+      <_PrebuiltIn20 Include="Microsoft.Extensions.DependencyModel" PackageVersion="1.1.1" />
+      <_PrebuiltIn20 Include="Microsoft.Extensions.DependencyModel" PackageVersion="2.0.0" />
+      <_PrebuiltIn20 Include="Microsoft.NET.Test.Sdk" PackageVersion="15.0.0" />
+      <_PrebuiltIn20 Include="Microsoft.NETCore.App" PackageVersion="1.1.2" />
+      <_PrebuiltIn20 Include="Microsoft.NETCore.App" PackageVersion="2.0.0" />
+      <_PrebuiltIn20 Include="Microsoft.NETCore.DotNetAppHost" PackageVersion="2.0.0" />
+      <_PrebuiltIn20 Include="Microsoft.NETCore.DotNetAppHost" PackageVersion="2.0.1-servicing-25615-03" />
+      <_PrebuiltIn20 Include="Microsoft.NETCore.DotNetHost" PackageVersion="2.0.1-servicing-25615-03" />
+      <_PrebuiltIn20 Include="Microsoft.NETCore.DotNetHostPolicy" PackageVersion="2.0.0" />
+      <_PrebuiltIn20 Include="Microsoft.NETCore.DotNetHostPolicy" PackageVersion="2.0.1-servicing-25615-03" />
+      <_PrebuiltIn20 Include="Microsoft.NETCore.DotNetHostResolver" PackageVersion="2.0.0" />
+      <_PrebuiltIn20 Include="Microsoft.NETCore.DotNetHostResolver" PackageVersion="2.0.1-servicing-25615-03" />
+      <_PrebuiltIn20 Include="Microsoft.NETCore.Platforms" PackageVersion="1.0.2-beta-24224-02" />
+      <_PrebuiltIn20 Include="Microsoft.NETCore.Platforms" PackageVersion="2.0.0" />
+      <_PrebuiltIn20 Include="Microsoft.Private.Intellisense" PackageVersion="2.0.0-preview3-25511-0" />
+      <_PrebuiltIn20 Include="Microsoft.TargetingPack.NETFramework.v4.6.1" PackageVersion="1.0.1" />
+      <_PrebuiltIn20 Include="Microsoft.TargetingPack.NETFramework.v4.6.2" PackageVersion="1.0.1" />
+      <_PrebuiltIn20 Include="Microsoft.TargetingPack.NETFramework.v4.6" PackageVersion="1.0.1" />
+      <_PrebuiltIn20 Include="Microsoft.TargetingPack.NETFramework.v4.7" PackageVersion="1.0.1" />
+      <_PrebuiltIn20 Include="Microsoft.TestPlatform.ObjectModel" PackageVersion="15.0.0" />
+      <_PrebuiltIn20 Include="Microsoft.TestPlatform.TestHost" PackageVersion="15.0.0" />
+      <_PrebuiltIn20 Include="NETStandard.Library.NETFramework" PackageVersion="2.0.0-preview3-25514-04" />
+      <_PrebuiltIn20 Include="NETStandard.Library.NETFramework" PackageVersion="2.0.0-preview3-25519-03" />
+      <_PrebuiltIn20 Include="NETStandard.Library.NETFramework" PackageVersion="2.0.1-servicing-26011-01" />
+      <_PrebuiltIn20 Include="NETStandard.Library" PackageVersion="2.0.0" />
+      <_PrebuiltIn20 Include="NuGet.Commands" PackageVersion="4.6.0-rtm-4918" />
+      <_PrebuiltIn20 Include="NuGet.Common" PackageVersion="4.3.0-rtm-4324" />
+      <_PrebuiltIn20 Include="NuGet.Common" PackageVersion="4.6.0-rtm-4918" />
+      <_PrebuiltIn20 Include="NuGet.Configuration" PackageVersion="4.3.0-rtm-4324" />
+      <_PrebuiltIn20 Include="NuGet.Configuration" PackageVersion="4.6.0-rtm-4918" />
+      <_PrebuiltIn20 Include="NuGet.DependencyResolver.Core" PackageVersion="4.3.0-rtm-4324" />
+      <_PrebuiltIn20 Include="NuGet.DependencyResolver.Core" PackageVersion="4.6.0-rtm-4918" />
+      <_PrebuiltIn20 Include="NuGet.Frameworks" PackageVersion="4.3.0-rtm-4324" />
+      <_PrebuiltIn20 Include="NuGet.Frameworks" PackageVersion="4.6.0-rtm-4918" />
+      <_PrebuiltIn20 Include="NuGet.LibraryModel" PackageVersion="4.3.0-rtm-4324" />
+      <_PrebuiltIn20 Include="NuGet.LibraryModel" PackageVersion="4.6.0-rtm-4918" />
+      <_PrebuiltIn20 Include="NuGet.Packaging.Core" PackageVersion="4.3.0-rtm-4324" />
+      <_PrebuiltIn20 Include="NuGet.Packaging.Core" PackageVersion="4.6.0-rtm-4918" />
+      <_PrebuiltIn20 Include="NuGet.Packaging" PackageVersion="4.3.0-rtm-4324" />
+      <_PrebuiltIn20 Include="NuGet.Packaging" PackageVersion="4.6.0-rtm-4918" />
+      <_PrebuiltIn20 Include="NuGet.ProjectModel" PackageVersion="4.3.0-rtm-4324" />
+      <_PrebuiltIn20 Include="NuGet.ProjectModel" PackageVersion="4.6.0-rtm-4918" />
+      <_PrebuiltIn20 Include="NuGet.Protocol" PackageVersion="4.3.0-rtm-4324" />
+      <_PrebuiltIn20 Include="NuGet.Protocol" PackageVersion="4.6.0-rtm-4918" />
+      <_PrebuiltIn20 Include="NuGet.Versioning" PackageVersion="4.3.0-rtm-4324" />
+      <_PrebuiltIn20 Include="NuGet.Versioning" PackageVersion="4.6.0-rtm-4918" />
+      <_PrebuiltIn20 Include="runtime.linux-x64.Microsoft.NETCore.DotNetAppHost" PackageVersion="2.0.0" />
+      <_PrebuiltIn20 Include="runtime.linux-x64.Microsoft.NETCore.DotNetAppHost" PackageVersion="2.0.1-servicing-25615-03" />
+      <_PrebuiltIn20 Include="runtime.linux-x64.Microsoft.NETCore.DotNetHost" PackageVersion="2.0.1-servicing-25615-03" />
+      <_PrebuiltIn20 Include="runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy" PackageVersion="2.0.0" />
+      <_PrebuiltIn20 Include="runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy" PackageVersion="2.0.1-servicing-25615-03" />
+      <_PrebuiltIn20 Include="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" PackageVersion="2.0.0" />
+      <_PrebuiltIn20 Include="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" PackageVersion="2.0.1-servicing-25615-03" />
+      <_PrebuiltIn20 Include="runtime.native.System.Data.SqlClient.sni" PackageVersion="4.4.0" />
+      <_PrebuiltIn20 Include="runtime.win-arm64.runtime.native.System.Data.SqlClient.sni" PackageVersion="4.4.0" />
+      <_PrebuiltIn20 Include="runtime.win-x64.runtime.native.System.Data.SqlClient.sni" PackageVersion="4.4.0" />
+      <_PrebuiltIn20 Include="runtime.win-x86.runtime.native.System.Data.SqlClient.sni" PackageVersion="4.4.0" />
+      <_PrebuiltIn20 Include="System.Buffers" PackageVersion="4.3.0" />
+      <_PrebuiltIn20 Include="System.Collections.Immutable" PackageVersion="1.3.0" />
+      <_PrebuiltIn20 Include="System.ComponentModel.EventBasedAsync" PackageVersion="4.0.11" />
+      <_PrebuiltIn20 Include="System.ComponentModel.Primitives" PackageVersion="4.1.0" />
+      <_PrebuiltIn20 Include="System.ComponentModel.TypeConverter" PackageVersion="4.1.0" />
+      <_PrebuiltIn20 Include="System.Diagnostics.DiagnosticSource" PackageVersion="4.3.1" />
+      <_PrebuiltIn20 Include="System.Diagnostics.TextWriterTraceListener" PackageVersion="4.0.0" />
+      <_PrebuiltIn20 Include="System.IO.Pipes.AccessControl" PackageVersion="4.3.0" />
+      <_PrebuiltIn20 Include="System.Linq" PackageVersion="4.3.0" />
+      <_PrebuiltIn20 Include="System.Net.Http" PackageVersion="4.3.2" />
+      <_PrebuiltIn20 Include="System.Net.Security" PackageVersion="4.3.1" />
+      <_PrebuiltIn20 Include="System.Reflection.Metadata" PackageVersion="1.4.1" />
+      <_PrebuiltIn20 Include="System.Runtime.Serialization.Json" PackageVersion="4.0.2" />
+      <_PrebuiltIn20 Include="System.Runtime.Serialization.Primitives" PackageVersion="4.1.1" />
+      <_PrebuiltIn20 Include="System.Security.Cryptography.ProtectedData" PackageVersion="4.0.0" />
+      <_PrebuiltIn20 Include="System.Text.Encoding.CodePages" PackageVersion="4.3.0" />
+      <_PrebuiltIn20 Include="System.Threading" PackageVersion="4.3.0" />
+      <_PrebuiltIn20 Include="System.Xml.XPath.XmlDocument" PackageVersion="4.0.1" />
+      <_PrebuiltIn20 Include="XliffTasks" PackageVersion="0.2.0-beta-000042" />
+
+      <PreviousReleasePrebuiltPackageInfos Include="@(_PrebuiltIn20)"
+                                           PackageId="%(_PrebuiltIn20.Identity)"
+                                           Release="2.0" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/Usage.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/Usage.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
+{
+    public class Usage
+    {
+        public string ProjectDirectory { get; set; }
+        public string AssetsFile { get; set; }
+        public string PackageIdentity { get; set; }
+
+        public UsageAnnotation Annotation { get; set; }
+    }
+}

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/UsageAnnotation.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/UsageAnnotation.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
+{
+    public class UsageAnnotation
+    {
+        public string SourceBuildPackageIdCreator { get; set; }
+        public string ProdConPackageIdCreator { get; set; }
+        public string InEarlierReleaseExactPrebuilt { get; set; }
+        public bool EndsUpInOutput { get; set; }
+
+        public IEnumerable<XObject> CreatePackageAnnotations()
+        {
+            if (!string.IsNullOrEmpty(SourceBuildPackageIdCreator))
+            {
+                yield return new XElement(
+                    nameof(SourceBuildPackageIdCreator),
+                    new XText(SourceBuildPackageIdCreator));
+            }
+            if (!string.IsNullOrEmpty(ProdConPackageIdCreator))
+            {
+                yield return new XElement(
+                    nameof(ProdConPackageIdCreator),
+                    new XText(ProdConPackageIdCreator));
+            }
+            if (!string.IsNullOrEmpty(InEarlierReleaseExactPrebuilt))
+            {
+                yield return new XElement(
+                    nameof(InEarlierReleaseExactPrebuilt),
+                    new XText(InEarlierReleaseExactPrebuilt));
+            }
+            if (EndsUpInOutput)
+            {
+                yield return new XAttribute("PoisonEndsUpInOutput", true);
+            }
+        }
+    }
+}

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/UsageData.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/UsageData.cs
@@ -1,0 +1,85 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
+{
+    public class UsageData
+    {
+        public string[] UnusedPackages { get; set; }
+        public Usage[] Usages { get; set; }
+
+        public XElement CreateSummaryReport()
+        {
+            return new XElement(
+                "UsageSummary",
+                GroupsToElements(
+                    Usages,
+                    new UsageGrouping.Package(),
+                    new UsageGrouping.Project()));
+        }
+
+        public XElement CreateDetailedReport()
+        {
+            return new XElement(
+                "UsageDetails",
+                new XElement(
+                    "Unknown",
+                    UnusedPackages.Select(id => Node("Package", id, null))),
+                new XElement(
+                    "PackageUsages",
+                    GroupsToElements(
+                        Usages,
+                        new UsageGrouping.Package(),
+                        new UsageGrouping.Project(),
+                        new UsageGrouping.AssetsFile())),
+                new XElement(
+                    "ProjectUsages",
+                    GroupsToElements(
+                        Usages,
+                        new UsageGrouping.Project(),
+                        new UsageGrouping.Package(),
+                        new UsageGrouping.AssetsFile())));
+        }
+
+        private static IEnumerable<XElement> GroupsToElements(
+            IEnumerable<Usage> usages,
+            params UsageGrouping[] groupings)
+        {
+            return GroupsToElementsCore(usages, groupings);
+        }
+
+        private static IEnumerable<XElement> GroupsToElementsCore(
+            IEnumerable<Usage> usages,
+            IEnumerable<UsageGrouping> groupings)
+        {
+            if (!groupings.Any())
+            {
+                return null;
+            }
+            UsageGrouping grouping = groupings.First();
+            return usages
+                .GroupBy(grouping.GetKey)
+                .OrderBy(g => g.Key)
+                .Select(g => grouping.CreateNode(
+                    g.First(),
+                    GroupsToElementsCore(g, groupings.Skip(1))));
+        }
+
+        private static XElement Node(string type, string name, IEnumerable<XElement> children)
+        {
+            var node = new XElement(type, children);
+
+            if (!string.IsNullOrEmpty(name))
+            {
+                node.Add(new XAttribute("Name", name));
+            }
+
+            return node;
+        }
+    }
+}

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/UsageGrouping.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/UsageGrouping.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
+{
+    public abstract class UsageGrouping
+    {
+        public class Package : UsageGrouping
+        {
+            public override string Type => nameof(Package);
+            public override string GetKey(Usage u) => u.PackageIdentity;
+
+            public override XElement CreateNode(Usage usage, IEnumerable<XObject> children)
+            {
+                IEnumerable<XObject> annotations = usage
+                    ?.Annotation.CreatePackageAnnotations()
+                    ?? Enumerable.Empty<XObject>();
+
+                return base.CreateNode(usage, annotations.Concat(children));
+            }
+        }
+
+        public class AssetsFile : UsageGrouping
+        {
+            public override string Type => nameof(AssetsFile);
+            public override string GetKey(Usage u) => u.AssetsFile;
+        }
+
+        public class Project : UsageGrouping
+        {
+            public override string Type => nameof(Project);
+            public override string GetKey(Usage u) => u.ProjectDirectory;
+        };
+
+        public abstract string Type { get; }
+        public abstract string GetKey(Usage usage);
+
+        public virtual XElement CreateNode(Usage usage, IEnumerable<XObject> children)
+        {
+            var node = new XElement(Type);
+            node.Add(new XAttribute("Name", GetKey(usage)));
+            node.Add(children);
+            return node;
+        }
+    }
+}

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/WriteUsageReports.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/WriteUsageReports.cs
@@ -1,0 +1,279 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.DotNet.Build.Tasks;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using Task = Microsoft.Build.Utilities.Task;
+
+namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
+{
+    public class WriteUsageReports : Task
+    {
+        private const string SnapshotPrefix = "PackageVersions.props.pre.";
+        private const string SnapshotSuffix = ".xml";
+
+        /// <summary>
+        /// Source usage data JSON file.
+        /// </summary>
+        [Required]
+        public string DataFile { get; set; }
+
+        [Required]
+        public string OutputDirectory { get; set; }
+
+        /// <summary>
+        /// A set of "PackageVersions.props.pre.{repo}.xml" files. They are analyzed to find
+        /// packages built during source-build, and which repo built them. This info is added to the
+        /// report. New packages are associated to a repo by going through each PVP in ascending
+        /// file modification order.
+        /// </summary>
+        public ITaskItem[] PackageVersionPropsSnapshots { get; set; }
+
+        /// <summary>
+        /// Infos that associate packages to the ProdCon build they're from.
+        /// 
+        /// %(PackageId): Identity of the package.
+        /// %(OriginBuildName): Name of the build that produced this package.
+        /// </summary>
+        public ITaskItem[] ProdConPackageInfos { get; set; }
+
+        /// <summary>
+        /// Path to a ProdCon build manifest file (build.xml) as an alternative way to pass
+        /// ProdConPackageInfos items.
+        /// </summary>
+        public string ProdConBuildManifestFile { get; set; }
+
+        /// <summary>
+        /// Infos for packages that were approved as prebuilts in an earlier release.
+        /// 
+        /// %(PackageId): Identity of the package.
+        /// %(PackageVersion): Version of the package.
+        /// %(Release): Name of the earlier release, e.g. "2.0".
+        /// </summary>
+        public ITaskItem[] PreviousReleasePrebuiltPackageInfos { get; set; }
+
+        /// <summary>
+        /// File containing the results of poisoning the prebuilts. Example format:
+        /// 
+        /// MATCH: output built\dotnet-sdk-...\System.Collections.dll(hash 4b...31) matches one of:
+        ///     intermediate\netstandard.library.2.0.1.nupkg\build\...\System.Collections.dll
+        /// 
+        /// The usage report reads this file, looking for 'intermediate\*.nupkg' to annotate.
+        /// </summary>
+        public string PoisonedReportFile { get; set; }
+
+        public override bool Execute()
+        {
+            UsageData data = JObject.Parse(File.ReadAllText(DataFile)).ToObject<UsageData>();
+
+            IEnumerable<RepoOutput> sourceBuildRepoOutputs = GetSourceBuildRepoOutputs();
+
+            // Map package id to the build name that created them in a ProdCon build.
+            var prodConPackageOrigin = new Dictionary<string, string>(
+                StringComparer.OrdinalIgnoreCase);
+
+            foreach (ITaskItem item in ProdConPackageInfos ?? Enumerable.Empty<ITaskItem>())
+            {
+                AddProdConPackage(
+                    prodConPackageOrigin,
+                    item.GetMetadata("PackageId"),
+                    item.GetMetadata("OriginBuildName"));
+            }
+
+            if (File.Exists(ProdConBuildManifestFile))
+            {
+                var xml = XElement.Parse(File.ReadAllText(ProdConBuildManifestFile));
+                foreach (var x in xml.Descendants("Package"))
+                {
+                    AddProdConPackage(
+                        prodConPackageOrigin,
+                        x.Attribute("Id")?.Value,
+                        x.Attribute("OriginBuildName")?.Value);
+                }
+            }
+
+            PreviousReleasePrebuilt[] previousReleasePrebuilts = PreviousReleasePrebuiltPackageInfos
+                ?.Select(item => new PreviousReleasePrebuilt
+                {
+                    Id = item.GetMetadata("PackageId"),
+                    Version = item.GetMetadata("PackageVersion"),
+                    Release = item.GetMetadata("Release")
+                })
+                .ToArray();
+
+            var poisonNupkgFilenames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            if (File.Exists(PoisonedReportFile))
+            {
+                foreach (string line in File.ReadAllLines(PoisonedReportFile))
+                {
+                    string[] segments = line.Split('\\');
+                    if (segments.Length > 2 &&
+                        segments[0].Trim() == "intermediate" &&
+                        segments[1].EndsWith(".nupkg"))
+                    {
+                        poisonNupkgFilenames.Add(Path.GetFileNameWithoutExtension(segments[1]));
+                    }
+                }
+            }
+
+            foreach (Usage usage in data.Usages)
+            {
+                string[] identity = usage.PackageIdentity.Split('/');
+                if (identity.Length != 2)
+                {
+                    Log.LogWarning(
+                        $"Data file contains invalid package identity '{usage.PackageIdentity}'. " +
+                        "Expected 2 segments when split by '/'.");
+                    continue;
+                }
+
+                string id = identity[0];
+                string version = identity[1];
+
+                string pvpIdent = WriteBuildOutputProps.GetPropertyName(id);
+
+                var sourceBuildCreator = new StringBuilder();
+                foreach (RepoOutput output in sourceBuildRepoOutputs)
+                {
+                    foreach (PackageVersionPropsElement p in output.Built)
+                    {
+                        if (p.Name.Equals(pvpIdent, StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (sourceBuildCreator.Length != 0)
+                            {
+                                sourceBuildCreator.Append(" ");
+                            }
+                            sourceBuildCreator.Append(output.Repo);
+                            sourceBuildCreator.Append(" ");
+                            sourceBuildCreator.Append(p.Name);
+                            sourceBuildCreator.Append("/");
+                            sourceBuildCreator.Append(p.Version);
+                        }
+                    }
+                }
+
+                prodConPackageOrigin.TryGetValue(id, out string prodConCreator);
+
+                string previousReleasePrebuilt = previousReleasePrebuilts
+                    ?.FirstOrDefault(p => p.Matches(id, version))
+                    ?.Release;
+
+                usage.Annotation = new UsageAnnotation
+                {
+                    SourceBuildPackageIdCreator = sourceBuildCreator.ToString(),
+                    ProdConPackageIdCreator = prodConCreator,
+                    InEarlierReleaseExactPrebuilt = previousReleasePrebuilt,
+                    EndsUpInOutput = poisonNupkgFilenames.Contains($"{id}.{version}")
+                };
+            }
+
+            Directory.CreateDirectory(OutputDirectory);
+
+            File.WriteAllText(
+                Path.Combine(OutputDirectory, "UsageSummary.xml"),
+                data.CreateSummaryReport().ToString());
+
+            File.WriteAllText(
+                Path.Combine(OutputDirectory, "UsageDetails.xml"),
+                data.CreateDetailedReport().ToString());
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private IEnumerable<RepoOutput> GetSourceBuildRepoOutputs()
+        {
+            if (PackageVersionPropsSnapshots == null)
+            {
+                return Enumerable.Empty<RepoOutput>();
+            }
+
+            var pvpSnapshotFiles = PackageVersionPropsSnapshots
+                .Select(item => item.ItemSpec)
+                .OrderBy(File.GetLastWriteTimeUtc)
+                .Select(file =>
+                {
+                    string filename = Path.GetFileName(file);
+                    return new
+                    {
+                        Repo = filename.Substring(
+                            SnapshotPrefix.Length,
+                            filename.Length - SnapshotPrefix.Length - SnapshotSuffix.Length),
+                        PackageVersionProp = PackageVersionPropsElement.ParseFileElements(file)
+                    };
+                })
+                .ToArray();
+
+            return pvpSnapshotFiles.Skip(1)
+                .Zip(pvpSnapshotFiles, (pvp, prev) => new RepoOutput
+                {
+                    Repo = prev.Repo,
+                    Built = pvp.PackageVersionProp.Except(prev.PackageVersionProp).ToArray()
+                })
+                .ToArray();
+        }
+
+        private void AddProdConPackage(
+            Dictionary<string, string> packageOrigin,
+            string id,
+            string origin)
+        {
+            if (!string.IsNullOrEmpty(id) &&
+                !string.IsNullOrEmpty(origin))
+            {
+                packageOrigin[id] = origin;
+            }
+        }
+
+        private class RepoOutput
+        {
+            public string Repo { get; set; }
+            public PackageVersionPropsElement[] Built { get; set; }
+        }
+
+        private struct PackageVersionPropsElement
+        {
+            public static PackageVersionPropsElement[] ParseFileElements(string file)
+            {
+                return XElement.Parse(File.ReadAllText(file))
+                    // Get the single PropertyGroup
+                    .Nodes().OfType<XElement>()
+                    .First()
+                    // Get all *PackageVersion property elements.
+                    .Nodes().OfType<XElement>()
+                    .Select(x => new PackageVersionPropsElement(
+                        x.Name.LocalName,
+                        x.Nodes().OfType<XText>().First().Value))
+                    .ToArray();
+            }
+
+            public string Name { get; }
+            public string Version { get; }
+
+            public PackageVersionPropsElement(string name, string version)
+            {
+                Name = name;
+                Version = version;
+            }
+        }
+
+        private class PreviousReleasePrebuilt
+        {
+            public string Id { get; set; }
+            public string Version { get; set; }
+            public string Release { get; set; }
+
+            public bool Matches(string id, string version) =>
+                Id.Equals(id, StringComparison.OrdinalIgnoreCase) &&
+                Version.Equals(version, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}


### PR DESCRIPTION
Include additional information when available. Split report process into two stages: allow regenerating the report on a different machine with additional information.

I've been using this to generate reports with the extra info by copying `bin/prebuilt-report` to my local (Windows) repo `bin/prebuilt-report`, adding in a `build.xml` from dotnet/versions and `poisoned.txt` from @crummel, and running `.\build.cmd /t:CreatePrebuiltUsageReport`.