### PR TITLE
Add capture and re-build of reference-only packages to eliminate prebuilts

### DIFF
--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -148,13 +148,13 @@ done
 
 echo 'Removing reference-only packages from tarball prebuilts...'
 
-for built_package in $(find $SCRIPT_ROOT/reference-packages/packages-to-delete/ -name '*.nupkg' | tr '[:upper:]' '[:lower:]')
+for ref_package in $(find $SCRIPT_ROOT/reference-packages/packages-to-delete/ -name '*.nupkg' | tr '[:upper:]' '[:lower:]')
 do
-    if [ -e $TARBALL_ROOT/prebuilt/nuget-packages/$(basename $built_package) ]; then
-        rm $TARBALL_ROOT/prebuilt/nuget-packages/$(basename $built_package)
+    if [ -e $TARBALL_ROOT/prebuilt/nuget-packages/$(basename $ref_package) ]; then
+        rm $TARBALL_ROOT/prebuilt/nuget-packages/$(basename $ref_package)
     fi
-    if [ -e $TARBALL_ROOT/prebuilt/smoke-test-packages/$(basename $built_package) ]; then
-        rm $TARBALL_ROOT/prebuilt/smoke-test-packages/$(basename $built_package)
+    if [ -e $TARBALL_ROOT/prebuilt/smoke-test-packages/$(basename $ref_package) ]; then
+        rm $TARBALL_ROOT/prebuilt/smoke-test-packages/$(basename $ref_package)
     fi
 done
 

--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -119,11 +119,11 @@ mkdir -p $TARBALL_ROOT/prebuilt/source-built
 find $SCRIPT_ROOT/packages -name '*.nupkg' -exec cp {} $TARBALL_ROOT/prebuilt/nuget-packages/ \;
 find $SCRIPT_ROOT/bin/obj/x64/Release/nuget-packages -name '*.nupkg' -exec cp {} $TARBALL_ROOT/prebuilt/nuget-packages/ \;
 
-# Copy reference-packages from bin dir to reference-packages directory.
+# Copy refpkgs from bin dir to refpkgs directory.
 # See corresponding change in dir.props to change ReferencePackagesBasePath conditionally in offline build.
-mkdir -p $TARBALL_ROOT/reference-packages
-cp -r $SCRIPT_ROOT/bin/obj/x64/Release/reference-packages/source $TARBALL_ROOT/reference-packages/source
-cp -r $SCRIPT_ROOT/bin/obj/x64/Release/reference-packages/staging $TARBALL_ROOT/reference-packages/staging
+mkdir -p $TARBALL_ROOT/refpkgs
+cp -r $SCRIPT_ROOT/bin/obj/x64/Release/refpkgs/src $TARBALL_ROOT/refpkgs/src
+cp -r $SCRIPT_ROOT/bin/obj/x64/Release/refpkgs/staging $TARBALL_ROOT/refpkgs/staging
 
 if [ -e $SCRIPT_ROOT/testing-smoke/smoke-test-packages ]; then
     cp -rf $SCRIPT_ROOT/testing-smoke/smoke-test-packages $TARBALL_ROOT/prebuilt

--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -119,7 +119,9 @@ mkdir -p $TARBALL_ROOT/prebuilt/source-built
 find $SCRIPT_ROOT/packages -name '*.nupkg' -exec cp {} $TARBALL_ROOT/prebuilt/nuget-packages/ \;
 find $SCRIPT_ROOT/bin/obj/x64/Release/nuget-packages -name '*.nupkg' -exec cp {} $TARBALL_ROOT/prebuilt/nuget-packages/ \;
 
-cp -r $SCRIPT_ROOT/reference-packages $TARBALL_ROOT/reference-packages
+mkdir -p $TARBALL_ROOT/reference-packages
+cp -r $SCRIPT_ROOT/reference-packages/source $TARBALL_ROOT/reference-packages/source
+cp -r $SCRIPT_ROOT/reference-packages/staging $TARBALL_ROOT/reference-packages/staging
 
 if [ -e $SCRIPT_ROOT/testing-smoke/smoke-test-packages ]; then
     cp -rf $SCRIPT_ROOT/testing-smoke/smoke-test-packages $TARBALL_ROOT/prebuilt
@@ -142,6 +144,18 @@ echo 'Copying source-built packages to tarball to replace packages needed before
 for built_package in $(find $SCRIPT_ROOT/bin/obj/x64/Release/blob-feed/packages/ -name '*.nupkg')
 do
     cp $built_package $TARBALL_ROOT/prebuilt/source-built/
+done
+
+echo 'Removing reference-only packages from tarball prebuilts...'
+
+for built_package in $(find $SCRIPT_ROOT/reference-packages/packages-to-delete/ -name '*.nupkg' | tr '[:upper:]' '[:lower:]')
+do
+    if [ -e $TARBALL_ROOT/prebuilt/nuget-packages/$(basename $built_package) ]; then
+        rm $TARBALL_ROOT/prebuilt/nuget-packages/$(basename $built_package)
+    fi
+    if [ -e $TARBALL_ROOT/prebuilt/smoke-test-packages/$(basename $built_package) ]; then
+        rm $TARBALL_ROOT/prebuilt/smoke-test-packages/$(basename $built_package)
+    fi
 done
 
 echo 'WORKAROUND: Overwriting the source-built roslyn-tools MSBuild files with prebuilt so that roslyn-tools can successfully build in the tarball... (https://github.com/dotnet/source-build/issues/654)'

--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -119,9 +119,11 @@ mkdir -p $TARBALL_ROOT/prebuilt/source-built
 find $SCRIPT_ROOT/packages -name '*.nupkg' -exec cp {} $TARBALL_ROOT/prebuilt/nuget-packages/ \;
 find $SCRIPT_ROOT/bin/obj/x64/Release/nuget-packages -name '*.nupkg' -exec cp {} $TARBALL_ROOT/prebuilt/nuget-packages/ \;
 
+# Copy reference-packages from bin dir to reference-packages directory.
+# See corresponding change in dir.props to change ReferencePackagesBasePath conditionally in offline build.
 mkdir -p $TARBALL_ROOT/reference-packages
-cp -r $SCRIPT_ROOT/reference-packages/source $TARBALL_ROOT/reference-packages/source
-cp -r $SCRIPT_ROOT/reference-packages/staging $TARBALL_ROOT/reference-packages/staging
+cp -r $SCRIPT_ROOT/bin/obj/x64/Release/reference-packages/source $TARBALL_ROOT/reference-packages/source
+cp -r $SCRIPT_ROOT/bin/obj/x64/Release/reference-packages/staging $TARBALL_ROOT/reference-packages/staging
 
 if [ -e $SCRIPT_ROOT/testing-smoke/smoke-test-packages ]; then
     cp -rf $SCRIPT_ROOT/testing-smoke/smoke-test-packages $TARBALL_ROOT/prebuilt
@@ -148,13 +150,10 @@ done
 
 echo 'Removing reference-only packages from tarball prebuilts...'
 
-for ref_package in $(find $SCRIPT_ROOT/reference-packages/packages-to-delete/ -name '*.nupkg' | tr '[:upper:]' '[:lower:]')
+for ref_package in $(find $SCRIPT_ROOT/bin/obj/x64/Release/reference-packages/packages-to-delete/ -name '*.nupkg' | tr '[:upper:]' '[:lower:]')
 do
     if [ -e $TARBALL_ROOT/prebuilt/nuget-packages/$(basename $ref_package) ]; then
         rm $TARBALL_ROOT/prebuilt/nuget-packages/$(basename $ref_package)
-    fi
-    if [ -e $TARBALL_ROOT/prebuilt/smoke-test-packages/$(basename $ref_package) ]; then
-        rm $TARBALL_ROOT/prebuilt/smoke-test-packages/$(basename $ref_package)
     fi
 done
 

--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -119,6 +119,8 @@ mkdir -p $TARBALL_ROOT/prebuilt/source-built
 find $SCRIPT_ROOT/packages -name '*.nupkg' -exec cp {} $TARBALL_ROOT/prebuilt/nuget-packages/ \;
 find $SCRIPT_ROOT/bin/obj/x64/Release/nuget-packages -name '*.nupkg' -exec cp {} $TARBALL_ROOT/prebuilt/nuget-packages/ \;
 
+cp -r $SCRIPT_ROOT/reference-packages $TARBALL_ROOT/reference-packages
+
 if [ -e $SCRIPT_ROOT/testing-smoke/smoke-test-packages ]; then
     cp -rf $SCRIPT_ROOT/testing-smoke/smoke-test-packages $TARBALL_ROOT/prebuilt
 fi

--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -119,11 +119,11 @@ mkdir -p $TARBALL_ROOT/prebuilt/source-built
 find $SCRIPT_ROOT/packages -name '*.nupkg' -exec cp {} $TARBALL_ROOT/prebuilt/nuget-packages/ \;
 find $SCRIPT_ROOT/bin/obj/x64/Release/nuget-packages -name '*.nupkg' -exec cp {} $TARBALL_ROOT/prebuilt/nuget-packages/ \;
 
-# Copy refpkgs from bin dir to refpkgs directory.
+# Copy reference-packages from bin dir to reference-packages directory.
 # See corresponding change in dir.props to change ReferencePackagesBasePath conditionally in offline build.
-mkdir -p $TARBALL_ROOT/refpkgs
-cp -r $SCRIPT_ROOT/bin/obj/x64/Release/refpkgs/src $TARBALL_ROOT/refpkgs/src
-cp -r $SCRIPT_ROOT/bin/obj/x64/Release/refpkgs/staging $TARBALL_ROOT/refpkgs/staging
+mkdir -p $TARBALL_ROOT/reference-packages
+cp -r $SCRIPT_ROOT/bin/obj/x64/Release/reference-packages/source $TARBALL_ROOT/reference-packages/source
+cp -r $SCRIPT_ROOT/bin/obj/x64/Release/reference-packages/staging $TARBALL_ROOT/reference-packages/staging
 
 if [ -e $SCRIPT_ROOT/testing-smoke/smoke-test-packages ]; then
     cp -rf $SCRIPT_ROOT/testing-smoke/smoke-test-packages $TARBALL_ROOT/prebuilt

--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -148,6 +148,12 @@ do
     cp $built_package $TARBALL_ROOT/prebuilt/source-built/
 done
 
+if [ $INCLUDE_LEAK_DETECTION -eq 1 ]; then
+  echo 'Building leak detection MSBuild tasks...'
+  ./Tools/dotnetcli/dotnet restore $SCRIPT_ROOT/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.csproj --source $FULL_TARBALL_ROOT/prebuilt/source-built --source $FULL_TARBALL_ROOT/prebuilt/nuget-packages
+  ./Tools/dotnetcli/dotnet publish -o $FULL_TARBALL_ROOT/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection $SCRIPT_ROOT/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.csproj
+fi
+
 echo 'Removing reference-only packages from tarball prebuilts...'
 
 for ref_package in $(find $SCRIPT_ROOT/bin/obj/x64/Release/reference-packages/packages-to-delete/ -name '*.nupkg' | tr '[:upper:]' '[:lower:]')
@@ -177,12 +183,6 @@ fi
 SOURCE_BUILT_SDK_TOOLS_DIR="$TARBALL_ROOT/Tools/source-built/$ROSLYN_TOOLS_PACKAGE/tools"
 cp "$REPO_TOOLSET_PACKAGE_DIR/tools/"*.props "$SOURCE_BUILT_SDK_TOOLS_DIR"
 cp "$REPO_TOOLSET_PACKAGE_DIR/tools/"*.targets "$SOURCE_BUILT_SDK_TOOLS_DIR"
-
-if [ $INCLUDE_LEAK_DETECTION -eq 1 ]; then
-  echo 'Building leak detection MSBuild tasks...'
-  ./Tools/dotnetcli/dotnet restore $SCRIPT_ROOT/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.csproj --source $FULL_TARBALL_ROOT/prebuilt/source-built --source $FULL_TARBALL_ROOT/prebuilt/nuget-packages
-  ./Tools/dotnetcli/dotnet publish -o $FULL_TARBALL_ROOT/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection $SCRIPT_ROOT/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.csproj
-fi
 
 echo 'Recording commits for the source-build repo and all submodules, to aid in reproducibility...'
 

--- a/build.proj
+++ b/build.proj
@@ -83,7 +83,7 @@
 
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Deleting disassembled dlls and temp il source" />
     <Delete Files="@(ReferenceOnlyPackageDlls)" />
-    <RemoveDir Directories="$(TempPath)" />
+    <RemoveDir Directories="$(IldasmTempOutputPath)" />
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Deleting disassembled dlls and temp il source done." />
   </Target>
 

--- a/build.proj
+++ b/build.proj
@@ -36,7 +36,7 @@
           Condition="'$(OfflineBuild)' != 'true'">
     <CopyReferenceOnlyPackages
         PackageCacheDir="$(PackagesDir)"
-        DestinationDir="$(ReferencePackagesDir)"
+        DestinationDir="$(ReferencePackagesStagingDir)"
         />
   </Target>
 

--- a/build.proj
+++ b/build.proj
@@ -35,8 +35,6 @@
           AfterTargets="Build"
           Condition="'$(OfflineBuild)' != 'true'">
 
