### PR TITLE
Organize build args for readability/mergeability

### DIFF
--- a/repos/application-insights.proj
+++ b/repos/application-insights.proj
@@ -10,15 +10,21 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
 
   <Target Name="RepoBuild">
-    <Exec Command="$(DotnetToolCommand) restore $(ProjectDirectory)/Microsoft.ApplicationInsights.csproj /p:Configuration=$(Configuration) /bl:restore.binlog $(RedirectRepoOutputToLog)"
+    <PropertyGroup>
+      <BuildCommandArgs>$(ProjectDirectory)/Microsoft.ApplicationInsights.csproj</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /p:Configuration=$(Configuration)</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) $(RedirectRepoOutputToLog)</BuildCommandArgs>
+    </PropertyGroup>
+
+    <Exec Command="$(DotnetToolCommand) restore /bl:restore.binlog $(BuildCommandArgs)  "
           EnvironmentVariables="@(EnvironmentVariables)"
           WorkingDirectory="$(ProjectDirectory)" />
 
-    <Exec Command="$(DotnetToolCommand) build $(ProjectDirectory)/Microsoft.ApplicationInsights.csproj /p:Configuration=$(Configuration) /bl:build.binlog $(RedirectRepoOutputToLog)"
+    <Exec Command="$(DotnetToolCommand) build /bl:build.binlog $(BuildCommandArgs)"
           EnvironmentVariables="@(EnvironmentVariables)"
           WorkingDirectory="$(ProjectDirectory)" />
 
-    <Exec Command="$(DotnetToolCommand) pack $(ProjectDirectory)/Microsoft.ApplicationInsights.csproj /p:Configuration=$(Configuration) /bl:pack.binlog $(RedirectRepoOutputToLog)"
+    <Exec Command="$(DotnetToolCommand) pack /bl:pack.binlog $(BuildCommandArgs)"
           EnvironmentVariables="@(EnvironmentVariables)"
           WorkingDirectory="$(ProjectDirectory)" />
   </Target>

--- a/repos/core-setup.proj
+++ b/repos/core-setup.proj
@@ -8,10 +8,19 @@
     <OverridePortableBuild Condition="'$(TargetOS)' == 'OSX'">true</OverridePortableBuild>
     <OverrideTargetRid Condition="'$(TargetOS)' == 'OSX'">osx-x64</OverrideTargetRid>
 
-    <BuildArguments>-ConfigurationGroup=$(Configuration) -PortableBuild=$(OverridePortableBuild) -SkipTests=true </BuildArguments>
+    <BuildArguments>-ConfigurationGroup=$(Configuration)</BuildArguments>
+    <BuildArguments>$(BuildArguments) -PortableBuild=$(OverridePortableBuild)</BuildArguments>
+    <BuildArguments>$(BuildArguments) -SkipTests=true</BuildArguments>
     <BuildArguments Condition="$(Platform.Contains('arm'))">$(BuildArguments) -TargetArchitecture=$(Platform) -DisableCrossgen=true -CrossBuild=true</BuildArguments>
-    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments) -- /p:BuildDebPackage=false /p:BuildAllPackages=true /p:OutputRid=$(OverrideTargetRid) /bl</BuildCommand>
+    <BuildArguments>$(BuildArguments) --</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:BuildDebPackage=false</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:BuildAllPackages=true</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:OutputRid=$(OverrideTargetRid)</BuildArguments>
+    <BuildArguments>$(BuildArguments) /bl</BuildArguments>
+
+    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments)</BuildCommand>
     <BuildCommand Condition="$(Platform.Contains('arm'))">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
+
     <OfficialBuildId>20180919-01</OfficialBuildId>
 
     <!-- Need to set $(PackagesOutput) so WriteVersions writes the versions file for cli, until cli respects auto-dependency flow -->

--- a/repos/coreclr.proj
+++ b/repos/coreclr.proj
@@ -6,13 +6,18 @@
     <OverridePortableBuild>$(PortableBuild)</OverridePortableBuild>
     <OverridePortableBuild Condition="'$(TargetOS)' == 'OSX'">true</OverridePortableBuild>
 
