### PR TITLE
Add cli-migrate to auto-update

### DIFF
--- a/repos/cli-migrate.proj
+++ b/repos/cli-migrate.proj
@@ -14,9 +14,7 @@
     <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
     <DependencyVersionInputRepoApiImplemented>false</DependencyVersionInputRepoApiImplemented>
     <UsesRepoToolset>true</UsesRepoToolset>
-
-    <!-- ProdCon is behind source-build: temporarily disable auto-update. -->
-    <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
+    <OrchestratedManifestBuildName>dotnet/cli-migrate</OrchestratedManifestBuildName>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
New ProdCon builds include the source-build fix commits.