-    <Exec Command="df -m $(PackagesDir)" />
-
     <CopyReferenceOnlyPackages
         PackageCacheDir="$(PackagesDir)"
         DllDestinationDir="$(ReferencePackagesSourceDir)"
@@ -63,7 +61,6 @@
 
     <!-- End Temporary workaround -->
 
-    <Exec Command="df -m $(PackagesDir)" />
     <Message Importance="High" Text="Reference-only Packages:" />
     <Message Importance="High" Text="%(ReferenceOnlyPackages.Identity)" />
 
@@ -72,11 +69,9 @@
     <Exec Command="$(IldasmPath) %(ReferenceOnlyPackageDlls.Identity) -all -out=$(ReferencePackagesSourceDir)%(ReferenceOnlyPackageDlls.RecursiveDir)%(ReferenceOnlyPackageDlls.Filename).il" />
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Disassembly done." />
 
-    <Exec Command="df -m $(PackagesDir)" />
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Deleting disassembled dlls" />
     <Delete Files="@(ReferenceOnlyPackageDlls)" />
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Deleting disassembled dlls done." />
-    <Exec Command="df -m $(PackagesDir)" />
   </Target>
 
   <!-- After building, generate a prebuilt usage report. -->

--- a/build.proj
+++ b/build.proj
@@ -37,13 +37,14 @@
 
     <CopyReferenceOnlyPackages
         PackageCacheDir="$(PackagesDir)"
-        DllDestinationDir="$(ReferencePackagesSourceDir)"
+        DllDestinationDir="$(ReferencePackagesDllsDir)"
         IdentifiedPackagesDir="$(ReferencePackagesToDeleteDir)"
         DestinationDir="$(ReferencePackagesStagingDir)"
         />
     
     <ItemGroup>
-      <ReferenceOnlyPackageDlls Include="$(ReferencePackagesSourceDir)/**/*.dll" />
+      <ReferenceOnlyPackages Include="$(ReferencePackagesToDeleteDir)/**/*.nupkg" />
+      <ReferenceOnlyPackageDlls Include="$(ReferencePackagesDllsDir)/**/*.dll" />
     </ItemGroup>
 
     <!-- Temporary workaround to exclude dlls that can't be round-tripped. See: https://github.com/dotnet/coreclr/issues/20262
@@ -52,21 +53,24 @@
 
     <ItemGroup>
     <!-- Issue https://github.com/dotnet/coreclr/issues/20262 -->
-      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)/**/System.Runtime.dll;$(ReferencePackagesSourceDir)/**/netstandard.dll" />
+      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesDllsDir)/**/System.Runtime.dll;$(ReferencePackagesDllsDir)/**/netstandard.dll" />
     <!-- The following dlls were brought in by Microsoft.NETCore.App-2.0.0-beta-001509-00 with the linker repo.  They contain ref assemblies
          that either contain resources or have native/unmanaged methods and cannot be round-tripped with ildasm/ilasm. -->
-      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)/**/2.0.0-beta-001509-00/**/*.dll" />
+      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesDllsDir)/**/2.0.0-beta-001509-00/**/*.dll" />
     </ItemGroup>
 
     <!-- End Temporary workaround -->
 
+    <Message Importance="High" Text="Reference-only Packages:" />
+    <Message Importance="High" Text="%(ReferenceOnlyPackages.Identity)" />
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Disassembling @(ReferenceOnlyPackageDlls->Count()) dlls" />
-    <Exec Command="$(IldasmPath) %(ReferenceOnlyPackageDlls.Identity) -all -out=%(ReferenceOnlyPackageDlls.RootDir)%(ReferenceOnlyPackageDlls.Directory)%(ReferenceOnlyPackageDlls.Filename).il" />
+    <MakeDir Directories="$(ReferencePackagesSourceDir)%(ReferenceOnlyPackageDlls.RecursiveDir)" />
+    <Exec Command="$(IldasmPath) %(ReferenceOnlyPackageDlls.Identity) -all -out=$(ReferencePackagesSourceDir)%(ReferenceOnlyPackageDlls.RecursiveDir)%(ReferenceOnlyPackageDlls.Filename).il" />
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Disassembly done." />
 
-    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Deleting disassembled dlls" />
-    <Delete Files="@(ReferenceOnlyPackageDlls)" />
-    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Deleting disassembled dlls done." />
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Deleting disassembled dlls directory" />
+    <RemoveDir Directories="$(ReferencePackagesDllsDir)" />
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Deleting disassembled dlls directory done." />
   </Target>
 
   <!-- After building, generate a prebuilt usage report. -->

--- a/build.proj
+++ b/build.proj
@@ -59,15 +59,9 @@
     <!-- Temporary workaround to exclude dlls that can't be round-tripped. See: https://github.com/dotnet/coreclr/issues/20262
          They'll end up in the source directory as dlls for now 
     -->
-
     <ItemGroup>
-    <!-- Issue https://github.com/dotnet/coreclr/issues/20262 -->
       <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)/**/System.Runtime.dll;$(ReferencePackagesSourceDir)/**/netstandard.dll" />
-    <!-- The following dlls were brought in by Microsoft.NETCore.App-2.0.0-beta-001509-00 with the linker repo.  They contain ref assemblies
-         that either contain resources or have native/unmanaged methods and cannot be round-tripped with ildasm/ilasm. -->
-      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)/**/2.0.0-beta-001509-00/**/*.dll" />
     </ItemGroup>
-
     <!-- End Temporary workaround -->
 
     <Message Importance="High" Text="Reference-only Packages:" />

--- a/build.proj
+++ b/build.proj
@@ -3,6 +3,7 @@
   <Import Project="dir.props" />
 
   <UsingTask AssemblyFile="$(LeakDetectionTasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.dll" TaskName="CheckForPoison" />
+  <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="CopyReferenceOnlyPackages" />
 
   <Target Name="Build" DependsOnTargets="PrepareOutput;InitBuild">
     <Message Text="Build Environment: $(Platform) $(Configuration) $(TargetOS) $(TargetRid)" />
@@ -28,6 +29,15 @@
 
   <Target Name="Clean">
     <RemoveDir Directories="$(BaseOutputPath)" />
+  </Target>
+
+  <Target Name="CopyReferenceOnlyPackages"
+          AfterTargets="Build"
+          Condition="'$(OfflineBuild)' != 'true'">
+    <CopyReferenceOnlyPackages
+        PackageCacheDir="$(PackagesDir)"
+        DestinationDir="$(ReferencePackagesDir)"
+        />
   </Target>
 
   <!-- After building, generate a prebuilt usage report. -->

--- a/build.proj
+++ b/build.proj
@@ -35,16 +35,18 @@
           AfterTargets="Build"
           Condition="'$(OfflineBuild)' != 'true'">
 
+    <Exec Command="df -m $(PackagesDir)" />
+
     <CopyReferenceOnlyPackages
         PackageCacheDir="$(PackagesDir)"
-        DllDestinationDir="$(ReferencePackagesDllsDir)"
+        DllDestinationDir="$(ReferencePackagesSourceDir)"
         IdentifiedPackagesDir="$(ReferencePackagesToDeleteDir)"
         DestinationDir="$(ReferencePackagesStagingDir)"
         />
     
     <ItemGroup>
       <ReferenceOnlyPackages Include="$(ReferencePackagesToDeleteDir)/**/*.nupkg" />
-      <ReferenceOnlyPackageDlls Include="$(ReferencePackagesDllsDir)/**/*.dll" />
+      <ReferenceOnlyPackageDlls Include="$(ReferencePackagesSourceDir)/**/*.dll" />
     </ItemGroup>
 
     <!-- Temporary workaround to exclude dlls that can't be round-tripped. See: https://github.com/dotnet/coreclr/issues/20262
@@ -53,24 +55,28 @@
 
     <ItemGroup>
     <!-- Issue https://github.com/dotnet/coreclr/issues/20262 -->
-      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesDllsDir)/**/System.Runtime.dll;$(ReferencePackagesDllsDir)/**/netstandard.dll" />
+      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)/**/System.Runtime.dll;$(ReferencePackagesSourceDir)/**/netstandard.dll" />
     <!-- The following dlls were brought in by Microsoft.NETCore.App-2.0.0-beta-001509-00 with the linker repo.  They contain ref assemblies
          that either contain resources or have native/unmanaged methods and cannot be round-tripped with ildasm/ilasm. -->
-      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesDllsDir)/**/2.0.0-beta-001509-00/**/*.dll" />
+      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)/**/2.0.0-beta-001509-00/**/*.dll" />
     </ItemGroup>
 
     <!-- End Temporary workaround -->
 
+    <Exec Command="df -m $(PackagesDir)" />
     <Message Importance="High" Text="Reference-only Packages:" />
     <Message Importance="High" Text="%(ReferenceOnlyPackages.Identity)" />
+
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Disassembling @(ReferenceOnlyPackageDlls->Count()) dlls" />
     <MakeDir Directories="$(ReferencePackagesSourceDir)%(ReferenceOnlyPackageDlls.RecursiveDir)" />
     <Exec Command="$(IldasmPath) %(ReferenceOnlyPackageDlls.Identity) -all -out=$(ReferencePackagesSourceDir)%(ReferenceOnlyPackageDlls.RecursiveDir)%(ReferenceOnlyPackageDlls.Filename).il" />
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Disassembly done." />
 
-    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Deleting disassembled dlls directory" />
-    <RemoveDir Directories="$(ReferencePackagesDllsDir)" />
-    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Deleting disassembled dlls directory done." />
+    <Exec Command="df -m $(PackagesDir)" />
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Deleting disassembled dlls" />
+    <Delete Files="@(ReferenceOnlyPackageDlls)" />
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Deleting disassembled dlls done." />
+    <Exec Command="df -m $(PackagesDir)" />
   </Target>
 
   <!-- After building, generate a prebuilt usage report. -->

--- a/build.proj
+++ b/build.proj
@@ -48,6 +48,11 @@
     
     <!-- Temporary workaround to exclude dlls that can't be round-tripped 
          They'll end up in the source directory as dlls for now 
+
+        Keep the following ItemGroup when workaround is removed:
+    <ItemGroup>
+        <Dlls Include="$(ReferencePackagesSourceDir)/**/*.dll" />
+    </ItemGroup>
     -->
 
     <ItemGroup>
@@ -58,6 +63,8 @@
 
     <Message Importance="High" Text="Disassembling @(Dlls->Count()) dlls" />
     <Exec Command="@(IldasmPath) %(Dlls.Identity) -all -out=%(Dlls.RootDir)%(Dlls.Directory)%(Dlls.Filename).il" />
+
+    <Message Importance="High" Text="Deleting disassembled dlls" />
     <Delete Files="@(Dlls)" />
   </Target>
 

--- a/build.proj
+++ b/build.proj
@@ -52,15 +52,16 @@
     </PropertyGroup>
     
     <ItemGroup>
-      <ReferenceOnlyPackages Include="$(ReferencePackagesToDeleteDir)/**/*.nupkg" />
-      <ReferenceOnlyPackageDlls Include="$(ReferencePackagesSourceDir)/**/*.dll" />
+      <ReferenceOnlyPackages Include="$(ReferencePackagesToDeleteDir)**/*.nupkg" />
+      <ReferenceOnlyPackageDlls Include="$(ReferencePackagesSourceDir)**/*.dll" />
     </ItemGroup>
 
     <!-- Temporary workaround to exclude dlls that can't be round-tripped. See: https://github.com/dotnet/coreclr/issues/20262
          They'll end up in the source directory as dlls for now 
     -->
     <ItemGroup>
-      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)/**/System.Runtime.dll;$(ReferencePackagesSourceDir)/**/netstandard.dll" />
+      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)**/System.Runtime.dll" />
+      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)**/netstandard.dll" />
     </ItemGroup>
     <!-- End Temporary workaround -->
 
@@ -82,7 +83,7 @@
 
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Deleting disassembled dlls and temp il source" />
     <Delete Files="@(ReferenceOnlyPackageDlls)" />
-    <Delete Files="@(IlSourceFiles)" />
+    <RemoveDir Directories="$(TempPath)" />
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Deleting disassembled dlls and temp il source done." />
   </Target>
 

--- a/build.proj
+++ b/build.proj
@@ -41,6 +41,15 @@
         IdentifiedPackagesDir="$(ReferencePackagesToDeleteDir)"
         DestinationDir="$(ReferencePackagesStagingDir)"
         />