-    <BuildArguments>$(Platform) $(Configuration) skiptests -PortableBuild=$(OverridePortableBuild) </BuildArguments>
+    <BuildArguments>$(Platform) $(Configuration) skiptests</BuildArguments>
+    <BuildArguments>$(BuildArguments) -PortableBuild=$(OverridePortableBuild)</BuildArguments>
     <BuildArguments Condition="'$(SkipDisablePgo)' != 'true'">$(BuildArguments) -nopgooptimize</BuildArguments>
     <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) msbuildonunsupportedplatform</BuildArguments>
     <BuildArguments Condition="'$(UseSystemLibraries)' == 'true'">$(BuildArguments) cmakeargs -DCLR_CMAKE_USE_SYSTEM_LIBUNWIND=TRUE</BuildArguments>
     <BuildArguments Condition="$(Platform.Contains('arm'))">$(BuildArguments) skipnuget cross -skiprestore cmakeargs -DFEATURE_GDBJIT=TRUE</BuildArguments>
-    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments) --</BuildCommand>
+    <BuildArguments>$(BuildArguments) --</BuildArguments>
+
+    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments)</BuildCommand>
+
     <BuildCommand Condition="$(Platform.Contains('arm'))">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
+
     <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension)</CleanCommand>
     <OfficialBuildId>20180919-02</OfficialBuildId>
   </PropertyGroup>

--- a/repos/corefx.proj
+++ b/repos/corefx.proj
@@ -8,9 +8,18 @@
     <OverrideTargetRid>$(TargetRid)</OverrideTargetRid>
     <OverrideTargetRid Condition="'$(TargetOS)' == 'OSX'">osx-x64</OverrideTargetRid>
 
-    <BuildArguments>-$(Configuration) -buildArch=$(Platform) -portable=$(OverridePortableBuild) -BuildTests=false -PackageRid=$(OverrideTargetRid)</BuildArguments>
-    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments) -- /p:BuildAllPackages=true /bl</BuildCommand>
+    <BuildArguments>-$(Configuration)</BuildArguments>
+    <BuildArguments>$(BuildArguments) -buildArch=$(Platform)</BuildArguments>
+    <BuildArguments>$(BuildArguments) -portable=$(OverridePortableBuild) </BuildArguments>
+    <BuildArguments>$(BuildArguments) -BuildTests=false</BuildArguments>
+    <BuildArguments>$(BuildArguments) -PackageRid=$(OverrideTargetRid)</BuildArguments>
+    <BuildArguments>$(BuildArguments) --</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:BuildAllPackages=true</BuildArguments>
+    <BuildArguments>$(BuildArguments) /bl</BuildArguments>
+
+    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments)</BuildCommand>
     <BuildCommand Condition="$(Platform.Contains('arm'))">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
+
     <PackagesOutput>$(ProjectDirectory)/bin/packages/$(Configuration)</PackagesOutput>
     <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension)</CleanCommand>
     <OfficialBuildId>20180919-02</OfficialBuildId>

--- a/repos/msbuild.proj
+++ b/repos/msbuild.proj
@@ -6,8 +6,22 @@
     <!-- Override value from commit to match expected build. -->
     <OfficialBuildId>20180426.1</OfficialBuildId>
     <PackagesOutput>$(ProjectDirectory)/artifacts/$(Configuration)/packages</PackagesOutput>
-    <OutputVersionArgs>/p:VersionPrefix=15.7.179 /p:DisableNerdbankVersioning=true /p:PreReleaseVersionLabel="" /p:BUILD_BUILDNUMBER=$(OfficialBuildId)</OutputVersionArgs>
-    <BuildCommand>$(ProjectDirectory)build/build$(ShellExtension) build -DotNetBuildFromSource -DotNetCoreSdkDir $(DotNetCliToolDir) -bootstraponly -skiptests -pack -configuration $(Configuration) /p:GitHeadSha=$(GitCommitHash) $(OutputVersionArgs)</BuildCommand>
+
+    <OutputVersionArgs>/p:VersionPrefix=15.7.179</OutputVersionArgs>
+    <OutputVersionArgs>$(OutputVersionArgs) /p:DisableNerdbankVersioning=true</OutputVersionArgs>
+    <OutputVersionArgs>$(OutputVersionArgs) /p:PreReleaseVersionLabel=""</OutputVersionArgs>
+    <OutputVersionArgs>$(OutputVersionArgs) /p:BUILD_BUILDNUMBER=$(OfficialBuildId)</OutputVersionArgs>
+
+    <BuildCommandArgs>build -DotNetBuildFromSource</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) -DotNetCoreSdkDir $(DotNetCliToolDir)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) -bootstraponly</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) -skiptests</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) -pack</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) -configuration $(Configuration)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:GitHeadSha=$(GitCommitHash)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) $(OutputVersionArgs)</BuildCommandArgs>
+
+    <BuildCommand>$(ProjectDirectory)build/build$(ShellExtension) $(BuildCommandArgs)</BuildCommand>
     <SourceOverrideRepoApiImplemented>true</SourceOverrideRepoApiImplemented>
     <RepoApiImplemented>false</RepoApiImplemented>
     <UsesRepoToolset>true</UsesRepoToolset>

