### PR TITLE
Add more logs in the archive settings.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -63,7 +63,7 @@ def addBuildStepsAndSetMachineAffinity(def job, String os, String configuration)
           // Dev certs doesn't seem to work in these platforms. https://github.com/dotnet/source-build/issues/560
           smokeTestExcludes += " --excludeWebHttpsTests";
         }
-        shell("./smoke-test.sh --minimal --projectOutput --configuration ${configuration} ${smokeTestExcludes}");
+        shell("./smoke-test.sh --minimal --configuration ${configuration} ${smokeTestExcludes}");
       }
     };
   };
@@ -128,7 +128,7 @@ def addPushJob(String project, String branch, String os, String configuration)
             shell("cd ./source-build;./build-source-tarball.sh ../tarball-output --skip-build");
 
             shell("cd ./tarball-output;./build.sh /p:Configuration=${configuration} ${loggingOptions}")
-            shell("cd ./tarball-output;./smoke-test.sh --minimal --projectOutput --configuration ${configuration}")
+            shell("cd ./tarball-output;./smoke-test.sh --minimal --configuration ${configuration}")
         }
       }
 
@@ -180,7 +180,7 @@ def addPushJob(String project, String branch, String os, String configuration)
             // now build from the tarball offline and without access to the regular non-tarball build
             shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/tarball/home --network none -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/tarball/build.sh /p:Configuration=${configuration} ${loggingOptions}");
             // finally, run a smoke-test on the result
-            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/tarball/home -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/tarball/smoke-test.sh --minimal --projectOutput --configuration ${configuration}");
+            shell("docker run -u=\"\$(id -u):\$(id -g)\" -t --sig-proxy=true -e HOME=/opt/tarball/home -v \$(pwd)/tarball-output:/opt/tarball --rm -w /opt/tarball microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2 /opt/tarball/smoke-test.sh --minimal --configuration ${configuration}");
         }
       }
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -3,7 +3,7 @@ import jobs.generation.ArchivalSettings;
 
 def project = GithubProject;
 def branch = GithubBranchName;
