### PR TITLE
Find test-only prebuilts with simple path patterns

### DIFF
--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -419,6 +419,16 @@
       <FailOnPrebuiltBaselineError Condition="'$(FailOnPrebuiltBaselineError)' == ''">false</FailOnPrebuiltBaselineError>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageVersionPropsSavedSnapshotFiles Include="$(PackageReportDir)snapshots/PackageVersions.props.pre.*.xml" />
+    </ItemGroup>
+
+    <WriteUsageReports DataFile="$(PackageReportDataFile)"
+                       PackageVersionPropsSnapshots="@(PackageVersionPropsSavedSnapshotFiles)"
+                       ProdConBuildManifestFile="$(ProdConManifestFile)"
+                       PoisonedReportFile="$(PoisonedReportFile)"
+                       OutputDirectory="$(PackageReportDir)" />
+
     <PropertyGroup Condition="'$(ContinueOnPrebuiltBaselineError)' == ''">
       <ContinueOnPrebuiltBaselineError>false</ContinueOnPrebuiltBaselineError>
       <ContinueOnPrebuiltBaselineError Condition="'$(FailOnPrebuiltBaselineError)' != 'true'">true</ContinueOnPrebuiltBaselineError>
@@ -430,16 +440,6 @@
       OutputBaselineFile="$(PackageReportDir)generated-new-baseline.xml"
       OutputReportFile="$(PackageReportDir)baseline-comparison.xml"
       ContinueOnError="$(ContinueOnPrebuiltBaselineError)" />
-
-    <ItemGroup>
-      <PackageVersionPropsSavedSnapshotFiles Include="$(PackageReportDir)snapshots/PackageVersions.props.pre.*.xml" />
-    </ItemGroup>
-
-    <WriteUsageReports DataFile="$(PackageReportDataFile)"
-                       PackageVersionPropsSnapshots="@(PackageVersionPropsSavedSnapshotFiles)"
-                       ProdConBuildManifestFile="$(ProdConManifestFile)"
-                       PoisonedReportFile="$(PoisonedReportFile)"
-                       OutputDirectory="$(PackageReportDir)" />
   </Target>
 
   <Target Name="GetProjectDirectory" Outputs="$(ProjectDirectory)" />

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/AnnotatedUsage.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/AnnotatedUsage.cs
@@ -14,6 +14,8 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
         public string SourceBuildPackageIdCreator { get; set; }
         public string ProdConPackageIdCreator { get; set; }
         public bool EndsUpInOutput { get; set; }
+        public bool TestProjectByHeuristic { get; set; }
+        public bool TestProjectOnlyByHeuristic { get; set; }
 
         public XElement ToXml() => new XElement(
             nameof(AnnotatedUsage),
@@ -21,6 +23,8 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
             Project.ToXAttributeIfNotNull(nameof(Project)),
             SourceBuildPackageIdCreator.ToXAttributeIfNotNull(nameof(SourceBuildPackageIdCreator)),
             ProdConPackageIdCreator.ToXAttributeIfNotNull(nameof(ProdConPackageIdCreator)),
+            TestProjectByHeuristic.ToXAttributeIfTrue(nameof(TestProjectByHeuristic)),
+            TestProjectOnlyByHeuristic.ToXAttributeIfTrue(nameof(TestProjectOnlyByHeuristic)),
             EndsUpInOutput.ToXAttributeIfTrue(nameof(EndsUpInOutput)));
     }
 }


### PR DESCRIPTION
Use some extremely simple checks against the project.assets.json path to determine which usages are performed by a test project, and which package-versions are restored only by test projects. These are added to `annotated-usage.xml` as `TestProjectByHeuristic="true"` (per usage) and `TestProjectOnlyByHeuristic="true"` (added to all usages of the package-version).

Also, write usage reports before baseline validation to make sure info is always generated.

https://github.com/dotnet/source-build/issues/730