--- a/repos/nuget-client.proj
+++ b/repos/nuget-client.proj
@@ -44,7 +44,7 @@
 
     <PropertyGroup>
       <PackCommand>$(BuildCommandBase) /t:PackXPlat</PackCommand>
-      <PackCommand>$(PackCommand) /p:PackagOutputPath=$(PackagesOutput)</PackCommand>
+      <PackCommand>$(PackCommand) /p:PackageOutputPath=$(PackagesOutput)</PackCommand>
       <PackCommand>$(PackCommand) /p:NoPackageAnalysis=true</PackCommand>
       <PackCommand>$(PackCommand) /flp:v=detailed</PackCommand>
       <PackCommand>$(PackCommand) /bl:pack.binlog</PackCommand>

--- a/repos/nuget-client.proj
+++ b/repos/nuget-client.proj
@@ -26,16 +26,32 @@
 
   <Target Name="RepoBuild"
           DependsOnTargets="InitSubmodules">
+    <PropertyGroup>
+      <BuildCommandBase>$(DotnetToolCommand) msbuild $(ProjectDirectory)/build/build.proj</BuildCommandBase>
+      <BuildCommandBase>$(BuildCommandBase) /p:VisualStudioVerion=15.0</BuildCommandBase>
+      <BuildCommandBase>$(BuildCommandBase) /p:Configuration=$(Configuration)</BuildCommandBase>
+      <BuildCommandBase>$(BuildCommandBase) /p:BuildRTM=false</BuildCommandBase>
+      <BuildCommandBase>$(BuildCommandBase) /p:BuildNumber=$(NuGetClientBuildNumber)</BuildCommandBase>
+    </PropertyGroup>
 
-    <Exec Command="$(DotnetToolCommand) msbuild $(ProjectDirectory)/build/build.proj /t:RestoreXPLAT /p:VisualStudioVerion=15.0 /p:Configuration=$(Configuration) /p:BuildRTM=false /p:BuildNumber=$(NuGetClientBuildNumber) /bl:restore.binlog $(RedirectRepoOutputToLog)"
+    <Exec Command="$(BuildCommandBase) /t:RestoreXPLAT /bl:restore.binlog $(RedirectRepoOutputToLog)"
           EnvironmentVariables="@(EnvironmentVariables)"
           WorkingDirectory="$(ProjectDirectory)" />
 
-    <Exec Command="$(DotnetToolCommand) msbuild $(ProjectDirectory)/build/build.proj /t:BuildXPLAT /p:VisualStudioVerion=15.0 /p:Configuration=$(Configuration) /p:BuildRTM=false /p:BuildNumber=$(NuGetClientBuildNumber) /bl:build.binlog $(RedirectRepoOutputToLog)"
+    <Exec Command="$(BuildCommandBase) /t:BuildXPLAT /bl:build.binlog $(RedirectRepoOutputToLog)"
           EnvironmentVariables="@(EnvironmentVariables)"
           WorkingDirectory="$(ProjectDirectory)" />
 
