### PR TITLE
[release/2.1] Split smoke test prebuilts out of main tarball

### DIFF
--- a/.vsts.pipelines/phases/ci-linux.yml
+++ b/.vsts.pipelines/phases/ci-linux.yml
@@ -129,9 +129,13 @@ phases:
 
   # tar the tarball directory into the drop directory.
   - script: |
-      $(docker.run) $(docker.tb.map) $(docker.drop.map) $(imageName) /bin/bash -c '
+      $(docker.run) $(docker.tb.map) $(docker.drop.map) $(docker.tb.work) $(imageName) /bin/bash -c '
         mkdir -p /drop/tarball/
-        tar -zcf "/drop/tarball/$(tarballName).tar.gz" "/tb/$(tarballName)"'
+        smokeTestPackages="$(tarballName)/prebuilt/smoke-test-packages"
+        find "$smokeTestPackages" -iname "*.nupkg" -exec mv {} "$smokeTestPackages" \;
+        find "$smokeTestPackages" -not -iname "*.nupkg" -delete
+        tar --numeric-owner "--exclude=$smokeTestPackages" -zcf "/drop/tarball/$(tarballName).tar.gz" "$(tarballName)"
+        tar --numeric-owner -zcf "/drop/tarball/$(tarballName)-smoke-test-prereqs.tar.gz" "$smokeTestPackages"'
     displayName: Copy tarball to output
     condition: and(succeeded(), eq(variables['buildOfflineTarball'], true))
 

--- a/.vsts.pipelines/phases/ci-linux.yml
+++ b/.vsts.pipelines/phases/ci-linux.yml
@@ -132,8 +132,14 @@ phases:
       $(docker.run) $(docker.tb.map) $(docker.drop.map) $(docker.tb.work) $(imageName) /bin/bash -c '
         mkdir -p /drop/tarball/
         smokeTestPackages="$(tarballName)/prebuilt/smoke-test-packages"
+        # smokeTestPackages is a package cache, with redundant data and unnecessary structure. E.g.
+        # $smokeTestPackages/name/version/name.version.nupkg <- We want this.
+        # $smokeTestPackages/name/version/lib/net46/name.dll <- This is already in the nupkg.
+        # This find moves the nupkg files into $smokeTestPackages:
         find "$smokeTestPackages" -iname "*.nupkg" -exec mv {} "$smokeTestPackages" \;
+        # This find removes all non-nupkg files, which are not wanted:
         find "$smokeTestPackages" -not -iname "*.nupkg" -delete
+        # Make one .tar.gz for build, another for extras necessary to smoke test:
         tar --numeric-owner "--exclude=$smokeTestPackages" -zcf "/drop/tarball/$(tarballName).tar.gz" "$(tarballName)"
         tar --numeric-owner -zcf "/drop/tarball/$(tarballName)-smoke-test-prereqs.tar.gz" "$smokeTestPackages"'
     displayName: Copy tarball to output


### PR DESCRIPTION
* Create two tarballs: split the smoke test prereqs into a separate tarball. They aren't required at all for builds, and for smoke-test, they're only required when the packages can't easily be acquired through the usual endpoint.
* Reduce `prebuilt/smoke-test-packages/` from an expanded NuGet package cache to a directory of nupkg files. This eliminates the redundancy of having both the nupkgs and their expanded contents in the tarball. (290 MB => 146 MB.)
* Set the working directory so the tarball has the `tarball_<build number>` dir in it, not `tb/tarball_<build number>` (absolute path).

We did these fixes by hand a few times--it'll be nice to get them in by default.

The tarball's still missing a nice name. Right now it's like `tarball_1967206-smoke-test-prereqs.tar.gz`. I can't think of a great way to get the branding (like `2.1.3`) in.

Example build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=1967945