### PR TITLE
Windows fixes in order to be able to build some submodules from master

### DIFF
--- a/repos/clicommandlineparser.proj
+++ b/repos/clicommandlineparser.proj
@@ -2,7 +2,9 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
-    <BuildCommandArgs>--restore --pack --configuration $(Configuration)</BuildCommandArgs>
+    <!-- In Windows -restore is already passed by default by build.cmd to build.ps1 -->
+    <BuildCommandArgs Condition="'$(OS)' == 'Windows_NT'">-pack -configuration $(Configuration)</BuildCommandArgs>
+    <BuildCommandArgs Condition="'$(OS)' != 'Windows_NT'">--restore --pack --configuration $(Configuration)</BuildCommandArgs>
 
     <!-- Pass in package version props using the Product Construction (ProdCon) API. -->
     <BuildCommandArgs>$(BuildCommandArgs) /p:PB_PackageVersionPropsUrl=file:%2F%2F$(PackageVersionPropsPath)</BuildCommandArgs>

--- a/repos/clicommandlineparser.proj
+++ b/repos/clicommandlineparser.proj
@@ -3,8 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <!-- In Windows -restore is already passed by default by build.cmd to build.ps1 -->
-    <BuildCommandArgs Condition="'$(OS)' == 'Windows_NT'">-pack -configuration $(Configuration)</BuildCommandArgs>
-    <BuildCommandArgs Condition="'$(OS)' != 'Windows_NT'">--restore --pack --configuration $(Configuration)</BuildCommandArgs>
+    <BuildCommandArgs>$(FlagParameterPrefix)pack $(FlagParameterPrefix)configuration $(Configuration)</BuildCommandArgs>
+    <BuildCommandArgs Condition="'$(OS)' != 'Windows_NT'">$(BuildCommandArgs) $(FlagParameterPrefix)restore</BuildCommandArgs>
 
     <!-- Pass in package version props using the Product Construction (ProdCon) API. -->
     <BuildCommandArgs>$(BuildCommandArgs) /p:PB_PackageVersionPropsUrl=file:%2F%2F$(PackageVersionPropsPath)</BuildCommandArgs>

--- a/repos/dir.props
+++ b/repos/dir.props
@@ -16,6 +16,8 @@
   <PropertyGroup>
     <OutputGitInfoPropsFile>$(GitInfoOutputDir)$(RepositoryName).props</OutputGitInfoPropsFile>
     <OfflineGitInfoPropsFile>$(GitInfoOfflineDir)$(RepositoryName).props</OfflineGitInfoPropsFile>
+    <FlagParameterPrefix Condition="'$(OS)' == 'Windows_NT'">-</FlagParameterPrefix>
+    <FlagParameterPrefix Condition="'$(OS)' != 'Windows_NT'">--</FlagParameterPrefix>
   </PropertyGroup>
 
   <Import Project="$(OutputGitInfoPropsFile)" Condition="Exists('$(OutputGitInfoPropsFile)')" />

--- a/repos/msbuild.proj
+++ b/repos/msbuild.proj
@@ -7,7 +7,7 @@
     <OfficialBuildId>20180426.1</OfficialBuildId>
     <PackagesOutput>$(ProjectDirectory)/artifacts/$(Configuration)/packages</PackagesOutput>
     <OutputVersionArgs>/p:VersionPrefix=15.7.179 /p:DisableNerdbankVersioning=true /p:PreReleaseVersionLabel="" /p:BUILD_BUILDNUMBER=$(OfficialBuildId)</OutputVersionArgs>
-    <BuildCommand>$(ProjectDirectory)build/build$(ShellExtension) build -DotNetBuildFromSource -DotNetCoreSdkDir $(DotNetCliToolDir) -bootstraponly -skiptests -pack -configuration $(Configuration) /p:GitHeadSha=$(GitCommitHash) $(OutputVersionArgs)</BuildCommand>
+    <BuildCommand>$(ProjectDirectory)build$(ShellExtension) -DotNetBuildFromSource -DotNetCoreSdkDir $(DotNetCliToolDir) -bootstraponly -skiptests -pack -configuration $(Configuration) /p:GitHeadSha=$(GitCommitHash) $(OutputVersionArgs)</BuildCommand>
     <SourceOverrideRepoApiImplemented>true</SourceOverrideRepoApiImplemented>
     <RepoApiImplemented>false</RepoApiImplemented>
     <UsesRepoToolset>true</UsesRepoToolset>

--- a/repos/roslyn-tools.proj
+++ b/repos/roslyn-tools.proj
@@ -2,8 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
-    <BuildArguments Condition="'$(OS)' == 'Windows_NT'">-pack -configuration $(Configuration)</BuildArguments>
-    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">--pack --configuration $(Configuration)</BuildArguments>
+    <BuildArguments>$(FlagParameterPrefix)pack $(FlagParameterPrefix)configuration $(Configuration)</BuildArguments>
     <BuildCommand>$(ProjectDirectory)\build$(ShellExtension) $(BuildArguments)</BuildCommand>
     <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
     <UsesRepoToolset>true</UsesRepoToolset>

--- a/repos/roslyn-tools.proj
+++ b/repos/roslyn-tools.proj
@@ -2,7 +2,9 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
-    <BuildCommand>$(ProjectDirectory)\build$(ShellExtension) --pack --configuration $(Configuration)</BuildCommand>
+    <BuildArguments Condition="'$(OS)' == 'Windows_NT'">-pack -configuration $(Configuration)</BuildArguments>
+    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">--pack --configuration $(Configuration)</BuildArguments>
+    <BuildCommand>$(ProjectDirectory)\build$(ShellExtension) $(BuildArguments)</BuildCommand>
     <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
     <UsesRepoToolset>true</UsesRepoToolset>
     <BuiltToolPackageId>$(RepoToolsetPackageId)</BuiltToolPackageId>


### PR DESCRIPTION
A while ago when doing the initial investigation on what was needed to build the whole stack on Windows I fix some of the submodules.

Contributes to: https://github.com/dotnet/source-build/issues/575

cc: @dagood @weshaggard 