-    <Exec Command="$(DotnetToolCommand) msbuild $(ProjectDirectory)/build/build.proj /t:PackXPLAT /p:VisualStudioVerion=15.0 /p:Configuration=$(Configuration) /p:BuildRTM=false /p:BuildNumber=$(NuGetClientBuildNumber) /p:PackageOutputPath=$(PackagesOutput) /p:NoPackageAnalysis=true /flp:v=detailed /bl:pack.binlog $(RedirectRepoOutputToLog)"
+    <PropertyGroup>
+      <PackCommand>$(BuildCommandBase) /t:PackXPlat</PackCommand>
+      <PackCommand>$(PackCommand) /p:PackagOutputPath=$(PackagesOutput)</PackCommand>
+      <PackCommand>$(PackCommand) /p:NoPackageAnalysis=true</PackCommand>
+      <PackCommand>$(PackCommand) /flp:v=detailed</PackCommand>
+      <PackCommand>$(PackCommand) /bl:pack.binlog</PackCommand>
+      <PackCommand>$(PackCommand) $(RedirectRepoOutputToLog)</PackCommand>
+    </PropertyGroup>
+
+    <Exec Command="$(PackCommand)"
           EnvironmentVariables="@(EnvironmentVariables)"
           WorkingDirectory="$(ProjectDirectory)" />
   </Target>

--- a/repos/roslyn.proj
+++ b/repos/roslyn.proj
@@ -5,7 +5,16 @@
   <PropertyGroup>
     <NuGetPackageVersion>2.3.2-beta1-61921-05</NuGetPackageVersion>
     <BuildNumber>20180426.3</BuildNumber>
-    <BuildCommand>$(DotnetToolCommand) build $(ProjectDirectory)/SourceBuild.sln /p:Configuration=$(Configuration) /p:OfficialBuild=true /p:BuildNumber=$(BuildNumber) /bl:build.binlog</BuildCommand>
+
+    <BuildCommandArgs>build</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) $(ProjectDirectory)/SourceBuild.sln</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:Configuration=$(Configuration)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:OfficialBuild=true</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:BuildNumber=$(BuildNumber)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /bl:build.binlog</BuildCommandArgs>
+
+    <BuildCommand>$(DotnetToolCommand) $(BuildCommandArgs)</BuildCommand>
+
     <PackagesOutput>$(ProjectDirectory)/Binaries/packages</PackagesOutput>
     <RepoApiImplemented>false</RepoApiImplemented>
     <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
@@ -31,12 +40,19 @@
 
   <Target Name="Restore" BeforeTargets="Build">
     <PropertyGroup>
-      <RestoreArgs Condition="'$(OS)' != 'Windows_NT'">--disable-parallel</RestoreArgs>
+      <RestoreArgs>restore</RestoreArgs>
+      <RestoreArgs Condition="'$(OS)' != 'Windows_NT'">$(RestoreArgs) --disable-parallel</RestoreArgs>
+      <RestoreArgs>$(RestoreArgs) $(ProjectDirectory)/SourceBuild.sln</RestoreArgs>
+      <RestoreArgs>$(RestoreArgs) $(RedirectRepoOutputToLog)</RestoreArgs>
     </PropertyGroup>
 
-    <Exec Command="$(DotnetToolCommand) restore $(RestoreArgs) $(ProjectDirectory)/SourceBuild.sln $(RedirectRepoOutputToLog)"
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Restoring 'roslyn'" />
+
+    <Exec Command="$(DotnetToolCommand) $(RestoreArgs)"
           WorkingDirectory="$(ProjectDirectory)"
           EnvironmentVariables="@(EnvironmentVariables)" />
+
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Restoring 'roslyn'...done" />
   </Target>
 
   <Target Name="FixNuSpecFilePathSeparators" BeforeTargets="Build">
@@ -56,13 +72,34 @@
     </ItemGroup>
 
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Packaging 'roslyn'" />
+
     <!-- Publish MSBuild project so that Microsoft.NETCore.Compilers.nuspec can find runtimes. -->
