### PR TITLE
Extend timeouts for push and PR jobs.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -32,7 +32,7 @@ def addPullRequestJob(String project, String branch, String os, String configura
 
   addBuildStepsAndSetMachineAffinity(newJob, os, configuration);
   Utilities.standardJobSetup(newJob, project, true, "*/${branch}");
-  Utilities.setJobTimeout(newJob, 180)
+  Utilities.setJobTimeout(newJob, 180);
   Utilities.addGithubPRTriggerForBranch(newJob, branch, contextString, triggerPhrase, !runByDefault);
 }
 
@@ -45,7 +45,7 @@ def addPushJob(String project, String branch, String os, String configuration)
 
     addBuildStepsAndSetMachineAffinity(newJob, os, configuration);
     Utilities.standardJobSetup(newJob, project, false, "*/${branch}");
-    Utilities.setJobTimeout(newJob, 180)
+    Utilities.setJobTimeout(newJob, 180);
     Utilities.addGithubPushTrigger(newJob);
 }
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -32,6 +32,7 @@ def addPullRequestJob(String project, String branch, String os, String configura
 
   addBuildStepsAndSetMachineAffinity(newJob, os, configuration);
   Utilities.standardJobSetup(newJob, project, true, "*/${branch}");
+  Utilities.setJobTimeout(newJob, 180)
   Utilities.addGithubPRTriggerForBranch(newJob, branch, contextString, triggerPhrase, !runByDefault);
 }
 
@@ -44,6 +45,7 @@ def addPushJob(String project, String branch, String os, String configuration)
 
     addBuildStepsAndSetMachineAffinity(newJob, os, configuration);
     Utilities.standardJobSetup(newJob, project, false, "*/${branch}");
+    Utilities.setJobTimeout(newJob, 180)
     Utilities.addGithubPushTrigger(newJob);
 }
 


### PR DESCRIPTION
Mac jobs have been timing out very close to the end of the build, up the timeout from two hours to three hours.
Skip CI please.