### PR TITLE
Fix some minor issues with the bootstrap documentation.

### DIFF
--- a/Documentation/boostrap-new-os.md
+++ b/Documentation/boostrap-new-os.md
@@ -44,15 +44,14 @@ For versions earlier than .NET Core 2.0, following dependencies are also require
 ### Building the bootstrap CLI
 There is a bash script file that automatizes most of the process of building the bootstrap CLI end to end. The bash script is located at `dotnet/source-build/scripts/bootstrap/buildbootstrapcli.sh`. It first creates a folder named by the new target RID, clones the coreclr, corefx and core-setup repos into it and checks out the same commit of each of the repos as the one that was used to build the seed CLI. This first step is skipped if the coreclr, corefx and core-setup folders already exist. This is important so that the sources can be modified to fix possible build issues and to target the new RID.
 
-The script needs to be passed several arguments. The target architecture, the build configuration, the target OS, the new RID and path to the folder with the untared seed CLI. There is also an optional option to specify the version of the Clang compiler to use to compile the native code. There is also an option to pass in a System.Private.CoreLib.dll built elsewhere and an option to crossgen it. This is useful if you are building debug configuration, since the seed CLI that comes from Azure is built for release configuration and the release version of System.Private.CoreLib.dll is not compatible with debug version of libcoreclr.so.
+The script needs to be passed several arguments. The target architecture, the build configuration, the target OS, the new RID and path to the folder with the untared seed CLI. There is also an optional option to specify the version of the Clang compiler to use to compile the native code. There is also an option to pass in a System.Private.CoreLib.dll built elsewhere. This is useful if you are building debug configuration, since the seed CLI that comes from Azure is built for release configuration and the release version of System.Private.CoreLib.dll is not compatible with debug version of libcoreclr.so.
 Here is the summary of the options that you get from running the script with `--help` option:
 ```
-Usage: buildbootstrapcli.sh [BuildType] --rid <Rid> --seedcli <SeedCli> [--os <OS>] [--clang <Major.Minor>] [--corelib <CoreLib>]
+Usage: buildbootstrapcli.sh [BuildType] -rid <Rid> -seedcli <SeedCli> [-os <OS>] [-clang <Major.Minor>] [-corelib <CoreLib>]
 
 Options:
   BuildType               Type of build (-debug, -release), default: -debug
   -clang <Major.Minor>    Override of the version of clang compiler to use
-  -config <Configuration> Build configuration (debug, release), default: debug
   -corelib <CoreLib>      Path to System.Private.CoreLib.dll, default: use the System.Private.CoreLib.dll from the seed CLI
   -os <OS>                Operating system (used for corefx build), default: Linux
   -rid <Rid>              Runtime identifier including the architecture part (e.g. rhel.6-x64)
@@ -61,7 +60,7 @@ Options:
 ```
 So, for example, when we were creating bootstrap CLI for RHEL / CentOS 6, the command was:
 ```bash
-./buildbootstrapcli.sh -rid rhel.6 -release -os Linux -seedcli ~/seed-cli
+./buildbootstrapcli.sh -release -rid rhel.6-x64 -os Linux -seedcli ~/seed-cli
 ```
 After running the script, check the console output. If the last line printed is `**** Bootstrap CLI was successfully built  ****`, then everything went fine and the bootstrap CLI is ready. You can find it in the `<Rid>-<Architecture>/dotnetcli` subfolder. So for the example command above, it would be `rhel.6-x64/dotnetcli`.
 If there were build errors, they need to be looked into and fixed. After that run the `buildbootstrapcli.sh` with the same arguments again. Repeat until everything builds.

--- a/scripts/bootstrap/buildbootstrapcli.sh
+++ b/scripts/bootstrap/buildbootstrapcli.sh
@@ -5,12 +5,11 @@ set -o pipefail
 usage()
 {
     echo "Builds a bootstrap CLI from sources"
-    echo "Usage: $0 [BuildType] --rid <Rid> --seedcli <SeedCli> [--os <OS>] [--clang <Major.Minor>] [--corelib <CoreLib>]"
+    echo "Usage: $0 [BuildType] -rid <Rid> -seedcli <SeedCli> [-os <OS>] [-clang <Major.Minor>] [-corelib <CoreLib>]"
     echo ""
     echo "Options:"
     echo "  BuildType               Type of build (-debug, -release), default: -debug"
     echo "  -clang <Major.Minor>    Override of the version of clang compiler to use"
-    echo "  -config <Configuration> Build configuration (debug, release), default: debug"
     echo "  -corelib <CoreLib>      Path to System.Private.CoreLib.dll, default: use the System.Private.CoreLib.dll from the seed CLI"
     echo "  -os <OS>                Operating system (used for corefx build), default: Linux"
     echo "  -rid <Rid>              Runtime identifier including the architecture part (e.g. rhel.6-x64)"


### PR DESCRIPTION
There are a couple incorrect things about the bootstrap documentation:

1. A reference to an option to crossgen the corelib, that doesn't exist.  Removed.
1. Incorrect double dashes in the usage.
1. A reference to a `-config` option that doesn't exist.
1. The example call is incorrect since it doesn't contain the architecture piece of the RID.
    1. I also rearranged it so the `-release` part was first, since this is easy to miss.

/cc @dseefeld @weshaggard @mateusrodrigues 