### PR TITLE
Add web to smoke-test, with and without dev certs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -13,8 +13,13 @@ def addBuildStepsAndSetMachineAffinity(def job, String os, String configuration)
       }
       else {
         shell("git submodule update --init --recursive");
-        shell("./build.sh /p:Configuration=${configuration} ${loggingOptions}")
-        shell("./smoke-test.sh --minimal --projectOutput --configuration ${configuration}")
+        shell("./build.sh /p:Configuration=${configuration} ${loggingOptions}");
+        smokeTestExcludes = "";
+        if (os == "Fedora24" || os == "OSX10.12") {
+          // Dev certs doesn't seem to work in these platforms. https://github.com/dotnet/source-build/issues/560
+          smokeTestExcludes += " --excludeWebHttpsTests";
+        }
+        shell("./smoke-test.sh --minimal --projectOutput --configuration ${configuration} ${smokeTestExcludes}");
       }
     };
   };

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -286,10 +286,9 @@ export NUGET_PACKAGES="$restoredPackagesDir"
 SOURCE_BUILT_PKGS_PATH="$SCRIPT_ROOT/bin/obj/x64/$configuration/blob-feed/packages/"
 prodConFeedUrl="$(cat "$SCRIPT_ROOT/ProdConFeed.txt")"
 
-resetCaches
-
 # Run all tests, local restore sources first, online restore sources second
 if [ "$excludeLocalTests" == "false" ]; then
+    resetCaches
     # Setup NuGet.Config with local restore source
     if [ -e "$SCRIPT_ROOT/smoke-testNuGet.Config" ]; then
         cp "$SCRIPT_ROOT/smoke-testNuGet.Config" "$testingDir/NuGet.Config"
@@ -303,9 +302,8 @@ if [ "$excludeLocalTests" == "false" ]; then
     echo "LOCAL RESTORE SOURCE - ALL TESTS PASSED!"
 fi
 
-resetCaches
-
 if [ "$excludeOnlineTests" == "false" ]; then
+    resetCaches
     # Setup NuGet.Config to use online restore sources
     if [ -e "$SCRIPT_ROOT/smoke-testNuGet.Config" ]; then
         cp "$SCRIPT_ROOT/smoke-testNuGet.Config" "$testingDir/NuGet.Config"


### PR DESCRIPTION
This gets the aspnetcore smoke-tests working, both with and without dev certs. I changed the 20 second delay to check every second up to 20 to see if the project's ready--this speeds it up a bit.

The challenge was figuring out why SIGINT wasn't working as expected. It turns out to be new behavior in 2.1 because https://github.com/dotnet/coreclr/pull/15393 makes .NET Core preserve `SIG_IGN` (signal ignore) when it's set on SIGINT. ~~I added `set -m` to avoid `SIG_IGN` being set when our `dotnet run` is backgrounded. (https://unix.stackexchange.com/a/356480)~~ I changed it to SIGTERM per @tmds's suggestion.