### PR TITLE
add  FreeBSD

### DIFF
--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/GetHostInformation.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/GetHostInformation.cs
@@ -38,6 +38,9 @@ namespace Microsoft.DotNet.Build.Tasks
                 case Platform.Darwin:
                     OSName = "OSX";
                     break;
+                case Platform.FreeBSD:
+                    OSName = "FreeBSD";
+                    break;
                 default:
                     Log.LogError("Could not determine display name for platform.");
                     return false;


### PR DESCRIPTION
fixes following error when executed on FreeBSD

/usr/home/furt/git/source-build2/tools-local/init-build.proj(70,5): error : Could not determine display name for platform.

