### PR TITLE
Detect the base commit in extract-patches.sh

### DIFF
--- a/extract-patches.sh
+++ b/extract-patches.sh
@@ -2,6 +2,13 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+getIndexedSubmoduleSha() {
+    (
+        cd "$DIR"
+        git ls-tree HEAD src/cli | awk '{print $3}'
+    )
+}
+
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
@@ -10,7 +17,7 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-BASE_SHA=$1
+BASE_SHA=${1:-$(getIndexedSubmoduleSha)}
 REPO_NAME=$(basename $(pwd))
 PATCHES_DIR=$DIR/patches/$REPO_NAME
 

--- a/extract-patches.sh
+++ b/extract-patches.sh
@@ -4,8 +4,8 @@ IFS=$'\n\t'
 
 getIndexedSubmoduleSha() {
     (
-        cd "$DIR"
-        git ls-tree HEAD "src/$REPO_NAME" | awk '{print $3}'
+        cd ".."
+        git ls-tree HEAD "$REPO_NAME" | awk '{print $3}'
     )
 }
 

--- a/extract-patches.sh
+++ b/extract-patches.sh
@@ -5,7 +5,7 @@ IFS=$'\n\t'
 getIndexedSubmoduleSha() {
     (
         cd "$DIR"
-        git ls-tree HEAD src/cli | awk '{print $3}'
+        git ls-tree HEAD "src/$REPO_NAME" | awk '{print $3}'
     )
 }
 
@@ -17,9 +17,9 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-BASE_SHA=${1:-$(getIndexedSubmoduleSha)}
 REPO_NAME=$(basename $(pwd))
 PATCHES_DIR=$DIR/patches/$REPO_NAME
+BASE_SHA=${1:-$(getIndexedSubmoduleSha)}
 
 if [ ! -d $PATCHES_DIR ]; then
     mkdir -p $PATCHES_DIR


### PR DESCRIPTION
Small improvement to `extract-patches.sh` to simplify patch workflow:

 1. `git am ../../patches/<repo>/*`
 2. Make changes, fixups, etc.
 3. `../../extract-patches.sh`
 4. Reset inadvertent changes to existing patch files due to client formatting or the new "From" commit hash.