-    <Exec Command="$(DotnetToolCommand) msbuild %(PublishWithoutBuildingProject.Identity) /p:Configuration=$(Configuration) /p:TargetFramework=netcoreapp2.0 /t:PublishWithoutBuilding /bl:publish.binlog $(RedirectRepoOutputToLog)"
+    <PropertyGroup>
+      <PublishCommandArgs>msbuild</PublishCommandArgs>
+      <PublishCommandArgs>$(PublishCommandArgs) /p:Configuration=$(Configuration)</PublishCommandArgs>
+      <PublishCommandArgs>$(PublishCommandArgs) /p:TargetFramework=netcoreapp2.0</PublishCommandArgs>
+      <PublishCommandArgs>$(PublishCommandArgs) /t:PublishWithoutBuilding</PublishCommandArgs>
+      <PublishCommandArgs>$(PublishCommandArgs) /bl:publish.binlog</PublishCommandArgs>
+    </PropertyGroup>
+
+    <Exec Command="$(DotnetToolCommand) $(PublishCommandArgs) %(PublishWithoutBuildingProject.Identity) $(RedirectRepoOutputToLog)"
           WorkingDirectory="$(ProjectDirectory)"
           EnvironmentVariables="@(EnvironmentVariables)" />
-    <Exec Command="$(DotnetToolCommand) pack --no-build $(ProjectDirectory)/src/NuGet/NuGetProjectPackUtil.csproj -p:Configuration=$(Configuration) -p:NuspecFile=%(NuSpecFiles.Identity) -p:NuspecBasePath=$(ProjectDirectory)/Binaries/$(Configuration) -p:PackageOutputPath=$(PackagesOutput) -p:NuGetPackageKind=release /bl:pack.binlog $(RedirectRepoOutputToLog)"
+
+    <PropertyGroup>
+      <PackCommandArgs>pack --no-build</PackCommandArgs>
+      <PackCommandArgs>$(PackCommandArgs) $(ProjectDirectory)/src/NuGet/NuGetProjectPackUtil.csproj</PackCommandArgs>
+      <PackCommandArgs>$(PackCommandArgs) -p:Configuration=$(Configuration)</PackCommandArgs>
+      <PackCommandArgs>$(PackCommandArgs) -p:NuspecBasePath=$(ProjectDirectory)/Binaries/$(Configuration)</PackCommandArgs>
+      <PackCommandArgs>$(PackCommandArgs) -p:PackageOutputPath=$(PackagesOutput)</PackCommandArgs>
+      <PackCommandArgs>$(PackCommandArgs) -p:NuGetPackageKind=release</PackCommandArgs>
+      <PackCommandArgs>$(PackCommandArgs) /bl:pack.binlog</PackCommandArgs>
+    </PropertyGroup>
+
+    <Exec Command="$(DotnetToolCommand) $(PackCommandArgs) -p:NuspecFile=%(NuSpecFiles.Identity) $(RedirectRepoOutputToLog)"
           WorkingDirectory="$(ProjectDirectory)"
           EnvironmentVariables="@(EnvironmentVariables)" />
+
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Packaging 'roslyn'...done" />
   </Target>
 

--- a/repos/sdk.proj
+++ b/repos/sdk.proj
@@ -3,13 +3,16 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <OfficialBuildId>20180919.1</OfficialBuildId>
+
     <OutputVersionArgs>/p:BUILD_BUILDNUMBER=$(OfficialBuildId)</OutputVersionArgs>
+
     <BuildCommandArgs>--pack --configuration $(Configuration) $(OutputVersionArgs)</BuildCommandArgs>
 
     <!-- Pass in package version props using the Product Construction (ProdCon) API. -->
     <BuildCommandArgs>$(BuildCommandArgs) /p:PB_PackageVersionPropsUrl=file:%2F%2F$(PackageVersionPropsPath)</BuildCommandArgs>
 
     <BuildCommand>$(ProjectDirectory)\build$(ShellExtension) $(BuildCommandArgs)</BuildCommand>
+
     <OrchestratedManifestBuildName>dotnet/sdk</OrchestratedManifestBuildName>
     <!-- NuGet SDK resolver only checks nuget.config files. https://github.com/Microsoft/msbuild/issues/2914 -->
     <NuGetConfigFile>$(ProjectDirectory)/nuget.config</NuGetConfigFile>

--- a/repos/templating.proj
+++ b/repos/templating.proj
@@ -23,12 +23,21 @@
   <ItemGroup>
     <RepositoryReference Include="clicommandlineparser" />
   </ItemGroup>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
 
   <Target Name="RepoBuild">