+
+    <!-- Ildasm has trouble writing to paths that are longer than 260 chars. (see https://github.com/dotnet/coreclr/issues/20397)
+         Create a temporary path to write il output which will then be copied back to the reference-packages/source dir.
+    -->
+    <PropertyGroup>
+      <TempPath>$([System.IO.Path]::GetTempPath())</TempPath>
+      <IldasmTempOutputFolderName>$([System.IO.Path]::GetRandomFileName())</IldasmTempOutputFolderName>
+      <IldasmTempOutputPath>$([System.IO.Path]::Combine($(TempPath),$(IldasmTempOutputFolderName)))/</IldasmTempOutputPath>
+    </PropertyGroup>
     
     <ItemGroup>
       <ReferenceOnlyPackages Include="$(ReferencePackagesToDeleteDir)/**/*.nupkg" />
@@ -65,13 +74,22 @@
     <Message Importance="High" Text="%(ReferenceOnlyPackages.Identity)" />
 
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Disassembling @(ReferenceOnlyPackageDlls->Count()) dlls" />
-    <MakeDir Directories="$(ReferencePackagesSourceDir)%(ReferenceOnlyPackageDlls.RecursiveDir)" />
-    <Exec Command="$(IldasmPath) %(ReferenceOnlyPackageDlls.Identity) -all -out=$(ReferencePackagesSourceDir)%(ReferenceOnlyPackageDlls.RecursiveDir)%(ReferenceOnlyPackageDlls.Filename).il" />
+    <MakeDir Directories="$(IldasmTempOutputPath)%(ReferenceOnlyPackageDlls.RecursiveDir)" />
+    <Exec Command="$(IldasmPath) %(ReferenceOnlyPackageDlls.Identity) -all -out=$(IldasmTempOutputPath)%(ReferenceOnlyPackageDlls.RecursiveDir)%(ReferenceOnlyPackageDlls.Filename).il" />
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Disassembly done." />
 
-    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Deleting disassembled dlls" />
+    <ItemGroup>
+      <IlSourceFiles Include="$(IldasmTempOutputPath)/**/*.il" />
+    </ItemGroup>
+
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Copying @(IlSourceFiles->Count()) IL source files" />
+    <Copy SourceFiles="@(IlSourceFiles)" DestinationFiles="$(ReferencePackagesSourceDir)%(IlSourceFiles.RecursiveDir)%(IlSourceFiles.Filename).il" />
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Copying IL source files done." />
+
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Deleting disassembled dlls and temp il source" />
     <Delete Files="@(ReferenceOnlyPackageDlls)" />
-    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Deleting disassembled dlls done." />
+    <Delete Files="@(IlSourceFiles)" />
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Deleting disassembled dlls and temp il source done." />
   </Target>
 
   <!-- After building, generate a prebuilt usage report. -->

--- a/build.proj
+++ b/build.proj
@@ -31,7 +31,7 @@
     <RemoveDir Directories="$(BaseOutputPath)" />
   </Target>
 
-  <Target Name="CopyReferenceOnlyPackages"
+  <Target Name="CopyAndDisAssembleReferenceOnlyPackages"
           AfterTargets="Build"
           Condition="'$(OfflineBuild)' != 'true'">
 

--- a/build.proj
+++ b/build.proj
@@ -31,7 +31,7 @@
     <RemoveDir Directories="$(BaseOutputPath)" />
   </Target>
 
-  <Target Name="CopyAndDisAssembleReferenceOnlyPackages"
+  <Target Name="CopyAndDisassembleReferenceOnlyPackages"
           AfterTargets="Build"
           Condition="'$(OfflineBuild)' != 'true'">
 
@@ -41,31 +41,38 @@
         IdentifiedPackagesDir="$(ReferencePackagesToDeleteDir)"
         DestinationDir="$(ReferencePackagesStagingDir)"
         />
-
-    <ItemGroup>
-        <IldasmPath Include="./src/coreclr/bin/Product/*/ildasm" />
-    </ItemGroup>
     
-    <!-- Temporary workaround to exclude dlls that can't be round-tripped 
-         They'll end up in the source directory as dlls for now 
-
-        Keep the following ItemGroup when workaround is removed:
     <ItemGroup>
-        <Dlls Include="$(ReferencePackagesSourceDir)/**/*.dll" />
+      <ReferenceOnlyPackageDlls Include="$(ReferencePackagesSourceDir)/**/*.dll" />
     </ItemGroup>
+
+    <!-- Temporary workaround to exclude dlls that can't be round-tripped. See: https://github.com/dotnet/coreclr/issues/20262
+         They'll end up in the source directory as dlls for now 
     -->
 
     <ItemGroup>
-        <Dlls Include="$(ReferencePackagesSourceDir)/**/*.dll" Exclude="$(ReferencePackagesSourceDir)/**/System.Runtime.dll;$(ReferencePackagesSourceDir)/**/netstandard.dll" />
+    <!-- Issue https://github.com/dotnet/coreclr/issues/20262 -->
+      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)/**/System.Runtime.dll;$(ReferencePackagesSourceDir)/**/netstandard.dll" />
+    <!-- The following dlls were brought in by Microsoft.NETCore.App-2.0.0-beta-001509-00 with the linker repo.  They contain ref assemblies
+         that either contain resources or have native/unmanaged methods and cannot be round-tripped with ildasm/ilasm. -->
+    <!-- Contain resources -->
+      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)/**/2.0.0-beta-001509-00/**/System.Collections.Immutable.dll" />
+      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)/**/2.0.0-beta-001509-00/**/System.Threading.Tasks.dll" />
+      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)/**/2.0.0-beta-001509-00/**/System.Reflection.Metadata.dll" />
+      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)/**/2.0.0-beta-001509-00/**/System.Threading.Tasks.Dataflow.dll" />
+    <!-- Pinvoke issue -->
+      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)/**/2.0.0-beta-001509-00/**/System.Data.dll" /> 
     </ItemGroup>
 
     <!-- End Temporary workaround -->
 
-    <Message Importance="High" Text="Disassembling @(Dlls->Count()) dlls" />
-    <Exec Command="@(IldasmPath) %(Dlls.Identity) -all -out=%(Dlls.RootDir)%(Dlls.Directory)%(Dlls.Filename).il" />
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Disassembling @(ReferenceOnlyPackageDlls->Count()) dlls" />
+    <Exec Command="$(IldasmPath) %(ReferenceOnlyPackageDlls.Identity) -all -out=%(ReferenceOnlyPackageDlls.RootDir)%(ReferenceOnlyPackageDlls.Directory)%(ReferenceOnlyPackageDlls.Filename).il" />
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Disassembly done." />
 
-    <Message Importance="High" Text="Deleting disassembled dlls" />
-    <Delete Files="@(Dlls)" />
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Deleting disassembled dlls" />
+    <Delete Files="@(ReferenceOnlyPackageDlls)" />
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Deleting disassembled dlls done." />
   </Target>
 
   <!-- After building, generate a prebuilt usage report. -->

--- a/build.proj
+++ b/build.proj
@@ -34,10 +34,31 @@
   <Target Name="CopyReferenceOnlyPackages"
           AfterTargets="Build"
           Condition="'$(OfflineBuild)' != 'true'">
+
     <CopyReferenceOnlyPackages
         PackageCacheDir="$(PackagesDir)"
+        DllDestinationDir="$(ReferencePackagesSourceDir)"
+        IdentifiedPackagesDir="$(ReferencePackagesToDeleteDir)"
         DestinationDir="$(ReferencePackagesStagingDir)"
         />
+
+    <ItemGroup>
+        <IldasmPath Include="./src/coreclr/bin/Product/*/ildasm" />
+    </ItemGroup>
+    
+    <!-- Temporary workaround to exclude dlls that can't be round-tripped 
+         They'll end up in the source directory as dlls for now 
+    -->
+
+    <ItemGroup>
+        <Dlls Include="$(ReferencePackagesSourceDir)/**/*.dll" Exclude="$(ReferencePackagesSourceDir)/**/System.Runtime.dll;$(ReferencePackagesSourceDir)/**/netstandard.dll" />
+    </ItemGroup>
+
+    <!-- End Temporary workaround -->
+
+    <Message Importance="High" Text="Disassembling @(Dlls->Count()) dlls" />
+    <Exec Command="@(IldasmPath) %(Dlls.Identity) -all -out=%(Dlls.RootDir)%(Dlls.Directory)%(Dlls.Filename).il" />
+    <Delete Files="@(Dlls)" />
   </Target>
 
   <!-- After building, generate a prebuilt usage report. -->

--- a/build.proj
+++ b/build.proj
@@ -55,13 +55,7 @@
       <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)/**/System.Runtime.dll;$(ReferencePackagesSourceDir)/**/netstandard.dll" />
     <!-- The following dlls were brought in by Microsoft.NETCore.App-2.0.0-beta-001509-00 with the linker repo.  They contain ref assemblies
          that either contain resources or have native/unmanaged methods and cannot be round-tripped with ildasm/ilasm. -->
-    <!-- Contain resources -->
-      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)/**/2.0.0-beta-001509-00/**/System.Collections.Immutable.dll" />
-      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)/**/2.0.0-beta-001509-00/**/System.Threading.Tasks.dll" />
-      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)/**/2.0.0-beta-001509-00/**/System.Reflection.Metadata.dll" />
-      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)/**/2.0.0-beta-001509-00/**/System.Threading.Tasks.Dataflow.dll" />
-    <!-- Pinvoke issue -->
-      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)/**/2.0.0-beta-001509-00/**/System.Data.dll" /> 
+      <ReferenceOnlyPackageDlls Remove="$(ReferencePackagesSourceDir)/**/2.0.0-beta-001509-00/**/*.dll" />
     </ItemGroup>
 
     <!-- End Temporary workaround -->

--- a/dir.props
+++ b/dir.props
@@ -19,6 +19,9 @@
     <DotNetCliToolDir>$(ProjectDir)Tools/dotnetcli/</DotNetCliToolDir>
     <PatchesDir>$(ProjectDir)patches/</PatchesDir>
     <PackagesDir>$(ProjectDir)packages/</PackagesDir>
+    <ReferencePackagesStagingDir>$(ProjectDir)reference-packages/staging/</ReferencePackagesStagingDir>
+    <ReferencePackagesSourceDir>$(ProjectDir)reference-packages/source/</ReferencePackagesSourceDir>
+    <ReferencePackagesDir>$(ProjectDir)reference-packages/packages/</ReferencePackagesDir>
     <DotNetSdkDir>$(DotNetCliToolDir)sdk/$(SDK_VERSION)/</DotNetSdkDir>
     <DotNetSdkResolversDir>$(DotNetSdkDir)SdkResolvers/</DotNetSdkResolversDir>
   </PropertyGroup>

--- a/dir.props
+++ b/dir.props
@@ -22,6 +22,7 @@
     <ReferencePackagesStagingDir>$(ProjectDir)reference-packages/staging/</ReferencePackagesStagingDir>
     <ReferencePackagesSourceDir>$(ProjectDir)reference-packages/source/</ReferencePackagesSourceDir>
     <ReferencePackagesDir>$(ProjectDir)reference-packages/packages/</ReferencePackagesDir>
+    <ReferencePackagesToDeleteDir>$(ProjectDir)reference-packages/packages-to-delete/</ReferencePackagesToDeleteDir>
     <DotNetSdkDir>$(DotNetCliToolDir)sdk/$(SDK_VERSION)/</DotNetSdkDir>
     <DotNetSdkResolversDir>$(DotNetSdkDir)SdkResolvers/</DotNetSdkResolversDir>
   </PropertyGroup>

--- a/dir.props
+++ b/dir.props
@@ -84,14 +84,14 @@
     <ReferencePackagesBasePath>$(IntermediatePath)</ReferencePackagesBasePath>
     <!--
       Change ReferencePackagesBasePath conditionally in offline build.
-      See corresponding change in build-source-tarball.sh to copy reference-packages
-      from source-build bin dir to tarball reference-packages dir.
+      See corresponding change in build-source-tarball.sh to copy refpkgs
+      from source-build bin dir to tarball refpkgs dir.
     -->
     <ReferencePackagesBasePath Condition="'$(OfflineBuild)' == 'true'">$(ProjectDir)</ReferencePackagesBasePath>
-    <ReferencePackagesStagingDir>$(ReferencePackagesBasePath)reference-packages/staging/</ReferencePackagesStagingDir>
-    <ReferencePackagesSourceDir>$(ReferencePackagesBasePath)reference-packages/source/</ReferencePackagesSourceDir>
-    <ReferencePackagesDir>$(ReferencePackagesBasePath)reference-packages/packages/</ReferencePackagesDir>
-    <ReferencePackagesToDeleteDir>$(ReferencePackagesBasePath)reference-packages/packages-to-delete/</ReferencePackagesToDeleteDir>
+    <ReferencePackagesStagingDir>$(ReferencePackagesBasePath)refpkgs/staging/</ReferencePackagesStagingDir>
+    <ReferencePackagesSourceDir>$(ReferencePackagesBasePath)refpkgs/src/</ReferencePackagesSourceDir>
+    <ReferencePackagesDir>$(ReferencePackagesBasePath)refpkgs/packages/</ReferencePackagesDir>
+    <ReferencePackagesToDeleteDir>$(ReferencePackagesBasePath)refpkgs/packages-to-delete/</ReferencePackagesToDeleteDir>
   </PropertyGroup>
 
   <!-- Import Build tools common props file where repo-independent properties are found -->

--- a/dir.props
+++ b/dir.props
@@ -19,10 +19,6 @@
     <DotNetCliToolDir>$(ProjectDir)Tools/dotnetcli/</DotNetCliToolDir>
     <PatchesDir>$(ProjectDir)patches/</PatchesDir>
     <PackagesDir>$(ProjectDir)packages/</PackagesDir>
