### PR TITLE
[release/2.1] Tarball build, smoke-test startup fixes

### DIFF
--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -2,22 +2,49 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-if [ -z "${1:-}" ]; then
+usage() {
     echo "usage: $0 <path-to-tarball-root> [--skip-build]"
+    echo ""
+}
+
+if [ -z "${1:-}" ]; then
+    usage
     exit 1
 fi
 
+TARBALL_ROOT=$1
+shift
+
 SKIP_BUILD=0
 
-if [ "${2:-}" == "--skip-build" ]; then
-    SKIP_BUILD=1
-fi
+while :; do
+    if [ $# -le 0 ]; then
+        break
+    fi
 
-TARBALL_ROOT=$1
+    lowerI="$(echo $1 | awk '{print tolower($0)}')"
+    case $lowerI in
+        -?|-h|--help)
+            usage
+            exit 0
+            ;;
+        --skip-build)
+            SKIP_BUILD=1
+            ;;
+        *)
+            echo "Unrecognized argument '$1'"
+            usage
+            exit 1
+            ;;
+    esac
+
+    shift
+done
+
 export FULL_TARBALL_ROOT=$(readlink -f $TARBALL_ROOT)
 
 if [ -e "$TARBALL_ROOT" ]; then
-    echo "error '$TARBALL_ROOT' exists"
+    echo "info: '$TARBALL_ROOT' already exists"
 fi
 
 export SCRIPT_ROOT="$(cd -P "$( dirname "$0" )" && pwd)"

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -57,7 +57,7 @@ while :; do
     case $lowerI in
         -?|-h|--help)
             usage
-            exit 1
+            exit 0
             ;;
         --dotnetdir)
             shift
@@ -106,6 +106,7 @@ while :; do
             archiveRestoredPackages=true
             ;;
         *)
+            echo "Unrecognized argument '$1'"
             usage
             exit 1
             ;;


### PR DESCRIPTION
Port https://github.com/dotnet/source-build/pull/674 to release/2.1 (clean cherry-pick)

Once this goes in, we should get a automatic merge PR to release/2.2 via https://github.com/dotnet/versions/pull/339.

> * Catch some bad build-source-tarball args and exit
> 
> Add an arg parsing loop, and stop running if something isn't recognized. For example, this prevents destroying my dev build if I spell "--skip-build" wrong or get the arg order incorrect.
> 
> * Use exit code 0 for "--help"
> 
> Also add unrecognized arg print in smoke-test.sh.
> 
> * TARBALL_ROOT already existing isn't an error
> 
> CI creates TARBALL_ROOT before building the tarball. Still include the message as informational in case it's useful to diagnose other scenarios.
> 
> (cherry picked from commit 9a012ebbec82e06e0c8cf53ad10c271940f5c170)