-loggingOptions = "/clp:v=detailed /p:MinimalConsoleLogOutput=false";
+loggingOptions = "";
 
 def addArchival(def job) {
   def archivalSettings = new ArchivalSettings()
@@ -13,6 +13,20 @@ def addArchival(def job) {
   archivalSettings.addFiles("init-tools.log")
   archivalSettings.addFiles("msbuild.log")
   archivalSettings.addFiles("testing-smoke/smoke-test.log")
+  // tarball builds use subdirectories, so add these
+  archivalSettings.addFiles("source-build/bin/logs/*")
+  archivalSettings.addFiles("source-build/src/**/*.binlog")
+  archivalSettings.addFiles("source-build/src/**/*.log")
+  archivalSettings.addFiles("source-build/init-tools.log")
+  archivalSettings.addFiles("source-build/msbuild.log")
+  archivalSettings.addFiles("source-build/testing-smoke/smoke-test.log")
+  archivalSettings.addFiles("tarball-output/bin/logs/*")
+  archivalSettings.addFiles("tarball-output/src/**/*.binlog")
+  archivalSettings.addFiles("tarball-output/src/**/*.log")
+  archivalSettings.addFiles("tarball-output/init-tools.log")
+  archivalSettings.addFiles("tarball-output/msbuild.log")
+  archivalSettings.addFiles("tarball-output/testing-smoke/smoke-test.log")
+
   archivalSettings.setFailIfNothingArchived()
   archivalSettings.setAlwaysArchive()
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -7,29 +7,22 @@ loggingOptions = "";
 
 def addArchival(def job) {
   def archivalSettings = new ArchivalSettings()
-  archivalSettings.addFiles("bin/logs/*")
-  // also grab prebuilt reports
-  archivalSettings.addFiles("bin/logs/**/*")
-  archivalSettings.addFiles("src/**/*.binlog")
-  archivalSettings.addFiles("src/**/*.log")
-  archivalSettings.addFiles("init-tools.log")
-  archivalSettings.addFiles("msbuild.log")
-  archivalSettings.addFiles("testing-smoke/smoke-test.log")
-  // tarball builds use subdirectories, so add these
-  archivalSettings.addFiles("source-build/bin/logs/*")
-  archivalSettings.addFiles("source-build/bin/logs/**/*")
-  archivalSettings.addFiles("source-build/src/**/*.binlog")
-  archivalSettings.addFiles("source-build/src/**/*.log")
-  archivalSettings.addFiles("source-build/init-tools.log")
-  archivalSettings.addFiles("source-build/msbuild.log")
-  archivalSettings.addFiles("source-build/testing-smoke/smoke-test.log")
-  archivalSettings.addFiles("tarball-output/bin/logs/*")
-  archivalSettings.addFiles("tarball-output/bin/logs/**/*")
-  archivalSettings.addFiles("tarball-output/src/**/*.binlog")
-  archivalSettings.addFiles("tarball-output/src/**/*.log")
-  archivalSettings.addFiles("tarball-output/init-tools.log")
-  archivalSettings.addFiles("tarball-output/msbuild.log")
-  archivalSettings.addFiles("tarball-output/testing-smoke/smoke-test.log")
+  // non-tarball builds just build in the root workspace directory.
+  // tarball builds clone to source-build, build from there, and then
+  // additionally build from a tarball-output directory.
+  // Grab these logs from all of those locations.
+  [ "", "source-build/", "tarball-output/"].each { logRoot ->
+    archivalSettings.addFiles("${logRoot}bin/logs/*")
+    // also grab prebuilt reports (bin/logs/prebuilt-reports).
+    // Use a wildcard here since we probably want anything added to
+    // bin/logs to show up in Jenkins anyway.
+    archivalSettings.addFiles("${logRoot}bin/logs/**/*")
+    archivalSettings.addFiles("${logRoot}src/**/*.binlog")
+    archivalSettings.addFiles("${logRoot}src/**/*.log")
+    archivalSettings.addFiles("${logRoot}init-tools.log")
+    archivalSettings.addFiles("${logRoot}msbuild.log")
+    archivalSettings.addFiles("${logRoot}testing-smoke/smoke-test.log")
+  }
 
   archivalSettings.setFailIfNothingArchived()
   archivalSettings.setAlwaysArchive()

--- a/netci.groovy
+++ b/netci.groovy
@@ -13,10 +13,7 @@ def addArchival(def job) {
   // Grab these logs from all of those locations.
   [ "", "source-build/", "tarball-output/"].each { logRoot ->
     archivalSettings.addFiles("${logRoot}bin/logs/*")
-    // also grab prebuilt reports (bin/logs/prebuilt-reports).
-    // Use a wildcard here since we probably want anything added to
-    // bin/logs to show up in Jenkins anyway.
-    archivalSettings.addFiles("${logRoot}bin/logs/**/*")
+    archivalSettings.addFiles("${logRoot}bin/prebuilt-report/*")
     archivalSettings.addFiles("${logRoot}src/**/*.binlog")
     archivalSettings.addFiles("${logRoot}src/**/*.log")
     archivalSettings.addFiles("${logRoot}init-tools.log")

--- a/netci.groovy
+++ b/netci.groovy
@@ -14,7 +14,7 @@ def addArchival(def job) {
   archivalSettings.addFiles("msbuild.log")
   archivalSettings.addFiles("testing-smoke/smoke-test.log")
   archivalSettings.setFailIfNothingArchived()
-  archivalSettings.setArchiveOnFailure()
+  archivalSettings.setAlwaysArchive()
 
   Utilities.addArchival(job, archivalSettings)
 }

--- a/netci.groovy
+++ b/netci.groovy
@@ -7,7 +7,11 @@ loggingOptions = "/clp:v=detailed /p:MinimalConsoleLogOutput=false";
 
 def addArchival(def job) {
   def archivalSettings = new ArchivalSettings()
-  archivalSettings.addFiles("src/**/artifacts/**/log/*.binlog")
+  archivalSettings.addFiles("bin/logs/*")
+  archivalSettings.addFiles("src/**/*.binlog")
+  archivalSettings.addFiles("src/**/*.log")
+  archivalSettings.addFiles("init-tools.log")
+  archivalSettings.addFiles("msbuild.log")
   archivalSettings.addFiles("testing-smoke/smoke-test.log")
   archivalSettings.setFailIfNothingArchived()
   archivalSettings.setArchiveOnFailure()

--- a/netci.groovy
+++ b/netci.groovy
@@ -8,6 +8,8 @@ loggingOptions = "";
 def addArchival(def job) {
   def archivalSettings = new ArchivalSettings()
   archivalSettings.addFiles("bin/logs/*")
+  // also grab prebuilt reports
+  archivalSettings.addFiles("bin/logs/**/*")
   archivalSettings.addFiles("src/**/*.binlog")
   archivalSettings.addFiles("src/**/*.log")
   archivalSettings.addFiles("init-tools.log")
@@ -15,12 +17,14 @@ def addArchival(def job) {
   archivalSettings.addFiles("testing-smoke/smoke-test.log")
   // tarball builds use subdirectories, so add these
   archivalSettings.addFiles("source-build/bin/logs/*")
+  archivalSettings.addFiles("source-build/bin/logs/**/*")
   archivalSettings.addFiles("source-build/src/**/*.binlog")
   archivalSettings.addFiles("source-build/src/**/*.log")
   archivalSettings.addFiles("source-build/init-tools.log")
   archivalSettings.addFiles("source-build/msbuild.log")
   archivalSettings.addFiles("source-build/testing-smoke/smoke-test.log")
   archivalSettings.addFiles("tarball-output/bin/logs/*")
+  archivalSettings.addFiles("tarball-output/bin/logs/**/*")
   archivalSettings.addFiles("tarball-output/src/**/*.binlog")
   archivalSettings.addFiles("tarball-output/src/**/*.log")
   archivalSettings.addFiles("tarball-output/init-tools.log")


### PR DESCRIPTION
I noticed some missing logs while doing the master branch work - not all repos are using binlogs yet so we're missing out on some logs.  This also adds more logs that source-build itself produces.