### PR TITLE
Fix CliCommandLineParser build manifest name.

### DIFF
--- a/repos/clicommandlineparser.proj
+++ b/repos/clicommandlineparser.proj
@@ -11,6 +11,7 @@
     <DependencyVersionInputRepoApiImplemented>false</DependencyVersionInputRepoApiImplemented>
     <UsesRepoToolset>true</UsesRepoToolset>
     <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
+    <OrchestratedManifestBuildName>dotnet/CliCommandLineParser</OrchestratedManifestBuildName>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Skip CI please.