### PR TITLE
Add more source-build documentation

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -22,13 +22,13 @@ git submodule update --init --recursive
 
 ## Building one repo
 
-By default we build the cli and its dependencies but the default root repository to build can be passed in.
+By default we build the cli and its dependencies but the default root repository to build can be passed in. For example, if you just want to build the .NET Core Runtime, you would just build the `core-setup` repo and its dependencies:
 
 ```console
 ./build.{cmd|sh} /p:RootRepo=core-setup
 ```
 
-Sometimes you want to just iterate on a single repo build and not rebuild all depedencies that can be done passing another property.
+Sometimes you want to just iterate on a single repo build and not rebuild all dependencies that can be done passing another property.
 
 ```console
 ./build.{cmd|sh} /p:RootRepo=core-setup /p:SkipRepoReferences=true
@@ -47,4 +47,12 @@ You can build the .NET Core SDK and generate a source tarball in a specific dire
 
 ```console
 ./build-source-tarball.sh <path-to-tarball-root>
+```
+
+After this completes, you can take the output tarball and build .NET Core again without an internet connection.
+
+```console
+tar -xf <path-to-tarball-root> -C <path-to-extraction-root>
+cd <path-to-extraction-root>
+./build.sh
 ```

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -47,12 +47,13 @@ You can build the .NET Core SDK and generate a source tarball in a specific dire
 
 ```console
 ./build-source-tarball.sh <path-to-tarball-root>
+tar -czf <tarball-destination> --directory <path-to-tarball-root> "."
 ```
 
-After this completes, you can take the output tarball and build .NET Core again without an internet connection.
+After this completes, you can take the output tarball to another machine and build .NET Core again without an internet connection.
 
 ```console
-tar -xf <path-to-tarball-root> -C <path-to-extraction-root>
+tar -xf <tarball-destination> -C <path-to-extraction-root>
 cd <path-to-extraction-root>
 ./build.sh
 ```

--- a/Documentation/boostrap-new-os.md
+++ b/Documentation/boostrap-new-os.md
@@ -71,7 +71,6 @@ The easiest way to test the bootstrap CLI that was just created is to create, bu
 TODO: describe how to do debug build and replace System.Private.CoreLib.dll
 #### Using bootstrap CLI on platforms with different OS or architecture
 If the bootstrap CLI was created for OS other than the one the seed cli supports (e.g. FreeBSD) or the target architecture of the target OS differs from the architecture of the bootstrap cli (e.g. ARM64), the managed assemblies in the bootstrap CLI cannot be loaded, since they contain native code for the target OS and architecture. Fortunately, they also contain the original IL code, so they can be re-crossgened for the target OS and architecture. Or it is possible to instruct the CoreCLR runtime to ignore the native code and use the IL by setting environment variables `COMPlus_ZapDisable=1` and `COMPlus_ReadyToRun=0`. That can be useful during the bringup. But ultimately, re-crossgening should be made to improve startup performance.
-TODO: describe how to re-crossgen the managed assemblies
 
 ## Use the bootstrap CLI to build source-build
 Now that you have an SDK that works on the new OS, you can build all of the .NET Core source code. To do this, first tar up the boostrap CLI: 

--- a/Documentation/boostrap-new-os.md
+++ b/Documentation/boostrap-new-os.md
@@ -72,3 +72,30 @@ TODO: describe how to do debug build and replace System.Private.CoreLib.dll
 #### Using bootstrap CLI on platforms with different OS or architecture
 If the bootstrap CLI was created for OS other than the one the seed cli supports (e.g. FreeBSD) or the target architecture of the target OS differs from the architecture of the bootstrap cli (e.g. ARM64), the managed assemblies in the bootstrap CLI cannot be loaded, since they contain native code for the target OS and architecture. Fortunately, they also contain the original IL code, so they can be re-crossgened for the target OS and architecture. Or it is possible to instruct the CoreCLR runtime to ignore the native code and use the IL by setting environment variables `COMPlus_ZapDisable=1` and `COMPlus_ReadyToRun=0`. That can be useful during the bringup. But ultimately, re-crossgening should be made to improve startup performance.
 TODO: describe how to re-crossgen the managed assemblies
+
+## Use the bootstrap CLI to build source-build
+Now that you have an SDK that works on the new OS, you can build all of the .NET Core source code. To do this, first tar up the boostrap CLI: 
+```
+tar -czf ~/dotnet.tar --directory /your/path/to/bootstrap/dotnetcli "."
+```
+Next, the ILASM tool that you built locally needs to be copied out so it can be used.
+
+```console
+mkdir ~/ilasm
+cp dotnet/source-build/scripts/bootstrap/RID/coreclr/bin/Product/RID.Release/* ~/ilasm
+cp /your/path/to/bootstrap/dotnetcli/shared/Microsoft.NETCore.App/VERSION/System.Private.CoreLib.dll ~/ilasm
+```
+TODO: make this next step better - possibly by adding a new build parameter that takes the path to ILASM.
+Now, we can initialize our build tools with the bootstrap CLI and the ILASM tool.
+
+```console
+DotNetBootstrapCliTarPath=~/dotnet.tar SOURCE_BUILD_SKIP_SUBMODULE_CHECK=1 ./init-tools.sh
+# Copy ILASM into the Tools directory
+cp ~/ilasm/* dotnet/source-build/Tools/ilasm/
+```
+
+Now you can build the whole product using the toolset you just bootstrapped:
+
+```console
+SOURCE_BUILD_SKIP_SUBMODULE_CHECK=1 ./build.sh
+```

--- a/Documentation/tool-dependencies.md
+++ b/Documentation/tool-dependencies.md
@@ -1,0 +1,11 @@
+# Tools used to build .NET Core
+
+* [.NET Core SDK](https://www.microsoft.com/net/download/)
+* [dotnet/buildtools](https://github.com/dotnet/buildtools)
+* [Microsoft.DotNet.BuildTools.Coreclr](https://dotnet.myget.org/feed/dotnet-buildtools/package/nuget/Microsoft.DotNet.BuildTools.CoreCLR)
+  * See https://github.com/dotnet/coreclr/issues/14345
+* [ILLink.Tasks](https://github.com/mono/linker/blob/master/corebuild/README.md)
+* [ILASM](https://github.com/dotnet/coreclr/tree/master/src/ilasm)
+  * Used to compile IL source code into .dll
+* [dotnet/roslyn-tools](https://github.com/dotnet/roslyn-tools)
+* [xlifftasks](https://github.com/dotnet/xliff-tasks)


### PR DESCRIPTION
- Add steps to the README how to build from the tarball
- Add bootstrap steps on how to build with the bootstrap SDK
- Add a list of tools required to build .NET Core