### PR TITLE
Add VersionStamp to CoreFX and core-setup builds.

### DIFF
--- a/repos/dir.props
+++ b/repos/dir.props
@@ -46,6 +46,11 @@
     <EnvironmentVariables Include="DotNetBuildOffline=true" Condition="'$(OfflineBuild)' == 'true'" />
     <EnvironmentVariables Include="DotNetCoreSdkDir=$(DotNetCliToolDir)" />
     <EnvironmentVariables Include="DotNetBuildToolsDir=$(ProjectDir)Tools/" />
+    <!-- Always build source-build as stabilized.  We don't publish packages so this
+         won't cause conflicts on package feeds, and it will make us match up for releases.  -->
+    <EnvironmentVariables Include="StabilizePackageVersion=true" />
+    <!-- Update the line below when branch quality changes -->
+    <EnvironmentVariables Include="PackageVersionStamp=rc1" />
   </ItemGroup>
 
 </Project>

--- a/repos/dir.props
+++ b/repos/dir.props
@@ -46,11 +46,8 @@
     <EnvironmentVariables Include="DotNetBuildOffline=true" Condition="'$(OfflineBuild)' == 'true'" />
     <EnvironmentVariables Include="DotNetCoreSdkDir=$(DotNetCliToolDir)" />
     <EnvironmentVariables Include="DotNetBuildToolsDir=$(ProjectDir)Tools/" />
-    <!-- Always build source-build as stabilized.  We don't publish packages so this
-         won't cause conflicts on package feeds, and it will make us match up for releases.  -->
-    <EnvironmentVariables Include="StabilizePackageVersion=true" />
-    <!-- Update the line below when branch quality changes -->
-    <EnvironmentVariables Include="PackageVersionStamp=rc1" />
+    <EnvironmentVariables Include="StabilizePackageVersion=$(UseStableVersions)" Condition="'$(UseStableVersions)' != ''" />
+    <EnvironmentVariables Include="PackageVersionStamp=$(VersionStamp)" Condition="'$(VersionStamp)' != ''" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This will make produced versions only use "-rc1" suffixes instead of "-rc1-buildnumber", which matches up with the official RC1 release.