### PR TITLE
Update ProdCon feed to 20180515-07

### DIFF
--- a/ProdConFeed.txt
+++ b/ProdConFeed.txt
@@ -1,1 +1,1 @@
-https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180515-06/final/index.json
+https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180515-07/final/index.json


### PR DESCRIPTION
Updates ProdCon feed to latest from `2.1-rtm`. This would only affect the result if the prebuilt SDK packages changed between these builds, which seems unlikely.