### PR TITLE
Merge release/2.1 infrastructure changes into master

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,0 +1,131 @@
+phases:
+- phase: source_build_ci
+  variables:
+    buildLoggingOptions: /clp:v=detailed /p:MinimalConsoleLogOutput=false
+    buildConfiguration: Release
+    buildOfflineTarball: false
+    docker.runInRoot: docker run --rm -v $(rootDirectory):/root -w /root
+    docker.runInSrc: docker run --rm -v $(Build.SourcesDirectory):/src -w /src
+    docker.runInSourceBuild: docker run --rm -v $(rootDirectory)/sb/source-build:/src -w /src
+    docker.runInTarball: docker run --rm -v $(rootDirectory)/sb/tarball/$(tarballName):/tb -w /tb
+    dropDirectory: $(stagingDirectory)/drop
+    rootDirectory: $(Build.SourcesDirectory)/..
+    stagingDirectory: $(rootDirectory)/sb/staging
+    tarballName: tarball_$(Build.BuildId)
+
+  queue:
+    name: DotNet-Build
+    demands: agent.os -equals linux
+    timeoutInMinutes: 240
+    parallel: 2
+    matrix:
+      centos71:
+        imageName: microsoft/dotnet-buildtools-prereqs:centos711503_prereqs_2
+      rhel7-unshared:
+        imageName: microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2
+        buildOfflineTarball: true
+
+  steps:
+    - template: ./.vsts.pipelines/steps/docker-cleanup-linux.yml
+
+    # create working directory and copy source into it
+    - script: |
+        set -x
+        $(docker.runInRoot) $(imageName) rm -rf /root/sb/
+        $(docker.runInRoot) $(imageName) mkdir -p /root/sb/tarball 
+        $(docker.runInSrc) -v $(rootDirectory):/root $(imageName) cp -r . /root/sb/source-build
+      displayName: Clean sb directory and copy source from cloned directory
+
+    # fetch vsts commits if building internally
+    - script: |
+        set -x
+        # Ignore failure for the first command. It will intentionally fail if the commit is only
+        # available in VSTS. "submodule update --init" is the simplest way to set up the submodule
+        # directory. ("submodule init" only sets up .git/config, not the e.g. src/coreclr/.git and
+        # .git/modules/src/coreclr/ directories.)
+        $(docker.runInSourceBuild) $(imageName) git submodule update --init --recursive
+        $(docker.runInSourceBuild) $(imageName) ./fetch-vsts-commits.sh $(user.PAT)
+      displayName: Fetch internal vsts commits
+      condition: and(succeeded(), ne(variables['user.PAT'], ''))
+
+    # init submodules
+    - script: $(docker.runInSourceBuild) $(imageName) git submodule update --init --recursive
+      displayName: Initialize submodules
+
+    # build source-build
+    - script: $(docker.runInSourceBuild) $(imageName) ./build.sh /p:ArchiveDownloadedPackages=true /p:Configuration=$(buildConfiguration) /p:ProdConBlobFeedUrlPrefix=$(prodConBlobFeedUrlPrefix) $(buildLoggingOptions)
+      displayName: Build source-build
+      timeoutInMinutes: 90
+
+    # copy logs to working directory
+    - script: |
+        set -x
+        $(docker.runInSourceBuild) -v $(dropDirectory)/logs:/logs $(imageName) /bin/bash -c "mkdir -p /logs/source-build/binlogs; find . -name '*.binlog' -exec cp {} /logs/source-build/binlogs \;"
+        $(docker.runInSourceBuild) -v $(dropDirectory)/logs:/logs $(imageName) /bin/bash -c "mkdir -p /logs/source-build/logs; find ./bin/logs -name '*.log' -exec cp {} /logs/source-build/logs \;"
+      displayName: Copy source-build logs
+      condition: always()
+      continueOnError: true
+
+    # run smoke tests
+    - script: $(docker.runInSourceBuild) $(imageName) ./build.sh /t:RunSmokeTest /p:Configuration=$(buildConfiguration) /p:ProdConBlobFeedUrlPrefix=$(prodConBlobFeedUrlPrefix)
+      displayName: Run smoke-test
+
+    # copy smoke test logs to working directory
+    - script: $(docker.runInSourceBuild) -v $(dropDirectory)/logs:/logs $(imageName)  /bin/bash -c "mkdir -p /logs/source-build/smoke-test; find ./testing-smoke -name '*.log' -exec cp {} /logs/source-build/smoke-test \;"
+      displayName: Copy smoke-test logs
+      condition: and(succeeded(), eq(variables['buildOfflineTarball'], false))
+      continueOnError: true
+
+    # create tarball
+    - script: $(docker.runInSourceBuild) -v $(rootDirectory)/sb/tarball:/tb $(imageName) ./build-source-tarball.sh /tb/$(tarballName) --skip-build
+      displayName: Create tarball
+      condition: and(succeeded(), eq(variables['buildOfflineTarball'], true))
+
+    # tar the tarball directory into the drop directory
+    - script: $(docker.runInSourceBuild) -v $(rootDirectory)/sb/tarball:/tb -v $(dropDirectory):/drop $(imageName) tar -zcvf /drop/$(tarballName).tar.gz /tb/$(tarballName)
+      displayName: Copy tarball to output
+      condition: and(succeeded(), eq(variables['buildOfflineTarball'], true))
+
+    # build tarball
+    - script: $(docker.runInTarball) --network='none' $(imageName) ./build.sh /p:Configuration=$(buildConfiguration) $(buildLoggingOptions)
+      displayName: Build tarball
+      timeoutInMinutes: 90
+      condition: and(succeeded(), eq(variables['buildOfflineTarball'], true))
+
+    # run smoke tests
+    - script: $(docker.runInTarball) $(imageName) ./smoke-test.sh --minimal --projectOutput --configuration $(buildConfiguration) --prodConBlobFeedUrl ''
+      displayName: Run smoke-test in tarball
+      condition: and(succeeded(), eq(variables['buildOfflineTarball'], true))
+
+    # copy all tarball logs to working directory
+    - script: |
+        set -x
+        $(docker.runInTarball) -v $(dropDirectory)/logs:/logs $(imageName) /bin/bash -c "mkdir -p /logs/tarball/binlogs; find . -name '*.binlog' -exec cp {} /logs/tarball/binlogs \;"
+        $(docker.runInTarball) -v $(dropDirectory)/logs:/logs $(imageName) /bin/bash -c "mkdir -p /logs/tarball/logs; find ./bin/logs -name '*.log' -exec cp {} /logs/tarball/logs \;"
+        $(docker.runInTarball) -v $(dropDirectory)/logs:/logs $(imageName) /bin/bash -c "mkdir -p /logs/tarball/smoke-test; find ./testing-smoke -name '*.log' -exec cp {} /logs/tarball/smoke-test \;"
+        # Copy prebuilt report
+        $(docker.runInSourceBuild) -v $(dropDirectory)/logs:/logs $(imageName) /bin/bash -c "mkdir -p /logs/prebuilt-report/online;  cp -r ./bin/prebuilt-report/* /logs/prebuilt-report/online"
+        $(docker.runInTarball)     -v $(dropDirectory)/logs:/logs $(imageName) /bin/bash -c "mkdir -p /logs/prebuilt-report/offline; cp -r ./bin/prebuilt-report/* /logs/prebuilt-report/offline"
+      displayName: Copy tarball logs
+      condition: eq(variables['buildOfflineTarball'], true)
+      continueOnError: true
+
+    # copy artifacts to staging - Copy to VSTS owned folder is done outside of docker so copied files have correct ownership so VSTS can clean them up later.
+    - task: CopyFiles@2
+      condition: always()
+      continueOnError: true
+      inputs:
+        sourceFolder: $(stagingDirectory)
+        targetFolder: $(Build.ArtifactStagingDirectory)
+
+    # publish artifacts
+    - task: PublishBuildArtifacts@1
+      displayName: Publish artifacts
+      condition: always()
+      continueOnError: true
+      inputs:
+        PathtoPublish: $(Build.ArtifactStagingDirectory)/drop
+        ArtifactName: drop
+        ArtifactType: Container
+
+    - template: ./.vsts.pipelines/steps/docker-cleanup-linux.yml