-    <ReferencePackagesStagingDir>$(ProjectDir)reference-packages/staging/</ReferencePackagesStagingDir>
-    <ReferencePackagesSourceDir>$(ProjectDir)reference-packages/source/</ReferencePackagesSourceDir>
-    <ReferencePackagesDir>$(ProjectDir)reference-packages/packages/</ReferencePackagesDir>
-    <ReferencePackagesToDeleteDir>$(ProjectDir)reference-packages/packages-to-delete/</ReferencePackagesToDeleteDir>
     <DotNetSdkDir>$(DotNetCliToolDir)sdk/$(SDK_VERSION)/</DotNetSdkDir>
     <DotNetSdkResolversDir>$(DotNetSdkDir)SdkResolvers/</DotNetSdkResolversDir>
   </PropertyGroup>
@@ -48,6 +44,7 @@
     <BaseOutputPath>$(ProjectDir)bin/</BaseOutputPath>
     <ToolsDir>$(ProjectDir)Tools/</ToolsDir>
     <ToolPackageExtractDir>$(ToolsDir)source-built/</ToolPackageExtractDir>
+    <IldasmPath>$(ToolsDir)ilasm/ildasm</IldasmPath>
     <ToolsLocalDir>$(ProjectDir)tools-local/</ToolsLocalDir>
     <TaskDirectory>$(ToolsLocalDir)tasks/</TaskDirectory>
     <TasksBinDir>$(TaskDirectory)Microsoft.DotNet.SourceBuild.Tasks/bin/Debug/netstandard1.5/</TasksBinDir>
@@ -84,6 +81,17 @@
     <ProdConManifestFile>$(PackageReportDir)prodcon-build.xml</ProdConManifestFile>
     <PoisonedReportFile>$(PackageReportDir)poisoned.txt</PoisonedReportFile>
     <ConflictingPackageReportDir>$(BaseOutputPath)conflict-report/</ConflictingPackageReportDir>
+    <ReferencePackagesBasePath>$(IntermediatePath)</ReferencePackagesBasePath>
+    <!--
+      Change ReferencePackagesBasePath conditionally in offline build.
+      See corresponding change in build-source-tarball.sh to copy reference-packages
+      from source-build bin dir to tarball reference-packages dir.
+    -->
+    <ReferencePackagesBasePath Condition="'$(OfflineBuild)' == 'true'">$(ProjectDir)</ReferencePackagesBasePath>
+    <ReferencePackagesStagingDir>$(ReferencePackagesBasePath)reference-packages/staging/</ReferencePackagesStagingDir>
+    <ReferencePackagesSourceDir>$(ReferencePackagesBasePath)reference-packages/source/</ReferencePackagesSourceDir>
+    <ReferencePackagesDir>$(ReferencePackagesBasePath)reference-packages/packages/</ReferencePackagesDir>
+    <ReferencePackagesToDeleteDir>$(ReferencePackagesBasePath)reference-packages/packages-to-delete/</ReferencePackagesToDeleteDir>
   </PropertyGroup>
 
   <!-- Import Build tools common props file where repo-independent properties are found -->

--- a/dir.props
+++ b/dir.props
@@ -89,6 +89,7 @@
     -->
     <ReferencePackagesBasePath Condition="'$(OfflineBuild)' == 'true'">$(ProjectDir)</ReferencePackagesBasePath>
     <ReferencePackagesStagingDir>$(ReferencePackagesBasePath)reference-packages/staging/</ReferencePackagesStagingDir>
+    <ReferencePackagesDllsDir>$(ReferencePackagesBasePath)reference-packages/dlls/</ReferencePackagesDllsDir>
     <ReferencePackagesSourceDir>$(ReferencePackagesBasePath)reference-packages/source/</ReferencePackagesSourceDir>
     <ReferencePackagesDir>$(ReferencePackagesBasePath)reference-packages/packages/</ReferencePackagesDir>
     <ReferencePackagesToDeleteDir>$(ReferencePackagesBasePath)reference-packages/packages-to-delete/</ReferencePackagesToDeleteDir>

--- a/dir.props
+++ b/dir.props
@@ -89,7 +89,6 @@
     -->
     <ReferencePackagesBasePath Condition="'$(OfflineBuild)' == 'true'">$(ProjectDir)</ReferencePackagesBasePath>
     <ReferencePackagesStagingDir>$(ReferencePackagesBasePath)reference-packages/staging/</ReferencePackagesStagingDir>
-    <ReferencePackagesDllsDir>$(ReferencePackagesBasePath)reference-packages/dlls/</ReferencePackagesDllsDir>
     <ReferencePackagesSourceDir>$(ReferencePackagesBasePath)reference-packages/source/</ReferencePackagesSourceDir>
     <ReferencePackagesDir>$(ReferencePackagesBasePath)reference-packages/packages/</ReferencePackagesDir>
     <ReferencePackagesToDeleteDir>$(ReferencePackagesBasePath)reference-packages/packages-to-delete/</ReferencePackagesToDeleteDir>

--- a/dir.props
+++ b/dir.props
@@ -81,17 +81,17 @@
     <ProdConManifestFile>$(PackageReportDir)prodcon-build.xml</ProdConManifestFile>
     <PoisonedReportFile>$(PackageReportDir)poisoned.txt</PoisonedReportFile>
     <ConflictingPackageReportDir>$(BaseOutputPath)conflict-report/</ConflictingPackageReportDir>
-    <ReferencePackagesBasePath>$(IntermediatePath)</ReferencePackagesBasePath>
+    <ReferencePackagesBaseDir>$(IntermediatePath)reference-packages/</ReferencePackagesBaseDir>
     <!--
-      Change ReferencePackagesBasePath conditionally in offline build.
+      Change ReferencePackagesBaseDir conditionally in offline build.
       See corresponding change in build-source-tarball.sh to copy reference-packages
       from source-build bin dir to tarball reference-packages dir.
     -->
-    <ReferencePackagesBasePath Condition="'$(OfflineBuild)' == 'true'">$(ProjectDir)</ReferencePackagesBasePath>
-    <ReferencePackagesStagingDir>$(ReferencePackagesBasePath)reference-packages/staging/</ReferencePackagesStagingDir>
-    <ReferencePackagesSourceDir>$(ReferencePackagesBasePath)reference-packages/source/</ReferencePackagesSourceDir>
-    <ReferencePackagesDir>$(ReferencePackagesBasePath)reference-packages/packages/</ReferencePackagesDir>
-    <ReferencePackagesToDeleteDir>$(ReferencePackagesBasePath)reference-packages/packages-to-delete/</ReferencePackagesToDeleteDir>
+    <ReferencePackagesBaseDir Condition="'$(OfflineBuild)' == 'true'">$(ProjectDir)reference-packages/</ReferencePackagesBaseDir>
+    <ReferencePackagesStagingDir>$(ReferencePackagesBaseDir)staging/</ReferencePackagesStagingDir>
+    <ReferencePackagesSourceDir>$(ReferencePackagesBaseDir)source/</ReferencePackagesSourceDir>
+    <ReferencePackagesDir>$(ReferencePackagesBaseDir)packages/</ReferencePackagesDir>
+    <ReferencePackagesToDeleteDir>$(ReferencePackagesBaseDir)packages-to-delete/</ReferencePackagesToDeleteDir>
   </PropertyGroup>
 
   <!-- Import Build tools common props file where repo-independent properties are found -->

--- a/dir.props
+++ b/dir.props
@@ -84,14 +84,14 @@
     <ReferencePackagesBasePath>$(IntermediatePath)</ReferencePackagesBasePath>
     <!--
       Change ReferencePackagesBasePath conditionally in offline build.
-      See corresponding change in build-source-tarball.sh to copy refpkgs
-      from source-build bin dir to tarball refpkgs dir.
+      See corresponding change in build-source-tarball.sh to copy reference-packages
+      from source-build bin dir to tarball reference-packages dir.
     -->
     <ReferencePackagesBasePath Condition="'$(OfflineBuild)' == 'true'">$(ProjectDir)</ReferencePackagesBasePath>
-    <ReferencePackagesStagingDir>$(ReferencePackagesBasePath)refpkgs/staging/</ReferencePackagesStagingDir>
-    <ReferencePackagesSourceDir>$(ReferencePackagesBasePath)refpkgs/src/</ReferencePackagesSourceDir>
-    <ReferencePackagesDir>$(ReferencePackagesBasePath)refpkgs/packages/</ReferencePackagesDir>
-    <ReferencePackagesToDeleteDir>$(ReferencePackagesBasePath)refpkgs/packages-to-delete/</ReferencePackagesToDeleteDir>
+    <ReferencePackagesStagingDir>$(ReferencePackagesBasePath)reference-packages/staging/</ReferencePackagesStagingDir>
+    <ReferencePackagesSourceDir>$(ReferencePackagesBasePath)reference-packages/source/</ReferencePackagesSourceDir>
+    <ReferencePackagesDir>$(ReferencePackagesBasePath)reference-packages/packages/</ReferencePackagesDir>
+    <ReferencePackagesToDeleteDir>$(ReferencePackagesBasePath)reference-packages/packages-to-delete/</ReferencePackagesToDeleteDir>
   </PropertyGroup>
 
   <!-- Import Build tools common props file where repo-independent properties are found -->

--- a/patches/linker/0002-Update-linker-to-use-2.0.0-runtime.patch
+++ b/patches/linker/0002-Update-linker-to-use-2.0.0-runtime.patch
@@ -3,6 +3,9 @@ From: dseefeld <dseefeld@microsoft.com>
 Date: Mon, 15 Oct 2018 19:18:18 +0000
 Subject: [PATCH] Update linker to use 2.0.0 runtime
 
+This patch changes the RuntimeFrameworkVersion because the beta-001509-00
+version causes issues with ildasm/ilasm round trip of reference-only 
+packages.
 ---
  linker/ILLink.props | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/patches/linker/0002-Update-linker-to-use-2.0.0-runtime.patch
+++ b/patches/linker/0002-Update-linker-to-use-2.0.0-runtime.patch
@@ -1,0 +1,25 @@
+From c884d2eeacddbb3a09b8b2bac3c132ff3b3b63e4 Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Mon, 15 Oct 2018 19:18:18 +0000
+Subject: [PATCH] Update linker to use 2.0.0 runtime
+
+---
+ linker/ILLink.props | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/linker/ILLink.props b/linker/ILLink.props
+index db2a8a8..b24b882 100644
+--- a/linker/ILLink.props
++++ b/linker/ILLink.props
+@@ -3,7 +3,7 @@
+   <PropertyGroup>
+     <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
+     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
+-    <RuntimeFrameworkVersion>2.0.0-beta-001509-00</RuntimeFrameworkVersion>
++    <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
+     <DefineConstants>$(DefineConstants);FEATURE_ILLINK</DefineConstants>
+     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+-- 
+1.8.3.1
+

--- a/patches/newtonsoft-json/0001-Run-dotnet-migrate-to-generate-Newtonsoft.Json.Dotne.patch
+++ b/patches/newtonsoft-json/0001-Run-dotnet-migrate-to-generate-Newtonsoft.Json.Dotne.patch
@@ -18,7 +18,7 @@ new file mode 100644
 index 0000000..797f637
 --- /dev/null
 +++ b/Src/Newtonsoft.Json/Newtonsoft.Json.Dotnet.csproj
-@@ -0,0 +1,137 @@
+@@ -0,0 +1,138 @@
 +<Project Sdk="Microsoft.NET.Sdk">
 +
 +  <PropertyGroup>
@@ -53,6 +53,7 @@ index 0000000..797f637
 +    <Reference Include="System.Xml.Linq" />
 +    <Reference Include="System" />
 +    <Reference Include="Microsoft.CSharp" />
++    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-alpha-003" PrivateAssets="all"/>
 +  </ItemGroup>
 +
 +  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">

--- a/patches/newtonsoft-json/0004-Add-roslyn-tools-to-nuget.config.patch
+++ b/patches/newtonsoft-json/0004-Add-roslyn-tools-to-nuget.config.patch
@@ -1,0 +1,27 @@
+From 6b3d2eed17b5e2e5627f968e6762f9396302144e Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Tue, 25 Sep 2018 16:49:22 +0000
+Subject: [PATCH] Add roslyn-tools to nuget.config
+
+---
+ Src/NuGet.Config | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/Src/NuGet.Config b/Src/NuGet.Config
+index 3e0a4cf..d12d36f 100644
+--- a/Src/NuGet.Config
++++ b/Src/NuGet.Config
+@@ -4,7 +4,8 @@
+     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+     <clear />
+     <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
++    <add key="roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
+     <!--<add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />-->
+     <add key="NuGet.org (v3)" value="https://api.nuget.org/v3/index.json" />
+   </packageSources>
+-</configuration>
+\ No newline at end of file
++</configuration>
+-- 
+1.8.3.1
+

--- a/repos/cli.proj
+++ b/repos/cli.proj
@@ -47,7 +47,7 @@
     <SourceOverrideRepoApiImplemented>true</SourceOverrideRepoApiImplemented>
 
     <EnvironmentExternalRestoreSources>$(SourceBuiltPackagesPath)</EnvironmentExternalRestoreSources>
-    <EnvironmentExternalRestoreSources Condition="'$(OfflineBuild)' == 'true'">$(EnvironmentExternalRestoreSources)%3B$(PrebuiltPackagesPath)</EnvironmentExternalRestoreSources>
+    <EnvironmentExternalRestoreSources Condition="'$(OfflineBuild)' == 'true'">$(EnvironmentExternalRestoreSources)%3B$(ReferencePackagesDir)%3B$(PrebuiltPackagesPath)</EnvironmentExternalRestoreSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -146,6 +146,11 @@
                             Condition="'$(OfflineBuild)' == 'true'" />
 
     <AddSourceToNuGetConfig NuGetConfigFile="%(NuGetConfigFiles.Identity)"
