### PR TITLE
Do not run dotnet when bootstrapping coreclr

### DIFF
--- a/scripts/bootstrap/buildbootstrapcli.sh
+++ b/scripts/bootstrap/buildbootstrapcli.sh
@@ -237,7 +237,7 @@ cd ..
 
 echo "**** BUILDING CORECLR NATIVE COMPONENTS ****"
 cd coreclr
-./build.sh $__configuration $__build_arch $__clangversion -skipgenerateversion -skipmscorlib -skiprestore -skiprestoreoptdata -skipnuget -nopgooptimize 2>&1 | tee coreclr.log
+./build.sh $__configuration $__build_arch $__clangversion -skipgenerateversion -skipmanaged -skipmscorlib -skiprestore -skiprestoreoptdata -skipnuget -nopgooptimize 2>&1 | tee coreclr.log
 export __coreclrbin=$(cat coreclr.log | sed -n -e 's/^.*Product binaries are available at //p')
 cd ..
 echo "CoreCLR binaries will be copied from $__coreclrbin"


### PR DESCRIPTION
This makes it easier to bootstrap incompatible Linux x86_64 distributions. The existing builds of .NET Core won't run there but the boostrap script will still (indirectly) try and run `dotnet` when building coreclr. That `dotnet` invocation will fail causing the bootstrap process to fail.

This depends on the coreclr ~~submodule~~ of the version being bootstrapped to include https://github.com/dotnet/coreclr/pull/19111 to correctly fix the issue. Otherwise there wont be any difference and `dotnet` might still be executed.

Fixes #663