-    <Exec Command="$(DotnetToolCommand) msbuild /t:Build @(MSBuildProperties->'/p:%(Identity)', ' ') $(ProjectDirectory)/build.proj /bl $(RedirectRepoOutputToLog)"
-          EnvironmentVariables="@(EnvironmentVariables)"
-          WorkingDirectory="$(ProjectDirectory)" />
+    <PropertyGroup>
+      <BuildCommandArgs>/t:Build</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /bl</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) @(MSBuildProperties->'/p:%(Identity)', ' ')</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) $(ProjectDirectory)build.proj</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) $(RedirectRepoOutputToLog)</BuildCommandArgs>
+    </PropertyGroup>
+
+    <Exec Command="$(DotnetToolCommand) msbuild $(BuildCommandArgs)"
+          WorkingDirectory="$(ProjectDirectory)"
+          EnvironmentVariables="@(EnvironmentVariables)" />
 
     <!-- The templates are built to a different folder than the packages, copy them into the packages folder. -->
     <ItemGroup>

--- a/repos/vstest.proj
+++ b/repos/vstest.proj
@@ -2,7 +2,15 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
-    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) -DotnetBuildFromSource -DotnetCoreSdkDir $(DotNetCliToolDir) -c $(Configuration) -r $(TargetRid) -v 15.3.0 -vs preview-20170628-02</BuildCommand>
+    <BuildCommandArgs>-DotNetBuildFromSource</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) -DotNetCoreSdkDir $(DotNetCliToolDir)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) -c $(Configuration)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) -r $(TargetRid)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) -v 15.3.0</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) -vs preview-20170628-02</BuildCommandArgs>
+
+    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildCommandArgs)</BuildCommand>
+
     <PackagesOutput>$(ProjectDirectory)/artifacts/$(Configuration)/packages</PackagesOutput>
     <RepoApiImplemented>false</RepoApiImplemented>
     <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>

--- a/repos/websdk.proj
+++ b/repos/websdk.proj
@@ -4,7 +4,12 @@
   <PropertyGroup>
     <WebSdkVersion>2.0.0-rel-20170629-588</WebSdkVersion>
     <CoreSdkVersion>2.0.0-preview3-20170728-1</CoreSdkVersion>
-    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) /p:SkipTests=true /bl</BuildCommand>
+
+    <BuildCommandArgs>/p:SkipTests=true</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /bl</BuildCommandArgs>
+
+    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildCommandArgs)</BuildCommand>
+
     <PackagesOutput>$(ProjectDirectory)/bin/Release/</PackagesOutput>
     <RepoApiImplemented>false</RepoApiImplemented>
   </PropertyGroup>

--- a/repos/xliff-tasks.proj
+++ b/repos/xliff-tasks.proj
@@ -2,21 +2,26 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
+    <BuildCommandArgs>pack</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) $(ProjectDirectory)src\XliffTasks\XliffTasks.csproj</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /v:normal</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /flp:Verbosity=Diag</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /bl</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) $(RedirectRepoOutputToLog)</BuildCommandArgs>
+
+    <BuildCommand>$(DotnetToolCommand) $(BuildCommandArgs)</BuildCommand>
+
     <PackagesOutput>$(ProjectDirectory)/bin/$(Configuration)</PackagesOutput>
     <BuildNumber>48</BuildNumber>
     <RepoApiImplemented>false</RepoApiImplemented>
     <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
   </PropertyGroup>
+
   <ItemGroup>
     <EnvironmentVariables Include="CommitCount=$(BuildNumber)" />
     <EnvironmentVariables Include="Configuration=$(Configuration)" />
   </ItemGroup>
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
 
-  <Target Name="RepoBuild">
-    <Exec Command="$(DotnetToolCommand) pack $(ProjectDirectory)src\XliffTasks\XliffTasks.csproj /v:normal /flp:Verbosity=Diag /bl $(RedirectRepoOutputToLog)"
-          EnvironmentVariables="@(EnvironmentVariables)"
-          WorkingDirectory="$(ProjectDirectory)" />
-  </Target>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
 </Project>
 


### PR DESCRIPTION
I like splitting args across lines because:

* Diffs (especially 3-way for merging) are hard to read with long lines.
* Automatic diffing can be smarter when the parts are grouped like this.
* Actual conflicts are more likely to be resolvable using basic choose A/B/C.

In a few cases I was able to share some parameters that were duplicated before.