+                            SourceName="reference-packages"
+                            SourcePath="$(ReferencePackagesDir)"
+                            Condition="'$(OfflineBuild)' == 'true'" />
+
+    <AddSourceToNuGetConfig NuGetConfigFile="%(NuGetConfigFiles.Identity)"
                             SourceName="source-built"
                             SourcePath="$(SourceBuiltPackagesPath)" />
   </Target>
@@ -215,6 +220,7 @@
           BeforeTargets="Build">
     <ItemGroup>
       <_DotNetRestoreSources Include="$(SourceBuiltPackagesPath)" />
+      <_DotNetRestoreSources Include="$(ReferencePackagesDir)" Condition="'$(OfflineBuild)' == 'true'"/>
       <_DotNetRestoreSources Include="$(PrebuiltPackagesPath)" Condition="'$(OfflineBuild)' == 'true'"/>
       <_DotNetRestoreSources Include="$(PrebuiltSourceBuiltPackagesPath)" Condition="'$(OfflineBuild)' == 'true'"/>
     </ItemGroup>

--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -380,6 +380,7 @@
       <TarballPrebuiltPackageFiles Include="$(PrebuiltPackagesPath)*.nupkg" />
 
       <SourceBuiltPackageFiles Include="$(SourceBuiltBlobFeedDir)**/*.nupkg" />
+      <ReferencePackageFiles Condition="'$(OfflineBuild)' == 'true'" Include="$(ReferencePackagesDir)**/*.nupkg" />
 
       <!-- Check all RIDs from all restored Microsoft.NETCore.Platforms packages. -->
       <PlatformsRuntimeJsonFiles Include="$(LocalNuGetPackagesRoot)*/microsoft.netcore.platforms/*/runtime.json" />
@@ -395,6 +396,7 @@
       RestoredPackageFiles="@(AllRestoredPackageFiles)"
       TarballPrebuiltPackageFiles="@(TarballPrebuiltPackageFiles)"
       SourceBuiltPackageFiles="@(SourceBuiltPackageFiles)"
+      ReferencePackageFiles="@(ReferencePackageFiles)"
       PlatformsRuntimeJsonFiles="@(PlatformsRuntimeJsonFiles)"
       TargetRid="$(TargetRid)"
       ProjectDirectories="@(ProjectDirectories)"

--- a/support/tarball/build.sh
+++ b/support/tarball/build.sh
@@ -13,18 +13,22 @@ export NUGET_PACKAGES="$SCRIPT_ROOT/packages/"
 
 MSBUILD_ARGUMENTS=("/p:OfflineBuild=true" "/flp:v=detailed" "/clp:v=detailed")
 
+echo "Rebuild reference assemblies"
+$CLI_ROOT/dotnet $CLI_ROOT/sdk/$CLI_VERSION/MSBuild.dll $SCRIPT_ROOT/tools-local/init-build.proj /t:BuildReferenceAssemblies ${MSBUILD_ARGUMENTS[@]} "$@"
+
 echo "Expanding BuildTools dependencies into packages directory..."
 # init-tools tries to copy from its script directory to Tools, which in this case is a copy to
 # itself. This is an error. To avoid the error, use a temp dir that we immediately delete.
 TEMP_TOOLS_DIR="$SCRIPT_ROOT/ToolsTemp"
 PREBUILT_PACKAGE_SOURCE="$SCRIPT_ROOT/prebuilt/nuget-packages"