--- a/.vsts.pipelines/builds/vsts_prodcon_update.yml
+++ b/.vsts.pipelines/builds/vsts_prodcon_update.yml
@@ -1,0 +1,101 @@
+phases:
+- phase: vsts_prodcon_update
+  variables:
+    # autoUpdate.skipBuildToolsUpdate: (User input: Should the BuildTools update be skipped? This is useful to isolate the update to ProdCon.)
+    # pb.feed.buildId: (User input: What build id is the prodcon blob feed from? This shows up in the commit.)
+    # pb.feed.indexJsonUrl: (User input: Where is the prodcon blob feed?)
+    # pb.feed.replaceNew: (User input for ProdConBlobFeedReplaceNew.)
+    # pb.feed.replaceOld: (User input for ProdConBlobFeedReplaceOld.)
+    manifestDir: $(repo.orchestrationUtilities.dir)\bin\obj\manifest-temp
+    manifestFile: $(manifestDir)\build.xml
+    repo.orchestrationUtilities.dir: $(Build.BinariesDirectory)\utilities
+    repo.orchestrationUtilities.url: https://usernameplaceholder:$(user.PAT)@devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/DotNet-Orchestration-Utilities
+    repo.sourceBuild.url: https://usernameplaceholder:$(user.PAT)@devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/DotNet-Source-Build-Trusted
+
+  queue:
+    name: DotNet-Build
+    demands: agent.os -equals windows_nt
+    timeoutInMinutes: 180
+
+  steps:
+    - powershell: |
+        $prefix = "refs/heads/"
+        $branch = "$(Build.SourceBranch)"
+        $branchName = $branch
+        if ($branchName.StartsWith($prefix))
+        {
+          $branchName = $branchName.Substring($prefix.Length)
+        }
+        Write-Host "For Build.SourceBranch $branch, FullBranchName is $branchName"
+        Write-Host "##vso[task.setvariable variable=FullBranchName;]$branchName"
+      displayName: Find true SourceBranchName
+
+    - powershell: |
+        # Ignore failure for the first command. It will intentionally fail if the commit is only
+        # available in VSTS. "submodule update --init" is the simplest way to set up the submodule
+        # directory. ("submodule init" only sets up .git/config, not the e.g. src/coreclr/.git and
+        # .git/modules/src/coreclr/ directories.)
+        git submodule update --init --recursive
+        # This fetches old commits (allowing the next update to succeed) and populates the git repo
+        # with the potential commits that may be upgraded to.
+        ./fetch-vsts-commits.ps1 $(user.PAT)
+        git submodule update --init --recursive
+      displayName: Fetch internal vsts commits
+
+    - powershell: |
+        # Ensure no straggling artifacts could interfere with manifest generation.
+        rm -Recurse -Force -ErrorAction Ignore "$(repo.orchestrationUtilities.dir)"
+        git clone "$(repo.orchestrationUtilities.url)" "$(repo.orchestrationUtilities.dir)"
+      displayName: Initialize DotNet-Orchestration-Utilities
+
+    - powershell: |
+        .\init-tools.cmd
+        Tools\dotnetcli\dotnet msbuild .\src\publish.proj `
+          /t:CreateFeedOrchestratedBuildManifest `
+          /p:ExpectedFeedUrl=$(pb.feed.indexJsonUrl) `
+          /p:AccountKey=$(pb.feed.accountKey) `
+          /p:ManifestName=cli `
+          /p:ManifestBuildId=$(pb.feed.buildId) `
+          /v:N /flp:v=Diag
+      workingDirectory: $(repo.orchestrationUtilities.dir)
+      displayName: Create orchestrated build manifest
+
+    - powershell: |
+        .\build.cmd /t:InitBuild /p:SkipPatches=true
+        .\build.cmd `
+          /t:UpdateDependencies `
+          /p:SkipBuildToolsUpdate=$(autoUpdate.skipBuildToolsUpdate) `
+          /p:UpdateFromManifestFile=$(manifestFile) `
+          /p:ProdConBlobFeedReplaceOld=$(pb.feed.replaceOld) `
+          /p:ProdConBlobFeedReplaceNew=$(pb.feed.replaceNew) `
+          /clp:v=Normal
+      displayName: Perform auto-update changes
+
+    - powershell: |
+        git `
+          -c user.name=dotnet-maestro-bot `
+          -c "user.email=dotnet-maestro-bot@microsoft.com" `
+          commit -a -m "Update to ProdCon $(pb.feed.buildId)"
+        git push -f $(repo.sourceBuild.url) HEAD:refs/heads/auto-update/$(FullBranchName)
+      displayName: Push auto-update commit
+
+    - task: CopyFiles@2
+      condition: always()
+      continueOnError: true
+      inputs:
+        sourceFolder: $(manifestDir)
+        targetFolder: $(Build.ArtifactStagingDirectory)\manifestDir
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish artifacts
+      condition: always()
+      continueOnError: true
+      inputs:
+        PathtoPublish: $(Build.ArtifactStagingDirectory)
+        ArtifactName: artifacts
+        ArtifactType: Container
+
+    - powershell: rm -Recurse -Force "$(repo.orchestrationUtilities.dir)"
+      condition: always()
+      continueOnError: true
+      displayName: Clean up DotNet-Orchestration-Utilities

--- a/.vsts.pipelines/steps/docker-cleanup-linux.yml
+++ b/.vsts.pipelines/steps/docker-cleanup-linux.yml
@@ -1,0 +1,5 @@
+  steps:
+  - script: docker system prune -a -f --volumes
+    displayName: Cleanup Docker
+    condition: always()
+    continueOnError: true

--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -83,12 +83,19 @@ mkdir -p $TARBALL_ROOT/prebuilt/nuget-packages
 find $SCRIPT_ROOT/packages -name '*.nupkg' -exec cp {} $TARBALL_ROOT/prebuilt/nuget-packages/ \;
 find $SCRIPT_ROOT/bin/obj/x64/Release/nuget-packages -name '*.nupkg' -exec cp {} $TARBALL_ROOT/prebuilt/nuget-packages/ \;
 
+if [ -e $SCRIPT_ROOT/testing-smoke/smoke-test-packages ]; then
+    cp -rf $SCRIPT_ROOT/testing-smoke/smoke-test-packages $TARBALL_ROOT/prebuilt
+fi
+
 echo 'Removing source-built packages from tarball prebuilts...'
 
 for built_package in $(find $SCRIPT_ROOT/bin/obj/x64/Release/blob-feed/packages/ -name '*.nupkg' | tr '[:upper:]' '[:lower:]')
 do
     if [ -e $TARBALL_ROOT/prebuilt/nuget-packages/$(basename $built_package) ]; then
         rm $TARBALL_ROOT/prebuilt/nuget-packages/$(basename $built_package)
+    fi
+    if [ -e $TARBALL_ROOT/prebuilt/smoke-test-packages/$(basename $built_package) ]; then
+        rm $TARBALL_ROOT/prebuilt/smoke-test-packages/$(basename $built_package)
     fi
 done
 

--- a/build.proj
+++ b/build.proj
@@ -51,8 +51,19 @@
     <MSBuild Projects="repos\$(RootRepo).proj" Targets="ReportPrebuiltUsage" />
   </Target>
 
+  <Target Name="RunSmokeTest" DependsOnTargets="GetProdConBlobFeedUrl">
+    <!--
+      Pass prodConBlobFeedUrl via EnvironmentVariables because it has '//' in it, which is
+      translated into '/' if it's passed in the Command arg.
+      This is also a problem when passing CLI feeds: https://github.com/dotnet/source-build/issues/561
+    -->
+    <Exec Command="./smoke-test.sh --minimal --projectOutput --configuration $(Configuration) --archiveRestoredPackages"
+          EnvironmentVariables="prodConBlobFeedUrl=$(ProdConBlobFeedUrl)" />
+  </Target>
+
   <Import Project="$(ProjectDir)dependencies.targets" />
 
   <Import Project="$(ToolsDir)VersionTools.targets" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
 
 </Project>

--- a/dependencies.props
+++ b/dependencies.props
@@ -38,19 +38,17 @@
       <RawVersionsBaseUrl>https://raw.githubusercontent.com/dotnet/versions</RawVersionsBaseUrl>
     </DependencyBuildInfo>
 
-    <DependencyInfo Include="ProdCon">
+    <DependencyInfo Include="ProdCon" Condition="'$(UpdateFromManifestFile)' == ''">
       <DependencyType>Orchestrated build</DependencyType>
       <BasePath>build-info/dotnet/product/cli/release/2.1.1</BasePath>
       <CurrentRef>$(ProdConCurrentRef)</CurrentRef>
       <VersionsRepoOwner>dotnet</VersionsRepoOwner>
       <VersionsRepo>versions</VersionsRepo>
     </DependencyInfo>
-
-    <UpdateStep Include="ProdCon">
-      <UpdaterType>Orchestrated blob feed attribute</UpdaterType>
-      <SingleLineFile>$(MSBuildThisFileDirectory)ProdConFeed.txt</SingleLineFile>
-      <AttributeName>Url</AttributeName>
-    </UpdateStep>
+    <DependencyInfo Include="ProdCon" Condition="'$(UpdateFromManifestFile)' != ''">
+      <DependencyType>Orchestrated build file</DependencyType>
+      <Path>$(UpdateFromManifestFile)</Path>
+    </DependencyInfo>
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipBuildToolsUpdate)' != 'true'">

--- a/dependencies.targets
+++ b/dependencies.targets
@@ -84,7 +84,16 @@
         UpdaterType="Build attribute from orchestrated build"
         AttributeName="BuildId"
         Path="%(RepoProjectWithProperties.Identity)"
-        ElementName="OfficialBuildId" />
+        ElementName="OfficialBuildId"
+        SkipIfNoReplacementFound="true" />
+
+      <UpdateStep
+        Include="ProdCon"
+        UpdaterType="Orchestrated blob feed attribute"
+        SingleLineFile="$(MSBuildThisFileDirectory)ProdConFeed.txt"
+        AttributeName="Url"
+        ReplacementSubstituteOld="$(ProdConBlobFeedReplaceOld)"
+        ReplacementSubstituteNew="$(ProdConBlobFeedReplaceNew)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/dir.targets
+++ b/dir.targets
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="GetProdConBlobFeedUrl">
+    <PropertyGroup>
+      <ProdConBlobFeedUrl>$([System.IO.File]::ReadAllText('$(ProdConFeedPath)').Trim())</ProdConBlobFeedUrl>
+      <ProdConBlobFeedUrl Condition="'$(ProdConBlobFeedUrlPrefix)' != ''">$(ProdConBlobFeedUrl.Replace('https://dotnetfeed.blob.core.windows.net/', '$(ProdConBlobFeedUrlPrefix)'))</ProdConBlobFeedUrl>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/fetch-vsts-commits.ps1
+++ b/fetch-vsts-commits.ps1
@@ -1,0 +1,40 @@
+param (
+    [Parameter(Mandatory=$true)][string]$pat,
+    [string]$remote_ref_name = "vsts"
+)
+
+function get_vsts_url(
+    [Parameter(Mandatory=$true)][string]$name,
+    [string]$instance = 'devdiv.visualstudio.com',
+    [string]$project = 'DevDiv')
+{
+    return "https://usernameplaceholder:${pat}@${instance}/${project}/_git/${name}/"
+}
+
+function fetch(
+    [Parameter(Mandatory=$true)][string]$name,
+    [Parameter(Mandatory=$true)][string]$remote)
+{
+    $cmd = @(
+        "-C", "src/$name"
+        # Disable credential manager if one is specified. Always use manual PAT.
+        "-c", "credential.helper="
+        "fetch"
+        $remote
+        "+refs/heads/*:refs/remotes/${remote_ref_name}/*"
+    )
+    echo "Fetching commits using: & git $cmd"
+    & git @cmd
+}
+
+function fetch_vsts(
+    [Parameter(Mandatory=$true)][string]$name,
+    [string]$url = (get_vsts_url "DotNet-$name-Trusted"))
+{
+    fetch "$name" "$url"
+}
+
+fetch_vsts cli
+fetch_vsts core-setup
+fetch_vsts coreclr
+fetch_vsts corefx

--- a/fetch-vsts-commits.sh
+++ b/fetch-vsts-commits.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+SCRIPT_ROOT="$(cd -P "$( dirname "$0" )" && pwd)"
+
+remote_ref_name=${remote_ref_name:-vsts}
+
+pat="${1:-}"
+
+if [ -z "$pat" ]; then
+    echo "usage: $0 <pat>"
+    echo ""
+    echo "The PAT should be a devdiv.visualstudio.com VSTS PAT."
+    echo "Get one at https://devdiv.visualstudio.com/_details/security/tokens."
+    echo ""
+    exit 1
+fi
+
+get_vsts_url() {
+    name=$1
+    instance=${2:-devdiv.visualstudio.com}
+    project=${3:-DevDiv}
+
+    echo "https://usernameplaceholder:${pat}@${instance}/${project}/_git/${name}/"
+}
+
+fetch() {
+    name=$1
+    remote=$2
+
+    (
+        cd "$SCRIPT_ROOT/src/$name"
+        git fetch "$remote" +refs/heads/*:refs/remotes/${remote_ref_name}/*
+    )
+}
+
+fetch_vsts() {
+    name=$1
+    url=${2:-$(get_vsts_url "DotNet-$name-Trusted")}
+
+    fetch "$name" "$url"
+}
+
+set -x
+
+fetch_vsts cli
+fetch_vsts core-setup
+fetch_vsts coreclr
+fetch_vsts corefx

--- a/repos/cli.proj
+++ b/repos/cli.proj
@@ -77,10 +77,8 @@
   <!-- Inject the ProdConFeed into NuGet.config to pick up AspNetCore packages.
        See https://github.com/dotnet/source-build/issues/561
   -->
-  <Target Name="AddProdConFeed" BeforeTargets="Build">
+  <Target Name="AddProdConFeed" BeforeTargets="Build" DependsOnTargets="GetProdConBlobFeedUrl">
     <PropertyGroup>
-      <ProdConBlobFeedUrl>$([System.IO.File]::ReadAllText('$(ProdConFeedPath)').Trim())</ProdConBlobFeedUrl>
-
       <NugetConfigTargetsFile>$(ProjectDirectory)build\NugetConfigFile.targets</NugetConfigTargetsFile>
       <ReplacementEndMark>&lt;/ItemGroup&gt;</ReplacementEndMark>
       <InsertItemLine>&lt;NugetConfigPrivateFeeds Include="$(ProdConBlobFeedUrl)" /&gt;$(ReplacementEndMark)</InsertItemLine>

--- a/repos/dir.props
+++ b/repos/dir.props
@@ -53,6 +53,7 @@
     <EnvironmentVariables Include="DotNetCoreSdkDir=$(DotNetCliToolDir)" />
     <EnvironmentVariables Include="DotNetBuildToolsDir=$(ProjectDir)Tools/" />
     <EnvironmentVariables Include="StabilizePackageVersion=$(UseStableVersions)" Condition="'$(UseStableVersions)' != ''" />
+    <EnvironmentVariables Include="PB_IsStable=$(UseStableVersions)" Condition="'$(UseStableVersions)' != ''" />
     <EnvironmentVariables Include="PackageVersionStamp=$(VersionStamp)" Condition="'$(VersionStamp)' != ''" />
 
     <!-- Turn off node reuse for source build because repos use conflicting versions 

--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -374,4 +374,5 @@
   <Target Name="GetOfficialBuildId" Outputs="$(OfficialBuildId)" />
 
   <Import Project="$(ToolsDir)VersionTools.targets" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., dir.targets))/dir.targets" />
 </Project>

--- a/repos/nuget-client.proj
+++ b/repos/nuget-client.proj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <EnvironmentVariables Include="MS_PFX_PATH=$(NuGetKeyFilePath)" />
+    <EnvironmentVariables Include="NUGET_PFX_PATH=$(NuGetKeyFilePath)" />
     <RepositoryReference Include="newtonsoft-json" />
     <RepositoryReference Include="common" />
   </ItemGroup>

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -25,6 +25,9 @@ cliDir="$testingDir/builtCli"
 logFile="$testingDir/smoke-test.log"
 restoredPackagesDir="$testingDir/packages"
 testingHome="$testingDir/home"
+archiveRestoredPackages=false
+archivedPackagesDir="$testingDir/smoke-test-packages"
+smokeTestPrebuilts="$SCRIPT_ROOT/prebuilt/smoke-test-packages"
 
 function usage() {
     echo ""
@@ -41,6 +44,10 @@ function usage() {
     echo "  --excludeLocalTests            exclude tests that use local sources for nuget packages"
     echo "  --excludeOnlineTests           exclude test that use online sources for nuget packages"
     echo "  --devCertsVersion <version>    use dotnet-dev-certs <version> instead of default $DEV_CERTS_VERSION_DEFAULT"
+    echo "  --prodConBlobFeedUrl <url>     override the prodcon blob feed specified in ProdConFeed.txt, removing it if empty"
+    echo "  --archiveRestoredPackages      capture all restored packages to $archivedPackagesDir"
+    echo "environment:"
+    echo "  prodConBlobFeedUrl    override the prodcon blob feed specified in ProdConFeed.txt, removing it if empty"
     echo ""
 }
 
@@ -94,6 +101,13 @@ while :; do
             shift
             devCertsVersion="$1"
             ;;
+        --prodconblobfeedurl)
+            shift
+            prodConBlobFeedUrl="$1"
+            ;;
+        --archiverestoredpackages)
+            archiveRestoredPackages=true
+            ;;
         *)
             usage
             exit 1
@@ -103,6 +117,7 @@ while :; do
     shift
 done
 
+prodConBlobFeedUrl="${prodConBlobFeedUrl-$(cat "$SCRIPT_ROOT/ProdConFeed.txt")}"
 
 function doCommand() {
     lang=$1
@@ -254,8 +269,49 @@ function resetCaches() {
     rm -rf "$restoredPackagesDir"
 }
 
+function runWebTests() {
+    doCommand C# web "$@" new restore run
+    doCommand C# mvc "$@" new restore run
+    doCommand C# webapi "$@" new restore run
+    doCommand C# razor "$@" new restore run
+
+    doCommand F# web "$@" new restore run
+    doCommand F# mvc "$@" new restore run
+    doCommand F# webapi "$@" new restore run
+}
+
+function resetCaches() {
+    rm -rf "$testingHome"
+    mkdir "$testingHome"
+
+    HOME="$testingHome"
+
+    # clean restore path
+    rm -rf "$restoredPackagesDir"
+}
+
 function setupProdConFeed() {
-    sed -i.bakProdCon "s|PRODUCT_CONTRUCTION_PACKAGES|$prodConFeedUrl|g" "$testingDir/NuGet.Config"
+    if [ "$prodConBlobFeedUrl" ]; then
+        sed -i.bakProdCon "s|PRODUCT_CONTRUCTION_PACKAGES|$prodConBlobFeedUrl|g" "$testingDir/NuGet.Config"
+    else
+        sed -i.bakProdCon "/PRODUCT_CONTRUCTION_PACKAGES/d" "$testingDir/NuGet.Config"
+    fi
+}
+
+function setupSmokeTestFeed() {
+    # Setup smoke-test-packages if they exist
+    if [ -e "$smokeTestPrebuilts" ]; then
+        sed -i.bakSmokeTestFeed "s|SMOKE_TEST_PACKAGE_FEED|$smokeTestPrebuilts|g" "$testingDir/NuGet.Config"
+    else
+        sed -i.bakSmokeTestFeed "/SMOKE_TEST_PACKAGE_FEED/d" "$testingDir/NuGet.Config"
+    fi
+}
+
+function copyRestoredPackages() {
+    if [ "$archiveRestoredPackages" == "true" ]; then
+        mkdir -p "$archivedPackagesDir"
+        cp -rf "$restoredPackagesDir"/* "$archivedPackagesDir"
+    fi
 }
 
 if [ "$__ROOT_REPO" != "known-good" ]; then
@@ -292,7 +348,6 @@ fi
 # setup restore path
 export NUGET_PACKAGES="$restoredPackagesDir"
 SOURCE_BUILT_PKGS_PATH="$SCRIPT_ROOT/bin/obj/x64/$configuration/blob-feed/packages/"
-prodConFeedUrl="$(cat "$SCRIPT_ROOT/ProdConFeed.txt")"
 
 # Run all tests, local restore sources first, online restore sources second
 if [ "$excludeLocalTests" == "false" ]; then
@@ -302,11 +357,13 @@ if [ "$excludeLocalTests" == "false" ]; then
         cp "$SCRIPT_ROOT/smoke-testNuGet.Config" "$testingDir/NuGet.Config"
         sed -i.bak "s|SOURCE_BUILT_PACKAGES|$SOURCE_BUILT_PKGS_PATH|g" "$testingDir/NuGet.Config"
         setupProdConFeed
+        setupSmokeTestFeed
         echo "$testingDir/NuGet.Config Contents:"
         cat "$testingDir/NuGet.Config"
     fi
     echo "RUN ALL TESTS - LOCAL RESTORE SOURCE"
     runAllTests
+    copyRestoredPackages
     echo "LOCAL RESTORE SOURCE - ALL TESTS PASSED!"
 fi
 
@@ -317,11 +374,13 @@ if [ "$excludeOnlineTests" == "false" ]; then
         cp "$SCRIPT_ROOT/smoke-testNuGet.Config" "$testingDir/NuGet.Config"
         sed -i.bak "/SOURCE_BUILT_PACKAGES/d" "$testingDir/NuGet.Config"
         setupProdConFeed
+        setupSmokeTestFeed
         echo "$testingDir/NuGet.Config Contents:"
         cat "$testingDir/NuGet.Config"
     fi
     echo "RUN ALL TESTS - ONLINE RESTORE SOURCE"
     runAllTests
+    copyRestoredPackages
     echo "ONLINE RESTORE SOURCE - ALL TESTS PASSED!"
 fi
 

--- a/smoke-testNuGet.Config
+++ b/smoke-testNuGet.Config
@@ -7,5 +7,6 @@
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet.myget.org/feed/dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="ProdCon" value="PRODUCT_CONTRUCTION_PACKAGES" />
+    <add key="smoke-test feed" value="SMOKE_TEST_PACKAGE_FEED" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
The 2.1.2 release saw some changes in `release/2.1` infra to support VSTS builds. This merge takes those changes into `master` for the future. I made some edits to the merge commit to fix conflicts and remove any submodule upgrades related to the 2.1.2 release.

**Don't squash this PR.** Squashing https://github.com/dotnet/source-build/pull/577 (an earlier 2.1 => master merge) made some commits it included to show up in this PR's commit list, too.