### PR TITLE
Fix buildbootstrapcli.sh for non-existing outputpath dir

### DIFF
--- a/scripts/bootstrap/buildbootstrapcli.sh
+++ b/scripts/bootstrap/buildbootstrapcli.sh
@@ -134,7 +134,7 @@ while [[ "$1" != "" ]]; do
         ;;
     -outputpath)
         shift
-        __outputpath=`getrealpath $1`
+        __outputpath=$1
         ;;
      *)
     echo "Unknown argument to build.sh $1"; exit 1
@@ -156,7 +156,7 @@ fi
 __build_arch=${__runtime_id#*-}
 
 if [[ -z "$__outputpath" ]]; then
-   __outputpath=`getrealpath $__runtime_id/dotnetcli`
+   __outputpath=$__runtime_id/dotnetcli
 fi
 
 if [[ -d "$__outputpath" ]]; then
@@ -165,6 +165,8 @@ fi
 
 mkdir -p $__runtime_id
 mkdir -p $__outputpath
+
+__outputpath=`getrealpath $__outputpath`
 
 cd $__runtime_id
 


### PR DESCRIPTION
`scripts/bootstrap/buildbootstrapcli.sh` claims to work with this invocation:

      ./scripts/bootstrap/buildbootstrapcli.sh -rid linux-x64 -seedcli Tools/dotnetcli/

But it fails with an error:

      realpath: linux-x64/dotnetcli: No such file or directory

Adding a `set -x` shows:

    + __build_arch=x64
    + [[ -z '' ]]
    ++ getrealpath linux-x64/dotnetcli
    ++ command -v realpath
    ++ realpath linux-x64/dotnetcli
    realpath: linux-x64/dotnetcli: No such file or directory
    + __outputpath=

This error is caused by the use of `realpath` (or `readlink -e`) on the computed value of `$__outputpath` before the directory has been created.

The directory is actually created later on by this script, so the fix is to just defer the `realpath` invocation until the script has done an `mkdir -p` on it.