+REF_PACKAGE_SOURCE="$SCRIPT_ROOT/reference-packages/packages"
 (
     # Log the commands that run.
     set -x
 
-    "$CLI_ROOT/dotnet" restore "$SCRIPT_ROOT/init-tools.msbuild" --no-cache --packages "$SCRIPT_ROOT/packages" --source "$PREBUILT_PACKAGE_SOURCE" || exit $?
+    "$CLI_ROOT/dotnet" restore "$SCRIPT_ROOT/init-tools.msbuild" --no-cache --packages "$SCRIPT_ROOT/packages" --source "$PREBUILT_PACKAGE_SOURCE" --source "$REF_PACKAGE_SOURCE" || exit $?
 
-    export __INIT_TOOLS_RESTORE_ARGS="--source $PREBUILT_PACKAGE_SOURCE" || exit $?
+    export __INIT_TOOLS_RESTORE_ARGS="--source $PREBUILT_PACKAGE_SOURCE --source $REF_PACKAGE_SOURCE" || exit $?
     "$SCRIPT_ROOT/Tools/init-tools.sh" "$SCRIPT_ROOT" "$SCRIPT_ROOT/Tools/dotnetcli/dotnet" "$TEMP_TOOLS_DIR" "$SCRIPT_ROOT/packages" || exit $?
 
     rm -rf "$TEMP_TOOLS_DIR" || exit $?

--- a/tools-local/init-build.proj
+++ b/tools-local/init-build.proj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <Import Project="..\dir.props" />
   <Import Project="..\Tools\Packaging.targets" />
+  <Import Project="..\Tools\IL.targets" />
 
   <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="GetHostInformation" />
   <UsingTask AssemblyFile="$(LeakDetectionTasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.dll" TaskName="MarkAndCatalogPackages" />
@@ -68,10 +69,25 @@
      <Exec Condition="'$(Platform)' == 'armel'" Command="$(ArmEnvironmentVariables) $(ProjectDir)cross/armel/tizen-build-rootfs.sh" />
   </Target>
 
-  <Target Name="BuildReferenceAssemblies" Condition="'$(OfflineBuild)' == 'true'">  
+  <Target Name="BuildReferenceAssemblies" Condition="'$(OfflineBuild)' == 'true'">
     <ItemGroup>
+      <IlSource Include="$(ReferencePackagesSourceDir)/**/*.il" />
       <ReferenceAssemblyDirectories Include ="$(ReferencePackagesStagingDir)/**/*.nuspec" />
     </ItemGroup>
+
+    <Message Importance="High" Text="refdir=$(ReferencePackagesStagingDir)%(IlSource.RecursiveDir)%(IlSource.FileName).dll" />
+    <Exec Command="$(IlasmToolPath) %(IlSource.Identity) -dll -quiet -nologo -output=$(ReferencePackagesStagingDir)%(IlSource.RecursiveDir)%(IlSource.Filename).dll" />
+
+    <!-- Temporary workaround to copy dlls that can't be round-tripped 
+         They just get copied from the source to the package staging area
+    -->
+    <ItemGroup>
+        <DllsInSource Include="$(ReferencePackagesSourceDir)/**/*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="%(DllsInSource.Identity)" DestinationFiles="$(ReferencePackagesStagingDir)%(DllsInSource.RecursiveDir)%(DllsInSource.Filename).dll" />
+
+    <!-- End Temporary workaround -->
+
     <NugetPack Nuspecs="%(ReferenceAssemblyDirectories.Identity)"
                OutputDirectory="$(ReferencePackagesDir)"
                ExcludeEmptyDirectories="false"

--- a/tools-local/init-build.proj
+++ b/tools-local/init-build.proj
@@ -5,6 +5,7 @@
     <GeneratingStaticPropertiesFile>true</GeneratingStaticPropertiesFile>
   </PropertyGroup>
   <Import Project="..\dir.props" />
+  <Import Project="..\Tools\Packaging.targets" />
 
   <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="GetHostInformation" />
   <UsingTask AssemblyFile="$(LeakDetectionTasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.dll" TaskName="MarkAndCatalogPackages" />
@@ -18,7 +19,7 @@
     Inputs="$(TargetInfoProps)"
     Outputs="$(BuildCompetedSuccessSemaphore)"
     >
-    <CallTarget Targets="BuildTasks;InstallSourceBuildSdkResolver;WriteDynamicPropsToStaticPropsFiles;GenerateRootFs;CreateAllGitInfoProps;ApplyPatches;PoisonPrebuiltPackages" />
+    <CallTarget Targets="BuildTasks;InstallSourceBuildSdkResolver;WriteDynamicPropsToStaticPropsFiles;GenerateRootFs;CreateAllGitInfoProps;ApplyPatches;PoisonPrebuiltPackages;BuildReferenceAssemblies" />
     <Touch Files="$(BuildCompetedSuccessSemaphore)" AlwaysCreate="true" />
   </Target>
 
@@ -33,7 +34,7 @@
 
   <Target Name="BuildTasks">
     <PropertyGroup Condition="'$(OfflineBuild)' == 'true'">
-      <OfflineSources>$(PrebuiltPackagesPath)</OfflineSources>
+      <OfflineSources>$(PrebuiltPackagesPath)%3B$(ReferencePackagesDir)</OfflineSources>
     </PropertyGroup>
     <Exec Command="$(DotNetCliToolDir)dotnet build tasks\Microsoft.DotNet.SourceBuild.Tasks\Microsoft.DotNet.SourceBuild.Tasks.csproj /p:RestoreSources=$(OfflineSources)" />
   </Target>
@@ -65,6 +66,16 @@
   <Target Name="GenerateRootFs" Condition="'$(OS)' != 'Windows_NT'">
      <Exec Condition="$(Platform.Contains('arm')) AND '$(Platform)' != 'armel'" Command="$(ArmEnvironmentVariables) $(ProjectDir)cross/build-rootfs.sh" />
      <Exec Condition="'$(Platform)' == 'armel'" Command="$(ArmEnvironmentVariables) $(ProjectDir)cross/armel/tizen-build-rootfs.sh" />
+  </Target>
+
+  <Target Name="BuildReferenceAssemblies" Condition="'$(OfflineBuild)' == 'true'">  
+    <ItemGroup>
+      <ReferenceAssemblyDirectories Include ="$(ReferencePackagesStagingDir)/**/*.nuspec" />
+    </ItemGroup>
+    <NugetPack Nuspecs="%(ReferenceAssemblyDirectories.Identity)"
+               OutputDirectory="$(ReferencePackagesDir)"
+               ExcludeEmptyDirectories="false"
+               CreateSymbolPackage="false" />
   </Target>
 
   <Target Name="WriteDynamicPropsToStaticPropsFiles">

--- a/tools-local/init-build.proj
+++ b/tools-local/init-build.proj
@@ -70,28 +70,32 @@
   </Target>
 
   <Target Name="BuildReferenceAssemblies" Condition="'$(OfflineBuild)' == 'true'">
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Building reference-only assemblies." />
     <ItemGroup>
-      <IlSource Include="$(ReferencePackagesSourceDir)/**/*.il" />
+      <IlSource Include="$(ReferencePackagesSourceDir)**/*.il" />
       <ReferenceAssemblyDirectories Include ="$(ReferencePackagesStagingDir)/**/*.nuspec" />
     </ItemGroup>
 
-    <MakeDir Directories="$(ReferencePackagesStagingDir)%(IlSource.RecursiveDir)" Condition="!Exists('$(ReferencePackagesStagingDir)%(IlSource.RecursiveDir)')" />
+    <MakeDir Directories="$(ReferencePackagesStagingDir)%(IlSource.RecursiveDir)" />
     <Exec Command="$(IlasmToolPath) %(IlSource.Identity) -dll -quiet -nologo -output=$(ReferencePackagesStagingDir)%(IlSource.RecursiveDir)%(IlSource.Filename).dll" />
 
     <!-- Temporary workaround to copy dlls that can't be round-tripped 
          They just get copied from the source to the package staging area
     -->
     <ItemGroup>
-        <DllsInSource Include="$(ReferencePackagesSourceDir)/**/*.dll" />
+      <DllsInSource Include="$(ReferencePackagesSourceDir)**/*.dll" />
     </ItemGroup>
     <Copy SourceFiles="%(DllsInSource.Identity)" DestinationFiles="$(ReferencePackagesStagingDir)%(DllsInSource.RecursiveDir)%(DllsInSource.Filename).dll" />
 
     <!-- End Temporary workaround -->
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Done building reference-only assemblies." />
 
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Packing reference-only packages." />
     <NugetPack Nuspecs="%(ReferenceAssemblyDirectories.Identity)"
                OutputDirectory="$(ReferencePackagesDir)"
                ExcludeEmptyDirectories="false"
                CreateSymbolPackage="false" />
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Done packing reference-only packages." />
   </Target>
 
   <Target Name="WriteDynamicPropsToStaticPropsFiles">

--- a/tools-local/init-build.proj
+++ b/tools-local/init-build.proj
@@ -5,8 +5,8 @@
     <GeneratingStaticPropertiesFile>true</GeneratingStaticPropertiesFile>
   </PropertyGroup>
   <Import Project="..\dir.props" />
-  <Import Project="..\Tools\Packaging.targets" />
-  <Import Project="..\Tools\IL.targets" />
+  <Import Project="$(ToolsDir)Packaging.targets" />
+  <Import Project="$(ToolsDir)IL.targets" />
 
   <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="GetHostInformation" />
   <UsingTask AssemblyFile="$(LeakDetectionTasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.dll" TaskName="MarkAndCatalogPackages" />
@@ -75,7 +75,7 @@
       <ReferenceAssemblyDirectories Include ="$(ReferencePackagesStagingDir)/**/*.nuspec" />
     </ItemGroup>
 
-    <Message Importance="High" Text="refdir=$(ReferencePackagesStagingDir)%(IlSource.RecursiveDir)%(IlSource.FileName).dll" />
+    <MakeDir Directories="$(ReferencePackagesStagingDir)%(IlSource.RecursiveDir)" Condition="!Exists('$(ReferencePackagesStagingDir)%(IlSource.RecursiveDir)')" />
     <Exec Command="$(IlasmToolPath) %(IlSource.Identity) -dll -quiet -nologo -output=$(ReferencePackagesStagingDir)%(IlSource.RecursiveDir)%(IlSource.Filename).dll" />
 
     <!-- Temporary workaround to copy dlls that can't be round-tripped 

--- a/tools-local/init-build.proj
+++ b/tools-local/init-build.proj
@@ -35,7 +35,7 @@
 
   <Target Name="BuildTasks">
     <PropertyGroup Condition="'$(OfflineBuild)' == 'true'">
-      <OfflineSources>$(PrebuiltPackagesPath)%3B$(ReferencePackagesDir)</OfflineSources>
+      <OfflineSources>$(ReferencePackagesDir)%3B$(PrebuiltPackagesPath)</OfflineSources>
     </PropertyGroup>
     <Exec Command="$(DotNetCliToolDir)dotnet build tasks\Microsoft.DotNet.SourceBuild.Tasks\Microsoft.DotNet.SourceBuild.Tasks.csproj /p:RestoreSources='$(OfflineSources)'" />
   </Target>

--- a/tools-local/init-build.proj
+++ b/tools-local/init-build.proj
@@ -19,7 +19,7 @@
     Inputs="$(TargetInfoProps)"
     Outputs="$(BuildCompetedSuccessSemaphore)"
     >
-    <CallTarget Targets="BuildTasks;InstallSourceBuildSdkResolver;WriteDynamicPropsToStaticPropsFiles;GenerateRootFs;CreateAllGitInfoProps;ApplyPatches;PoisonPrebuiltPackages;BuildReferenceAssemblies" />
+    <CallTarget Targets="BuildReferenceAssemblies;BuildTasks;InstallSourceBuildSdkResolver;WriteDynamicPropsToStaticPropsFiles;GenerateRootFs;CreateAllGitInfoProps;ApplyPatches;PoisonPrebuiltPackages" />
     <Touch Files="$(BuildCompetedSuccessSemaphore)" AlwaysCreate="true" />
   </Target>
 
@@ -36,7 +36,7 @@
     <PropertyGroup Condition="'$(OfflineBuild)' == 'true'">
       <OfflineSources>$(PrebuiltPackagesPath)%3B$(ReferencePackagesDir)</OfflineSources>
     </PropertyGroup>
-    <Exec Command="$(DotNetCliToolDir)dotnet build tasks\Microsoft.DotNet.SourceBuild.Tasks\Microsoft.DotNet.SourceBuild.Tasks.csproj /p:RestoreSources=$(OfflineSources)" />
+    <Exec Command="$(DotNetCliToolDir)dotnet build tasks\Microsoft.DotNet.SourceBuild.Tasks\Microsoft.DotNet.SourceBuild.Tasks.csproj /p:RestoreSources='$(OfflineSources)'" />
   </Target>
 
   <Target Name="GetRepoProjects">

--- a/tools-local/init-build.proj
+++ b/tools-local/init-build.proj
@@ -20,7 +20,7 @@
     Inputs="$(TargetInfoProps)"
     Outputs="$(BuildCompetedSuccessSemaphore)"
     >
-    <CallTarget Targets="BuildReferenceAssemblies;BuildTasks;InstallSourceBuildSdkResolver;WriteDynamicPropsToStaticPropsFiles;GenerateRootFs;CreateAllGitInfoProps;ApplyPatches;PoisonPrebuiltPackages" />
+    <CallTarget Targets="BuildTasks;InstallSourceBuildSdkResolver;WriteDynamicPropsToStaticPropsFiles;GenerateRootFs;CreateAllGitInfoProps;ApplyPatches;PoisonPrebuiltPackages" />
     <Touch Files="$(BuildCompetedSuccessSemaphore)" AlwaysCreate="true" />
   </Target>
 

--- a/tools-local/prebuilt-baseline-offline.xml
+++ b/tools-local/prebuilt-baseline-offline.xml
@@ -31,15 +31,8 @@
   </ProjectDirectories>
   <NeverRestoredTarballPrebuilts>
     <PackageIdentity Id="Microsoft.DotNet.BuildTools" Version="2.1.0-rc1-03131-06" />
-    <PackageIdentity Id="Microsoft.NETCore.App" Version="2.1.4" />
-    <PackageIdentity Id="Microsoft.NETCore.ILAsm" Version="2.1.5-servicing-26911-03" />
-    <PackageIdentity Id="Microsoft.NETCore.ILDAsm" Version="2.1.5-servicing-26911-03" />
-    <PackageIdentity Id="Microsoft.NETCore.Jit" Version="2.1.5-servicing-26911-03" />
-    <PackageIdentity Id="Microsoft.NETCore.Runtime.CoreCLR" Version="2.1.5-servicing-26911-03" />
     <PackageIdentity Id="RoslynTools.RepoToolset" Version="1.0.0-beta2-62805-03" />
     <PackageIdentity Id="runtime.linux-x64.Microsoft.NETCore.App" Version="2.1.4" />
-    <PackageIdentity Id="runtime.linux-x64.Microsoft.NETCore.ILAsm" Version="2.1.5-servicing-26911-03" />
-    <PackageIdentity Id="runtime.linux-x64.Microsoft.NETCore.ILDAsm" Version="2.1.5-servicing-26911-03" />
     <PackageIdentity Id="runtime.linux-x64.Microsoft.NETCore.Jit" Version="2.1.5-servicing-26911-03" />
     <PackageIdentity Id="runtime.linux-x64.Microsoft.NETCore.Runtime.CoreCLR" Version="2.1.5-servicing-26911-03" />
   </NeverRestoredTarballPrebuilts>
@@ -53,7 +46,6 @@
     <Usage Id="fmdev.XliffParser" Version="0.5.3" />
     <Usage Id="FSharp.Core" Version="4.5.2" />
     <Usage Id="Libuv" Version="1.9.1" />
-    <Usage Id="MicroBuild.Core" Version="0.2.0" />
     <Usage Id="Microsoft.3rdpartytools.MarkdownLog" Version="0.10.0-alpha-experimental" />
     <Usage Id="Microsoft.Build" Version="14.3.0" />
     <Usage Id="Microsoft.Build" Version="15.1.548" />
@@ -87,7 +79,6 @@
     <Usage Id="Microsoft.CodeAnalysis.Analyzers" Version="1.1.0" />
     <Usage Id="Microsoft.CodeAnalysis.Common" Version="1.3.0" />
     <Usage Id="Microsoft.CodeAnalysis.Common" Version="2.6.0-beta3-62316-02" />
-    <Usage Id="Microsoft.CodeAnalysis.Compilers" Version="2.6.0-beta3-62316-02" />
     <Usage Id="Microsoft.CodeAnalysis.CSharp" Version="1.3.0" />
     <Usage Id="Microsoft.CodeAnalysis.CSharp" Version="2.6.0-beta3-62316-02" />
     <Usage Id="Microsoft.CodeAnalysis.VisualBasic" Version="1.3.0" />
@@ -103,11 +94,9 @@
     <Usage Id="Microsoft.DiaSymReader.Native" Version="1.4.1" />
     <Usage Id="Microsoft.DiaSymReader.Native" Version="1.5.0" />
     <Usage Id="Microsoft.DiaSymReader.Native" Version="1.7.0" />
-    <Usage Id="Microsoft.Docker.Sdk" Version="1.1.0" />
     <Usage Id="Microsoft.DotNet.Archive" Version="0.2.0-beta-63027-01" />
     <Usage Id="Microsoft.DotNet.Build.Tasks.Feed" Version="2.1.0-rc1-03130-05" />
     <Usage Id="Microsoft.DotNet.BuildTools.CoreCLR" Version="1.0.4-prerelease" />
-    <Usage Id="Microsoft.DotNet.BuildTools.TestSuite" Version="2.1.0-rc1-03131-06" />
     <Usage Id="Microsoft.DotNet.Cli.CommandLine" Version="0.1.1-alpha-167" />
     <Usage Id="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
     <Usage Id="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
@@ -116,9 +105,6 @@
     <Usage Id="Microsoft.DotNet.PlatformAbstractions" Version="2.0.4" />
     <Usage Id="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0-preview2-26306-03" />
     <Usage Id="Microsoft.DotNet.VersionTools" Version="2.1.0-rc1-03130-05" />
-    <Usage Id="Microsoft.DotNet.Web.ItemTemplates" Version="2.1.5" />
-    <Usage Id="Microsoft.DotNet.Web.ProjectTemplates.2.1" Version="2.1.5" />
-    <Usage Id="Microsoft.DotNet.Web.Spa.ProjectTemplates" Version="2.1.5" />
     <Usage Id="Microsoft.Extensions.CommandLineUtils" Version="1.1.0" />
     <Usage Id="Microsoft.Extensions.DependencyModel" Version="1.0.0" />
     <Usage Id="Microsoft.Extensions.DependencyModel" Version="1.0.3" />
@@ -130,66 +116,18 @@
     <Usage Id="Microsoft.Net.Compilers" Version="2.8.0-beta4-62824-10" />
     <Usage Id="Microsoft.Net.Compilers.netcore" Version="2.6.0-beta3-62316-02" />
     <Usage Id="Microsoft.Net.Compilers.Targets.NetCore" Version="0.1.5-dev" />
-    <Usage Id="Microsoft.NET.Sdk.Razor" Version="2.1.2" />
-    <Usage Id="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <Usage Id="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <Usage Id="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <Usage Id="Microsoft.NETCore.App" Version="1.0.3" />
-    <Usage Id="Microsoft.NETCore.App" Version="1.0.5" />
-    <Usage Id="Microsoft.NETCore.App" Version="1.1.1" />
     <Usage Id="Microsoft.NETCore.App" Version="1.1.2" />
-    <Usage Id="Microsoft.NETCore.App" Version="2.0.0-beta-001509-00" />
-    <Usage Id="Microsoft.NETCore.App" Version="2.0.0" />
-    <Usage Id="Microsoft.NETCore.App" Version="2.1.0-preview1-26116-04" />
-    <Usage Id="Microsoft.NETCore.App" Version="2.1.0" />
     <Usage Id="Microsoft.NETCore.Compilers" Version="2.8.0-beta2-62719-08" />
     <Usage Id="Microsoft.NETCore.Compilers" Version="2.8.0-beta4-62824-10" />
-    <Usage Id="Microsoft.NETCore.DotNetAppHost" Version="2.0.0" />
-    <Usage Id="Microsoft.NETCore.DotNetAppHost" Version="2.1.0-preview1-26116-04" />
-    <Usage Id="Microsoft.NETCore.DotNetAppHost" Version="2.1.0" />
-    <Usage Id="Microsoft.NETCore.DotNetAppHost" Version="2.1.5-servicing-26911-03" />
-    <Usage Id="Microsoft.NETCore.DotNetHost" Version="1.0.1" />
-    <Usage Id="Microsoft.NETCore.DotNetHost" Version="1.1.0" />
-    <Usage Id="Microsoft.NETCore.DotNetHost" Version="2.1.5-servicing-26911-03" />
     <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="1.0.3" />
-    <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="1.0.5" />
-    <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="1.1.0" />
     <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="1.1.2" />
-    <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="2.0.0" />
-    <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="2.1.0-preview1-26116-04" />
-    <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="2.1.0" />
-    <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="2.1.5-servicing-26911-03" />
-    <Usage Id="Microsoft.NETCore.DotNetHostResolver" Version="1.0.1" />
-    <Usage Id="Microsoft.NETCore.DotNetHostResolver" Version="1.1.0" />
-    <Usage Id="Microsoft.NETCore.DotNetHostResolver" Version="2.0.0" />
-    <Usage Id="Microsoft.NETCore.DotNetHostResolver" Version="2.1.0-preview1-26116-04" />
-    <Usage Id="Microsoft.NETCore.DotNetHostResolver" Version="2.1.0" />
-    <Usage Id="Microsoft.NETCore.DotNetHostResolver" Version="2.1.5-servicing-26911-03" />
     <Usage Id="Microsoft.NETCore.Jit" Version="1.0.5" />
-    <Usage Id="Microsoft.NETCore.Jit" Version="1.0.7" />
-    <Usage Id="Microsoft.NETCore.Jit" Version="1.1.1" />
     <Usage Id="Microsoft.NETCore.Jit" Version="1.1.2" />
-    <Usage Id="Microsoft.NETCore.Platforms" Version="1.0.1" />
-    <Usage Id="Microsoft.NETCore.Platforms" Version="1.0.2-beta-24224-02" />
-    <Usage Id="Microsoft.NETCore.Platforms" Version="1.0.2" />
-    <Usage Id="Microsoft.NETCore.Platforms" Version="1.1.0" />
-    <Usage Id="Microsoft.NETCore.Platforms" Version="2.0.0-beta-25006-01" />
-    <Usage Id="Microsoft.NETCore.Platforms" Version="2.0.0" />
-    <Usage Id="Microsoft.NETCore.Platforms" Version="2.1.0-preview1-26116-01" />
-    <Usage Id="Microsoft.NETCore.Platforms" Version="2.1.0" />
-    <Usage Id="Microsoft.NETCore.Platforms" Version="2.1.1-servicing-26902-02" />
     <Usage Id="Microsoft.NETCore.Runtime.CoreCLR" Version="1.0.5" />
-    <Usage Id="Microsoft.NETCore.Runtime.CoreCLR" Version="1.0.7" />
-    <Usage Id="Microsoft.NETCore.Runtime.CoreCLR" Version="1.1.1" />
     <Usage Id="Microsoft.NETCore.Runtime.CoreCLR" Version="1.1.2" />
-    <Usage Id="Microsoft.NETCore.Targets" Version="1.0.1" />
-    <Usage Id="Microsoft.NETCore.Targets" Version="1.0.3" />
-    <Usage Id="Microsoft.NETCore.Targets" Version="1.1.0" />
-    <Usage Id="Microsoft.NETCore.Windows.ApiSets" Version="1.0.1" />
-    <Usage Id="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-alpha-003" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net40" Version="1.0.0-alpha-003" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net46" Version="1.0.0-alpha-003" />
-    <Usage Id="Microsoft.Portable.Targets" Version="0.1.1-dev" />
     <Usage Id="Microsoft.TargetingPack.NETFramework.v4.6" Version="1.0.1" />
     <Usage Id="Microsoft.TargetingPack.NETFramework.v4.6.1" Version="1.0.1" />
     <Usage Id="Microsoft.TemplateEngine.Cli.Localization" Version="1.0.2-beta3" />
@@ -205,7 +143,6 @@
     <Usage Id="Microsoft.VisualStudio.QualityTools.DataCollectors" Version="15.6.0-preview-1270639" />
     <Usage Id="Microsoft.VisualStudio.RemoteControl" Version="14.0.262-masterA5CACE98" />
     <Usage Id="Microsoft.VisualStudio.Sdk.BuildTasks.14.0" Version="14.0.12-pre" />
-    <Usage Id="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.15" />
     <Usage Id="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" />
     <Usage Id="Microsoft.VisualStudio.Telemetry" Version="15.6.815-master284DF69C" />
     <Usage Id="Microsoft.VisualStudio.Utilities.Internal" Version="14.0.74-masterCEEA65A3" />
@@ -215,11 +152,6 @@
     <Usage Id="Microsoft.Win32.Registry" Version="4.0.0" />
     <Usage Id="Microsoft.Win32.Registry" Version="4.3.0" />
     <Usage Id="Microsoft.xunit.netcore.extensions" Version="2.1.0-rc1-03131-06" />
-    <Usage Id="NETStandard.Library" Version="1.6.0" />
-    <Usage Id="NETStandard.Library" Version="1.6.1" />
-    <Usage Id="NETStandard.Library" Version="2.0.0-beta-25006-01" />
-    <Usage Id="NETStandard.Library" Version="2.0.0" />
-    <Usage Id="NETStandard.Library" Version="2.0.1" />
     <Usage Id="NETStandard.Library.NETFramework" Version="2.0.1-servicing-26011-01" />
     <Usage Id="Newtonsoft.Json" Version="6.0.4" />
     <Usage Id="Newtonsoft.Json" Version="8.0.3" />
@@ -250,10 +182,8 @@
     <Usage Id="NuGet.Versioning" Version="4.3.0-preview1-2500" />
     <Usage Id="NuGet.Versioning" Version="4.3.0-preview2-4095" />
     <Usage Id="NuGet.Versioning" Version="4.7.0-preview1-4992" />
-    <Usage Id="NUnit3.DotNetNew.Template" Version="1.5.1" />
     <Usage Id="OpenCover" Version="4.6.519" />
     <Usage Id="optimization.linux-x64.PGO.CoreCLR" Version="2.1.0-release-20180815-0105" />
-    <Usage Id="optimization.PGO.CoreCLR" Version="2.1.0-release-20180815-0105" />
     <Usage Id="optimization.windows_nt-x64.PGO.CoreCLR" Version="2.1.0-release-20180815-0105" />
     <Usage Id="optimization.windows_nt-x86.PGO.CoreCLR" Version="2.1.0-release-20180815-0105" />
     <Usage Id="ReportGenerator" Version="3.0.1" />
@@ -301,28 +231,11 @@
     <Usage Id="runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.1" Rid="fedora.24-x64" />
     <Usage Id="runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.2" Rid="fedora.24-x64" />
     <Usage Id="runtime.linux-x64.Microsoft.NETCore.App" Version="2.0.0" Rid="linux-x64" />
-    <Usage Id="runtime.linux-x64.Microsoft.NETCore.DotNetAppHost" Version="2.0.0" Rid="linux-x64" />
-    <Usage Id="runtime.linux-x64.Microsoft.NETCore.DotNetAppHost" Version="2.1.5-servicing-26911-03" Rid="linux-x64" />
-    <Usage Id="runtime.linux-x64.Microsoft.NETCore.DotNetHost" Version="2.1.5-servicing-26911-03" Rid="linux-x64" />
     <Usage Id="runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy" Version="2.0.0" Rid="linux-x64" />
     <Usage Id="runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy" Version="2.1.5-servicing-26911-03" Rid="linux-x64" />
     <Usage Id="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" Version="2.0.0" Rid="linux-x64" />
     <Usage Id="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" Version="2.1.5-servicing-26911-03" Rid="linux-x64" />
-    <Usage Id="runtime.native.System" Version="4.0.0" />
-    <Usage Id="runtime.native.System" Version="4.3.0" />
-    <Usage Id="runtime.native.System.Data.SqlClient.sni" Version="4.4.0" />
-    <Usage Id="runtime.native.System.IO.Compression" Version="4.1.0" />
-    <Usage Id="runtime.native.System.IO.Compression" Version="4.3.0" />
-    <Usage Id="runtime.native.System.Net.Http" Version="4.0.1" />
-    <Usage Id="runtime.native.System.Net.Http" Version="4.3.0" />
-    <Usage Id="runtime.native.System.Net.Security" Version="4.0.1" />
-    <Usage Id="runtime.native.System.Net.Security" Version="4.3.0" />
-    <Usage Id="runtime.native.System.Security.Cryptography" Version="4.0.0" />
-    <Usage Id="runtime.native.System.Security.Cryptography" Version="4.0.1" />
-    <Usage Id="runtime.native.System.Security.Cryptography.Apple" Version="4.3.0" />
-    <Usage Id="runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.0" />
     <Usage Id="runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.1" />
-    <Usage Id="runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.2" />
     <Usage Id="runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.0" Rid="opensuse.13.2-x64" />
     <Usage Id="runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.1" Rid="opensuse.13.2-x64" />
     <Usage Id="runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.2" Rid="opensuse.13.2-x64" />
@@ -330,7 +243,6 @@
     <Usage Id="runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.1" Rid="opensuse.42.1-x64" />
     <Usage Id="runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.2" Rid="opensuse.42.1-x64" />
     <Usage Id="runtime.osx-x64.Microsoft.NETCore.App" Version="2.0.0" Rid="osx-x64" />
-    <Usage Id="runtime.osx-x64.Microsoft.NETCore.DotNetAppHost" Version="2.0.0" Rid="osx-x64" />
     <Usage Id="runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy" Version="2.0.0" Rid="osx-x64" />
     <Usage Id="runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver" Version="2.0.0" Rid="osx-x64" />
     <Usage Id="runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple" Version="4.3.0" Rid="osx.10.10-x64" />
@@ -406,9 +318,6 @@
     <Usage Id="System.Buffers" Version="4.0.0" />
     <Usage Id="System.Buffers" Version="4.3.0" />
     <Usage Id="System.CodeDom" Version="4.4.0" />
-    <Usage Id="System.Collections" Version="4.0.11-rc2-24027" />
-    <Usage Id="System.Collections" Version="4.0.11" />
-    <Usage Id="System.Collections" Version="4.3.0" />
     <Usage Id="System.Collections.Concurrent" Version="4.0.12" />
     <Usage Id="System.Collections.Concurrent" Version="4.3.0" />
     <Usage Id="System.Collections.Immutable" Version="1.2.0" />
@@ -430,7 +339,6 @@
     <Usage Id="System.ComponentModel.Primitives" Version="4.3.0" />
     <Usage Id="System.ComponentModel.TypeConverter" Version="4.1.0" />
     <Usage Id="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <Usage Id="System.Composition" Version="1.1.0" />
     <Usage Id="System.Composition.AttributedModel" Version="1.1.0" />
     <Usage Id="System.Composition.Convention" Version="1.1.0" />
     <Usage Id="System.Composition.Hosting" Version="1.1.0" />
@@ -440,9 +348,6 @@
     <Usage Id="System.Console" Version="4.0.0" />
     <Usage Id="System.Console" Version="4.3.0" />
     <Usage Id="System.Diagnostics.Contracts" Version="4.0.1" />
-    <Usage Id="System.Diagnostics.Debug" Version="4.0.11-rc2-24027" />
-    <Usage Id="System.Diagnostics.Debug" Version="4.0.11" />
-    <Usage Id="System.Diagnostics.Debug" Version="4.3.0" />
     <Usage Id="System.Diagnostics.DiagnosticSource" Version="4.0.0" />
     <Usage Id="System.Diagnostics.DiagnosticSource" Version="4.3.0" />
     <Usage Id="System.Diagnostics.DiagnosticSource" Version="4.3.1" />
@@ -455,9 +360,6 @@
     <Usage Id="System.Diagnostics.StackTrace" Version="4.3.0" />
     <Usage Id="System.Diagnostics.TextWriterTraceListener" Version="4.0.0" />
     <Usage Id="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />
-    <Usage Id="System.Diagnostics.Tools" Version="4.0.1-rc2-24027" />
-    <Usage Id="System.Diagnostics.Tools" Version="4.0.1" />
-    <Usage Id="System.Diagnostics.Tools" Version="4.3.0" />
     <Usage Id="System.Diagnostics.TraceSource" Version="4.0.0" />
     <Usage Id="System.Diagnostics.TraceSource" Version="4.3.0" />
     <Usage Id="System.Diagnostics.Tracing" Version="4.1.0" />
@@ -465,9 +367,6 @@
     <Usage Id="System.Drawing.Common.TestData" Version="1.0.7" />
     <Usage Id="System.Dynamic.Runtime" Version="4.0.11" />
     <Usage Id="System.Dynamic.Runtime" Version="4.3.0" />
-    <Usage Id="System.Globalization" Version="4.0.11-rc2-24027" />
-    <Usage Id="System.Globalization" Version="4.0.11" />
-    <Usage Id="System.Globalization" Version="4.3.0" />
     <Usage Id="System.Globalization.Calendars" Version="4.0.1" />
     <Usage Id="System.Globalization.Calendars" Version="4.3.0" />
     <Usage Id="System.Globalization.Extensions" Version="4.0.1" />
@@ -513,8 +412,6 @@
     <Usage Id="System.Net.Http" Version="4.3.3" />
     <Usage Id="System.Net.NameResolution" Version="4.0.0" />
     <Usage Id="System.Net.NameResolution" Version="4.3.0" />
-    <Usage Id="System.Net.Primitives" Version="4.0.11" />
-    <Usage Id="System.Net.Primitives" Version="4.3.0" />
     <Usage Id="System.Net.Requests" Version="4.0.11" />
     <Usage Id="System.Net.Requests" Version="4.3.0" />
     <Usage Id="System.Net.Security" Version="4.0.0" />
@@ -533,8 +430,6 @@
     <Usage Id="System.ObjectModel" Version="4.3.0" />
     <Usage Id="System.Private.DataContractSerialization" Version="4.1.1" />
     <Usage Id="System.Private.DataContractSerialization" Version="4.3.0" />
-    <Usage Id="System.Private.Uri" Version="4.0.1" />
-    <Usage Id="System.Private.Uri" Version="4.3.0" />
     <Usage Id="System.Reflection" Version="4.1.0-rc2-24027" />
     <Usage Id="System.Reflection" Version="4.1.0" />
     <Usage Id="System.Reflection" Version="4.3.0" />
@@ -549,25 +444,16 @@
     <Usage Id="System.Reflection.Emit.Lightweight" Version="4.0.1-rc2-24027" />
     <Usage Id="System.Reflection.Emit.Lightweight" Version="4.0.1" />
     <Usage Id="System.Reflection.Emit.Lightweight" Version="4.3.0" />
-    <Usage Id="System.Reflection.Extensions" Version="4.0.1-rc2-24027" />
-    <Usage Id="System.Reflection.Extensions" Version="4.0.1" />
-    <Usage Id="System.Reflection.Extensions" Version="4.3.0" />
     <Usage Id="System.Reflection.Metadata" Version="1.3.0" />
     <Usage Id="System.Reflection.Metadata" Version="1.4.1" />
     <Usage Id="System.Reflection.Metadata" Version="1.4.2" />
     <Usage Id="System.Reflection.Metadata" Version="1.5.0" />
     <Usage Id="System.Reflection.Metadata" Version="1.6.0" />
-    <Usage Id="System.Reflection.Primitives" Version="4.0.1-rc2-24027" />
-    <Usage Id="System.Reflection.Primitives" Version="4.0.1" />
-    <Usage Id="System.Reflection.Primitives" Version="4.3.0" />
     <Usage Id="System.Reflection.TypeExtensions" Version="4.1.0-rc2-24027" />
     <Usage Id="System.Reflection.TypeExtensions" Version="4.1.0" />
     <Usage Id="System.Reflection.TypeExtensions" Version="4.3.0" />
     <Usage Id="System.Resources.Reader" Version="4.0.0" />
     <Usage Id="System.Resources.Reader" Version="4.3.0" />
-    <Usage Id="System.Resources.ResourceManager" Version="4.0.1-rc2-24027" />
-    <Usage Id="System.Resources.ResourceManager" Version="4.0.1" />
-    <Usage Id="System.Resources.ResourceManager" Version="4.3.0" />
     <Usage Id="System.Resources.Writer" Version="4.0.0" />
     <Usage Id="System.Runtime" Version="4.1.0-rc2-24027" />
     <Usage Id="System.Runtime" Version="4.1.0" />
@@ -575,8 +461,6 @@
     <Usage Id="System.Runtime.Extensions" Version="4.1.0-rc2-24027" />
     <Usage Id="System.Runtime.Extensions" Version="4.1.0" />
     <Usage Id="System.Runtime.Extensions" Version="4.3.0" />
-    <Usage Id="System.Runtime.Handles" Version="4.0.1" />
-    <Usage Id="System.Runtime.Handles" Version="4.3.0" />
     <Usage Id="System.Runtime.InteropServices" Version="4.1.0" />
     <Usage Id="System.Runtime.InteropServices" Version="4.3.0" />
     <Usage Id="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
@@ -616,14 +500,9 @@
     <Usage Id="System.Security.Principal.Windows" Version="4.0.0" />
     <Usage Id="System.Security.Principal.Windows" Version="4.3.0" />
     <Usage Id="System.Spatial" Version="5.6.4" />
-    <Usage Id="System.Text.Encoding" Version="4.0.11-rc2-24027" />
-    <Usage Id="System.Text.Encoding" Version="4.0.11" />
-    <Usage Id="System.Text.Encoding" Version="4.3.0" />
     <Usage Id="System.Text.Encoding.CodePages" Version="4.0.1" />
     <Usage Id="System.Text.Encoding.CodePages" Version="4.3.0" />
     <Usage Id="System.Text.Encoding.CodePages" Version="4.4.0" />
-    <Usage Id="System.Text.Encoding.Extensions" Version="4.0.11" />
-    <Usage Id="System.Text.Encoding.Extensions" Version="4.3.0" />
     <Usage Id="System.Text.RegularExpressions" Version="4.1.0" />
     <Usage Id="System.Text.RegularExpressions" Version="4.3.0" />
     <Usage Id="System.Text.RegularExpressions.TestData" Version="1.0.2" />
@@ -632,9 +511,6 @@
     <Usage Id="System.Threading" Version="4.3.0" />
     <Usage Id="System.Threading.Overlapped" Version="4.0.1" />
     <Usage Id="System.Threading.Overlapped" Version="4.3.0" />
-    <Usage Id="System.Threading.Tasks" Version="4.0.11-rc2-24027" />
-    <Usage Id="System.Threading.Tasks" Version="4.0.11" />
-    <Usage Id="System.Threading.Tasks" Version="4.3.0" />
     <Usage Id="System.Threading.Tasks.Dataflow" Version="4.6.0" />
     <Usage Id="System.Threading.Tasks.Dataflow" Version="4.7.0" />
     <Usage Id="System.Threading.Tasks.Extensions" Version="4.0.0" />
@@ -645,8 +521,6 @@
     <Usage Id="System.Threading.Thread" Version="4.3.0" />
     <Usage Id="System.Threading.ThreadPool" Version="4.0.10" />
     <Usage Id="System.Threading.ThreadPool" Version="4.3.0" />
-    <Usage Id="System.Threading.Timer" Version="4.0.1" />
-    <Usage Id="System.Threading.Timer" Version="4.3.0" />
     <Usage Id="System.ValueTuple" Version="4.3.0" />
     <Usage Id="System.ValueTuple" Version="4.3.1" />
     <Usage Id="System.ValueTuple" Version="4.4.0" />
@@ -667,8 +541,6 @@
     <Usage Id="WindowsAzure.Storage" Version="7.2.1" />
     <Usage Id="XliffTasks" Version="0.2.0-beta-000081" />
     <Usage Id="XliffTasks" Version="0.2.0-beta-62730-03" />
-    <Usage Id="xunit" Version="2.2.0-beta2-build3300" />
-    <Usage Id="xunit" Version="2.3.1" />
     <Usage Id="xunit.abstractions" Version="2.0.1-rc2" />
     <Usage Id="xunit.abstractions" Version="2.0.1" />
     <Usage Id="xunit.analyzers" Version="0.7.0" />

--- a/tools-local/prebuilt-baseline-online.xml
+++ b/tools-local/prebuilt-baseline-online.xml
@@ -125,7 +125,6 @@
     <Usage Id="Microsoft.NETCore.App" Version="1.0.5" />
     <Usage Id="Microsoft.NETCore.App" Version="1.1.1" />
     <Usage Id="Microsoft.NETCore.App" Version="1.1.2" />
-    <Usage Id="Microsoft.NETCore.App" Version="2.0.0-beta-001509-00" />
     <Usage Id="Microsoft.NETCore.App" Version="2.0.0" />
     <Usage Id="Microsoft.NETCore.App" Version="2.1.0-preview1-26116-04" />
     <Usage Id="Microsoft.NETCore.App" Version="2.1.0" />
@@ -164,7 +163,6 @@
     <Usage Id="Microsoft.NETCore.Platforms" Version="1.0.2-beta-24224-02" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="1.0.2" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="1.1.0" />
-    <Usage Id="Microsoft.NETCore.Platforms" Version="2.0.0-beta-25006-01" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="2.0.0" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="2.1.0-preview1-26116-01" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="2.1.0" />
@@ -209,7 +207,6 @@
     <Usage Id="Microsoft.xunit.netcore.extensions" Version="2.1.0-rc1-03131-06" />
     <Usage Id="NETStandard.Library" Version="1.6.0" />
     <Usage Id="NETStandard.Library" Version="1.6.1" />
-    <Usage Id="NETStandard.Library" Version="2.0.0-beta-25006-01" />
     <Usage Id="NETStandard.Library" Version="2.0.0" />
     <Usage Id="NETStandard.Library" Version="2.0.1" />
     <Usage Id="NETStandard.Library.NETFramework" Version="2.0.1-servicing-26011-01" />

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/CopyReferenceOnlyPackages.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/CopyReferenceOnlyPackages.cs
@@ -1,0 +1,105 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.SourceBuild.Tasks
+{
+    /// <summary>
+    /// For each nupkg directory under the PackageCacheDir, find all directories containing only
+    /// dlls under the /ref/ folder.  These are packages that contain references only.
+    /// Copies all found expanded reference-only packages to the destination directory, excluding
+    /// the .nupkg file.  The .nupkg file is deleted from the PackageCacheDir so it doesn't end up
+    /// in prebuilts.
+    /// </summary>
+    public class CopyReferenceOnlyPackages : Task
+    {
+        /// <summary>
+        /// Package cache dir containing prebuilt nupkgs. Path is expected to be like:
+        /// 
+        /// {PackageCacheDir}/{lowercase id}/{version}/{lowercase id}.{version}.nupkg
+        ///
+        /// This code assumes that these are expanded packages loaded from nuget.
+        /// </summary>
+        [Required]
+        public string PackageCacheDir { get; set; }
+
+        /// <summary>
+        /// The destination directory for the reference packages.
+        /// </summary>
+        [Required]
+        public string DestinationDir { get; set; }
+        public override bool Execute()
+        {
+            DateTime startTime = DateTime.Now;
+
+            var referenceOnlyPackageDirectories = Directory.EnumerateFiles(PackageCacheDir, "*.nupkg", SearchOption.AllDirectories)
+                .Where(nupkgFilePath =>
+                {
+                    // Get all files in the nupkg path and normalize directory separators
+                    var nupkgFiles = Directory.EnumerateFiles(Path.GetDirectoryName(nupkgFilePath), "*.*", SearchOption.AllDirectories).Select(f => f.Replace("\\","/"));
+
+                    // Do not include directories that contain exes, shared object files, OSX dynamic libraries
+                    // or profiling data
+                    string[] extensionsToExclude = { ".exe", ".dylib", ".so", ".profdata", ".pgd" };
+                    string[] pathsToExclude = { "testdata" };
+                    
+                    // Return directories that, if containing dlls, only have dlls in the
+                    // ref folder.
+                    return
+                        !nupkgFiles.Any(file => extensionsToExclude.Contains(Path.GetExtension(file)) || pathsToExclude.Any(path => file.Contains(path))) &&
+                        nupkgFiles
+                            .Where(file => String.Equals(Path.GetExtension(file), ".dll", StringComparison.OrdinalIgnoreCase))
+                            .All(dir => dir.Contains(@"/ref/"));
+                })
+                .Select(f => Path.GetDirectoryName(f));
+
+            foreach (var dir in referenceOnlyPackageDirectories)
+            {
+                Log.LogMessage(
+                    MessageImportance.High,
+                    $"{dir}");
+                Directory.CreateDirectory(dir.Replace(PackageCacheDir, DestinationDir));
+                foreach (string dirPath in Directory.EnumerateDirectories(dir, "*", SearchOption.AllDirectories))
+                {
+                    Directory.CreateDirectory(dirPath.Replace(PackageCacheDir, DestinationDir));
+                }
+                if (Directory.EnumerateFiles(dir, "*.dll", SearchOption.AllDirectories).Count() > 0)
+                {
+                    Log.LogMessage(
+                        MessageImportance.High,
+                            $"Found dlls in {dir}.");
+                }
+                foreach (var file in Directory.EnumerateFiles(dir, "*.*", SearchOption.AllDirectories).Where(f => !f.EndsWith(".nupkg") && !f.EndsWith(".nupkg.sha512")))
+                {
+                    File.Copy(file, file.Replace(PackageCacheDir, DestinationDir));
+                }
+                // Remove nupkgs for the packages that were copied so they don't end up in prebuilts
+                foreach (var file in Directory.EnumerateFiles(dir, "*.*", SearchOption.AllDirectories).Where(f => f.EndsWith(".nupkg")))
+                {
+                    File.Delete(file);
+                }
+            }
+
+            foreach (var file in Directory.EnumerateFiles(DestinationDir, "*.nuspec", SearchOption.AllDirectories))
+            {
+                Log.LogMessage(MessageImportance.High, $"Adding <files> section to {file}");
+                var fileText = File.ReadAllText(file);
+                File.WriteAllText(file, fileText.Replace("</package>", "<files><file src=\".\\**\\*.*\"/></files>\n</package>"));
+            }
+            // Report status on the task
+            Log.LogMessage(
+                MessageImportance.High,
+                "Identified reference-only packages. " +
+                    $"Found {referenceOnlyPackageDirectories.Count()} packages.  Took {DateTime.Now - startTime} ");
+
+            return !Log.HasLoggedErrors;
+        }
+
+    }
+}

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/WritePackageUsageData.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/WritePackageUsageData.cs
@@ -22,6 +22,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
     {
         public string[] RestoredPackageFiles { get; set; }
         public string[] TarballPrebuiltPackageFiles { get; set; }
+        public string[] ReferencePackageFiles { get; set; }
         public string[] SourceBuiltPackageFiles { get; set; }
 
         /// <summary>
@@ -110,12 +111,17 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
                 .Distinct()
                 .ToArray();
 
+            PackageIdentity[] referencePackages = ReferencePackageFiles.NullAsEmpty()
+                .Select(ReadNuGetPackageInfos.ReadIdentity)
+                .Distinct()
+                .ToArray();
+
             PackageIdentity[] sourceBuilt = SourceBuiltPackageFiles.NullAsEmpty()
                 .Select(ReadNuGetPackageInfos.ReadIdentity)
                 .Distinct()
                 .ToArray();
 
-            IEnumerable<PackageIdentity> prebuilt = restored.Except(sourceBuilt);
+            IEnumerable<PackageIdentity> prebuilt = restored.Except(sourceBuilt).Except(referencePackages);
 
             PackageIdentity[] toCheck = NuGetPackageInfos.NullAsEmpty()
                 .Select(item => new PackageIdentity(


### PR DESCRIPTION
Adds detection of packages in the source-build build that either a) have no binaries or b) only have dlls that are in the /ref/ folder.  For ones with dlls, disassembles them with ildasm and provides the IL as source to the tarball.  When building the tarball, these assemblies are re-build with ilasm and the packages are re-packed to be available for the tarball build.
There are a couple more items to complete before this is done:
- [x] There are two dlls that don't roundtrip with this process: System.Runtime.dll and netstandard.dll - These have been identified as an issue with ilasm/ildasm (see: https://github.com/dotnet/coreclr/issues/20262)
- [x] The prebuilt reporting doesn't detect that these packages are no longer prebuilts.

@dagood & @crummel  PTAL