### PR TITLE
 Merge branch 'release/2.2' into 'master'

### DIFF
--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -138,7 +138,6 @@ if [ -z "${SOURCE_BUILD_SKIP_PREBUILT_REPORT:-}" ]; then
     )
 fi
 
-
 echo 'WORKAROUND: Overwriting the source-built roslyn-tools MSBuild files with prebuilt so that roslyn-tools can successfully build in the tarball... (https://github.com/dotnet/source-build/issues/654)'
 
 ROSLYN_TOOLS_PACKAGE='RoslynTools.RepoToolset'

--- a/dependencies.props
+++ b/dependencies.props
@@ -23,6 +23,16 @@
     <ILLinkTasksPackageVersion>0.1.5-preview-1461378</ILLinkTasksPackageVersion>
   </PropertyGroup>
 
+  <!--
+    Packages built by ProdCon, but not source-build. These are included as prebuilts, or embedded in
+    the product as version strings to be used by the SDK to fetch extra content.
+  -->
+  <PropertyGroup>
+    <MicrosoftAspNetCoreAllPackageVersion>2.1.0</MicrosoftAspNetCoreAllPackageVersion>
+    <MicrosoftAspNetCoreAppPackageVersion>2.1.0</MicrosoftAspNetCoreAppPackageVersion>
+    <MicrosoftNETSdkRazorPackageVersion>2.1.0</MicrosoftNETSdkRazorPackageVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- Get ILAsm tool version from CoreCLR. -->
     <RemoteDependencyBuildInfo Include="CoreClr">

--- a/dependencies.targets
+++ b/dependencies.targets
@@ -95,5 +95,20 @@
         ReplacementSubstituteOld="$(ProdConBlobFeedReplaceOld)"
         ReplacementSubstituteNew="$(ProdConBlobFeedReplaceNew)" />
     </ItemGroup>
+
+    <!-- Upgrade some package versions that are built only by ProdCon. -->
+    <ItemGroup>
+      <PackageUpdatedFromProdCon Include="Microsoft.AspNetCore.All" Element="MicrosoftAspNetCoreAllPackageVersion" />
+      <PackageUpdatedFromProdCon Include="Microsoft.AspNetCore.App" Element="MicrosoftAspNetCoreAppPackageVersion" />
+      <PackageUpdatedFromProdCon Include="Microsoft.NET.Sdk.Razor" Element="MicrosoftNETSdkRazorPackageVersion" />
+
+      <UpdateStep
+        Include="ProdCon"
+        UpdaterType="Orchestrated blob feed package version"
+        PackageId="@(PackageUpdatedFromProdCon)"
+        Path="$(MSBuildThisFileDirectory)dependencies.props"
+        ElementName="%(PackageUpdatedFromProdCon.Element)"
+        SkipIfNoReplacementFound="true" />
+    </ItemGroup>
   </Target>
 </Project>

--- a/netci.groovy
+++ b/netci.groovy
@@ -1,5 +1,5 @@
-import jobs.generation.Utilities;
 import jobs.generation.ArchivalSettings;
+import jobs.generation.Utilities;
 
 def project = GithubProject;
 def branch = GithubBranchName;

--- a/repos/cli.proj
+++ b/repos/cli.proj
@@ -36,12 +36,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ExtraPackageVersionPropsPackageInfo
-      Include="
-        Microsoft.AspNetCore.All;
-        Microsoft.AspNetCore.App;
-        Microsoft.NET.Sdk.Razor"
-      Version="2.1.0" />
+    <ExtraPackageVersionPropsPackageInfo Include="Microsoft.AspNetCore.All" Version="$(MicrosoftAspNetCoreAllPackageVersion)" />
+    <ExtraPackageVersionPropsPackageInfo Include="Microsoft.AspNetCore.App" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
+    <ExtraPackageVersionPropsPackageInfo Include="Microsoft.NET.Sdk.Razor" Version="$(MicrosoftNETSdkRazorPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I think we should try to turn on automation to merge `release/2.2` => `master`. This would let us make infra PRs once to `release/2.1` and they'd be merged automatically to `release/2.2` then `master`. I made this one-time cleanup merge (wasn't too bad) to prepare. Think this makes sense?