### PR TITLE
Change default bootstrap type to release

### DIFF
--- a/Documentation/boostrap-new-os.md
+++ b/Documentation/boostrap-new-os.md
@@ -45,12 +45,15 @@ For versions earlier than .NET Core 2.1, following dependencies are also require
 There is a bash script file that automatizes most of the process of building the bootstrap CLI end to end. The bash script is located at `dotnet/source-build/scripts/bootstrap/buildbootstrapcli.sh`. It first creates a folder named by the new target RID, clones the coreclr, corefx and core-setup repos into it and checks out the same commit of each of the repos as the one that was used to build the seed CLI. This first step is skipped if the coreclr, corefx and core-setup folders already exist. This is important so that the sources can be modified to fix possible build issues and to target the new RID.
 
 The script needs to be passed several arguments. The target architecture, the build configuration, the target OS, the new RID and path to the folder with the untared seed CLI. There is also an optional option to specify the version of the Clang compiler to use to compile the native code. There is also an option to pass in a System.Private.CoreLib.dll built elsewhere. This is useful if you are building debug configuration, since the seed CLI that comes from Azure is built for release configuration and the release version of System.Private.CoreLib.dll is not compatible with debug version of libcoreclr.so.
+
+The build configuration (debug or release) specified here *must* match with the configuration of the seed CLI. Otherwise everything will build fine but you will get a cryptic error as soon as coreclr tries to load a dll.
+
 Here is the summary of the options that you get from running the script with `--help` option:
 ```
 Usage: buildbootstrapcli.sh [BuildType] -rid <Rid> -seedcli <SeedCli> [-os <OS>] [-clang <Major.Minor>] [-corelib <CoreLib>]
 
 Options:
-  BuildType               Type of build (-debug, -release), default: -debug
+  BuildType               Type of build (-debug, -release), default: -release
   -clang <Major.Minor>    Override of the version of clang compiler to use
   -corelib <CoreLib>      Path to System.Private.CoreLib.dll, default: use the System.Private.CoreLib.dll from the seed CLI
   -os <OS>                Operating system (used for corefx build), default: Linux
@@ -60,7 +63,7 @@ Options:
 ```
 So, for example, when we were creating bootstrap CLI for RHEL / CentOS 6, the command was:
 ```bash
-./buildbootstrapcli.sh -release -rid rhel.6-x64 -os Linux -seedcli ~/seed-cli
+./buildbootstrapcli.sh -rid rhel.6-x64 -os Linux -seedcli ~/seed-cli
 ```
 After running the script, check the console output. If the last line printed is `**** Bootstrap CLI was successfully built  ****`, then everything went fine and the bootstrap CLI is ready. You can find it in the `<Rid>-<Architecture>/dotnetcli` subfolder. So for the example command above, it would be `rhel.6-x64/dotnetcli`.
 If there were build errors, they need to be looked into and fixed. After that run the `buildbootstrapcli.sh` with the same arguments again. Repeat until everything builds.

--- a/scripts/bootstrap/buildbootstrapcli.sh
+++ b/scripts/bootstrap/buildbootstrapcli.sh
@@ -8,7 +8,7 @@ usage()
     echo "Usage: $0 [BuildType] -rid <Rid> -seedcli <SeedCli> [-os <OS>] [-clang <Major.Minor>] [-corelib <CoreLib>]"
     echo ""
     echo "Options:"
-    echo "  BuildType               Type of build (-debug, -release), default: -debug"
+    echo "  BuildType               Type of build (-debug, -release), default: -release"
     echo "  -clang <Major.Minor>    Override of the version of clang compiler to use"
     echo "  -corelib <CoreLib>      Path to System.Private.CoreLib.dll, default: use the System.Private.CoreLib.dll from the seed CLI"
     echo "  -os <OS>                Operating system (used for corefx build), default: Linux"
@@ -95,7 +95,7 @@ getrealpath()
 __build_os=Linux
 __runtime_id=
 __corelib=
-__configuration=debug
+__configuration=release
 __clangversion=
 __outputpath=
 
@@ -230,7 +230,7 @@ fi
 
 echo "**** BUILDING CORE-SETUP NATIVE COMPONENTS ****"
 cd core-setup
-src/corehost/build.sh --arch "$__build_arch" --hostver "2.0.0" --apphostver "2.0.0" --fxrver "2.0.0" --policyver "2.0.0" --commithash `git rev-parse HEAD`
+src/corehost/build.sh --configuration $__configuration --arch "$__build_arch" --hostver "2.0.0" --apphostver "2.0.0" --fxrver "2.0.0" --policyver "2.0.0" --commithash `git rev-parse HEAD`
 cd ..
 
 echo "**** BUILDING CORECLR NATIVE COMPONENTS ****"


### PR DESCRIPTION
Bootstrapping works with a seed CLI. The CLI distributed by Microsoft is a release build. The CLI built by source-build is a release build. There's a much greater chance that the default cli will be a release build rather than a debug build. An incompatible configuration will not work. So change the default from debug to release to make it more likely to work.

Also update the docs to point out that the seed CLI configuration must match the configuration being used here or the dotnet command will fail at runtime with cryptic error messages.