### PR TITLE
Add Azure DevOps dnceng instance CI YAML

### DIFF
--- a/.vsts.pipelines/builds/ci.yml
+++ b/.vsts.pipelines/builds/ci.yml
@@ -1,21 +1,25 @@
+# Matrix build types:
+#   Production: Only runs the build, not a tarball build. Called "production" because it's the part
+#     used to produce tarballs. Some platforms might not be capable of producing a tarball yet: we
+#     still call this type of build "production" for consistency.
+#   Online: The leg produces a tarball then builds it while connected to the internet.
+#   Offline: The leg produces a tarball then builds it offline. Network disconnected using Docker.
+
 phases:
 - template: ../phases/ci-linux.yml
   parameters:
-    name: ci_Docker
+    phase: centos71
+    imageName: microsoft/dotnet-buildtools-prereqs:centos-7-b46d863-20180719033416
     matrix:
-      centos71-unshared:
-        artifactName: ci_Docker_centos71-unshared
-        buildOfflineTarball: true
-        imageName: microsoft/dotnet-buildtools-prereqs:centos711503_prereqs_2
+      Production: {}
+      Online: { type: Online }
+      Online Portable: { type: Online Portable }
+      Offline: { type: Offline }
+      Offline Portable: { type: Offline Portable }
+
 - template: ../phases/ci-linux.yml
   parameters:
-    name: ci_Docker_RHEL_host
-    dockerRegistryPassword: $(BotAccount-dotnet-docker-acr-bot-password)
-    dockerRegistryServer: $(acr.server)
-    dockerRegistryUserName: $(acr.userName)
-    queueName: DotNetCore-Infra
-    queueDemands: VSTS_OS -equals Linux_RHEL_7.4
-    matrix:
-      rhel7.5:
-        artifactName: ci_Docker_RHEL_host_rhel7.5
-        imageName: dotnetdocker.azurecr.io/dotnet-buildtools-prereqs:rhel-7.5-b4560f6-20180725153037
+    phase: ubuntu1604
+    imageName: microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-c103199-20180628134544
+
+- template: ../phases/ci-osx.yml

--- a/.vsts.pipelines/phases/ci-linux.yml
+++ b/.vsts.pipelines/phases/ci-linux.yml
@@ -34,8 +34,7 @@ phases:
     demands: ${{ parameters.queueDemands }}
     timeoutInMinutes: 270
     parallel: 8
-    matrix:
-      ${{ insert }}: ${{ parameters.matrix }}
+    matrix: ${{ parameters.matrix }}
 
   steps:
   - template: ../steps/docker-cleanup-linux.yml

--- a/.vsts.pipelines/phases/ci-linux.yml
+++ b/.vsts.pipelines/phases/ci-linux.yml
@@ -1,20 +1,16 @@
 parameters:
-  dockerRegistryPassword: ''
-  dockerRegistryServer: ''
-  dockerRegistryUserName: ''
-  matrix: null
-  name: ci
-  queueDemands: Agent.OS -equals Linux
-  queueName: DotNet-Build
+  imageName: null
+  matrix:
+    Production: {}
+  phase: null
+  queueDemands: docker
+  queueName: dnceng-linux-external-temp
 
 phases:
-- phase: ${{ parameters.name }}
+- phase: ${{ parameters.phase }}
   variables:
-    # Prefix to distinguish artifacts from different legs. No documented variable for this exists.
-    artifactName: no_artifact_name
-    buildLoggingOptions: ''
-    buildConfiguration: Release
-    buildOfflineTarball: false
+    # Prefix to distinguish artifacts from different legs.
+    artifactName: ${{ format('$(type)_{0}', parameters.phase) }}
     # Use ":z" to set selinux flag for sharing in build-owned root dir. https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label
     docker.agentSrc.map: -v $(Build.SourcesDirectory):/agentSrc:z
     docker.agentSrc.work: -w /agentSrc
@@ -26,107 +22,74 @@ phases:
     docker.src.work: -w /src
     docker.tb.map: -v $(rootDirectory)/sb/tarball:/tb:z
     docker.tb.work: -w /tb
-    dockerRegistry.password: ${{ parameters.dockerRegistryPassword }}
-    dockerRegistry.server: ${{ parameters.dockerRegistryServer }}
-    dockerRegistry.userName: ${{ parameters.dockerRegistryUserName }}
     dropDirectory: $(stagingDirectory)/drop
+    imageName: ${{ parameters.imageName }}
     rootDirectory: $(Build.SourcesDirectory)/..
     stagingDirectory: $(rootDirectory)/sb/staging
     tarballName: tarball_$(Build.BuildId)
+    # Default type, can be overridden by matrix legs.
+    type: Production
   queue:
     name: ${{ parameters.queueName }}
     demands: ${{ parameters.queueDemands }}
-    timeoutInMinutes: 240
-    parallel: 2
-    matrix: ${{ parameters.matrix }}
+    timeoutInMinutes: 270
+    parallel: 8
+    matrix:
+      ${{ insert }}: ${{ parameters.matrix }}
+
   steps:
   - template: ../steps/docker-cleanup-linux.yml
-
-  # Docker registry login and pull, if one is defined.
-  - script: |
-      docker login -u $(dockerRegistry.userName) -p $(dockerRegistry.password) $(dockerRegistry.server)
-      docker pull $(imageName)
-    displayName: Docker login and image pull
-    condition: and(succeeded(), ne(variables['dockerRegistry.server'], ''))
-
-  # Docker registry logout, if one is defined. Do this immediately: avoid unnecessary login time.
-  - script: docker logout $(dockerRegistry.server)
-    displayName: Docker logout
-    condition: ne(variables['dockerRegistry.server'], '')
+  - template: ../steps/calculate-config-flags-linux.yml
 
   # Create working directory and copy source into it.
   - script: |
       set -x
+      df -h
       $(docker.run) $(docker.root.map) $(docker.agentSrc.map) $(docker.agentSrc.work) $(imageName) bash -c '
         rm -rf /root/sb/
         mkdir -p /root/sb/tarball
         cp -r . /root/sb/source-build'
     displayName: Clean sb directory and copy source from cloned directory
 
-  # Fetch vsts commits if building internally.
-  - script: |
-      set -x
-      # Ignore failure for the first command. It will intentionally fail if the commit is only
-      # available in VSTS. "submodule update --init" is the simplest way to set up the submodule
-      # directory. ("submodule init" only sets up .git/config, not the e.g. src/coreclr/.git and
-      # .git/modules/src/coreclr/ directories.)
-      $(docker.run) $(docker.src.map) $(docker.src.work) $(imageName) git submodule update --init --recursive
-      $(docker.run) $(docker.src.map) $(docker.src.work) $(imageName) ./fetch-vsts-commits.sh $(user.PAT)
-    displayName: Fetch internal vsts commits
-    condition: and(succeeded(), ne(variables['user.PAT'], ''))
-
-  # Initialize submodules.
-  - script: $(docker.run) $(docker.src.map) $(docker.src.work) $(imageName) git submodule update --init --recursive
-    displayName: Initialize submodules
+  - template: ../steps/init-submodules-sh.yml
+    parameters:
+      commandPrefix: $(docker.run) $(docker.src.map) $(docker.src.work) $(imageName)
 
   # Build source-build.
   - script: |
-      $(docker.run) $(docker.src.map) $(docker.src.work) $(imageName) ./build.sh \
-        /p:ArchiveDownloadedPackages=true \
-        /p:Configuration=$(buildConfiguration) \
-        /p:ContinueOnPrebuiltBaselineError=$(buildOfflineTarball) \
-        /p:ProdConBlobFeedUrlPrefix=$(prodConBlobFeedUrlPrefix) \
-        $(buildLoggingOptions)
-    displayName: Build source-build
-    timeoutInMinutes: 90
-
-  # Copy logs to working directory.
-  - script: |
       set -x
-      $(docker.run) $(docker.logs.map) $(docker.src.map) $(docker.src.work) $(imageName) /bin/bash -c "
-        mkdir -p /logs/source-build/logs
-        find . \( \
-          -iname '*.binlog' -o \
-          -iname '*.log' \) \
-          -exec cp {} --parents /logs/source-build/logs \;"
-    displayName: Copy source-build logs
-    condition: always()
-    continueOnError: true
+      df -h
+      if [ "$(sb.tarball)" != "true" ]; then
+        failOnBaselineError=true
+      fi
+      $(docker.run) $(docker.src.map) $(docker.src.work) $(imageName) ./build.sh \
+        /p:Configuration=$(sb.configuration) \
+        /p:PortableBuild=$(sb.portable) \
+        /p:ArchiveDownloadedPackages=$(sb.tarball) \
+        /p:FailOnPrebuiltBaselineError=$failOnBaselineError \
+        /p:ProdConBlobFeedUrlPrefix=$(prodConBlobFeedUrlPrefix)
+    displayName: Build source-build
+    timeoutInMinutes: 120
 
   # Run smoke tests.
   - script: |
+      set -x
+      df -h
       $(docker.run) $(docker.src.map) $(docker.src.work) $(imageName) ./build.sh \
         /t:RunSmokeTest \
-        /p:Configuration=$(buildConfiguration) \
+        /p:Configuration=$(sb.configuration) \
         /p:ProdConBlobFeedUrlPrefix=$(prodConBlobFeedUrlPrefix)
     displayName: Run smoke-test
 
-  # Copy smoke test logs to working directory.
-  - script: |
-      $(docker.run) $(docker.logs.map) $(docker.src.map) $(docker.src.work) $(imageName) /bin/bash -c "
-        mkdir -p /logs/source-build/smoke-test
-        find ./testing-smoke -name '*.log' -exec cp {} /logs/source-build/smoke-test \;"
-    displayName: Copy smoke-test logs
-    condition: always()
-    continueOnError: true
-
   # Create tarball.
   - script: |
+      set -x
+      df -h
       $(docker.run) $(docker.tb.map) $(docker.src.map) $(docker.src.work) $(imageName) ./build-source-tarball.sh \
         "/tb/$(tarballName)" \
         --skip-build
     displayName: Create tarball
-    condition: and(succeeded(), eq(variables['buildOfflineTarball'], true))
+    condition: and(succeeded(), eq(variables['sb.tarball'], true))
 
   # tar the tarball directory into the drop directory.
   - script: |
@@ -144,46 +107,66 @@ phases:
         tar --numeric-owner "--exclude=$smokeTestPackages" -zcf "/drop/tarball/$(tarballName).tar.gz" "$(tarballName)"
         tar --numeric-owner -zcf "/drop/tarball/$(tarballName)-smoke-test-prereqs.tar.gz" "$smokeTestPackages"'
     displayName: Copy tarball to output
-    condition: and(succeeded(), eq(variables['buildOfflineTarball'], true))
+    condition: and(succeeded(), eq(variables['sb.tarball'], true))
 
   # Build tarball.
   - script: |
-      $(docker.run) $(docker.tb.map) $(docker.tb.work) --network='none' $(imageName) "$(tarballName)/build.sh" \
-        /p:Configuration=$(buildConfiguration) \
-        $(buildLoggingOptions)
+      set -x
+      df -h
+      networkArg=
+      if [ "$(sb.tarballOffline)" = "true" ]; then
+        networkArg="--network=none"
+      fi
+      $(docker.run) $(docker.tb.map) $(docker.tb.work) $networkArg $(imageName) "$(tarballName)/build.sh" \
+        /p:Configuration=$(sb.configuration) \
+        /p:PortableBuild=$(sb.portable) \
+        /p:FailOnPrebuiltBaselineError=true
     displayName: Build tarball
-    timeoutInMinutes: 90
-    condition: and(succeeded(), eq(variables['buildOfflineTarball'], true))
+    timeoutInMinutes: 120
+    condition: and(succeeded(), eq(variables['sb.tarball'], true))
 
   # Run smoke tests.
   - script: |
+      set -x
+      df -h
       $(docker.run) $(docker.tb.map) $(docker.tb.work) $(imageName) "$(tarballName)/smoke-test.sh" \
         --minimal \
         --projectOutput \
-        --configuration $(buildConfiguration) \
+        --configuration $(sb.configuration) \
         --prodConBlobFeedUrl ''
     displayName: Run smoke-test in tarball
-    condition: and(succeeded(), eq(variables['buildOfflineTarball'], true))
+    condition: and(succeeded(), eq(variables['sb.tarball'], true))
 
-  # Copy all tarball logs to working directory.
+  - script: df -h
+    displayName: Check space (df -h)
+    condition: always()
+    continueOnError: true
+
+  # Copy logs and reports to staging directory.
+  - script: |
+      set -x
+      $(docker.run) $(docker.logs.map) $(docker.src.map) $(docker.src.work) $(imageName) /bin/bash -c "
+        mkdir -p /logs/source-build/logs
+        find . \( \
+          -path './bin/*-report/*' -o \
+          -iname '*.binlog' -o \
+          -iname '*.log' \) \
+          -exec cp {} --parents /logs/source-build/logs \;"
+    displayName: Copy source-build logs
+    condition: always()
+    continueOnError: true
   - script: |
       set -x
       $(docker.run) $(docker.logs.map) $(docker.tb.map) $(docker.tb.work) $(imageName) /bin/bash -c "
         mkdir -p /logs/tarball/logs
         cd \"$(tarballName)\"
         find . \( \
+          -path './bin/*-report/*' -o \
           -iname '*.binlog' -o \
           -iname '*.log' \) \
-          -exec cp {} --parents /logs/tarball/logs \;
-        # Copy offline prebuilt report
-        mkdir -p /logs/prebuilt-report/offline
-        cp -r ./bin/prebuilt-report/* /logs/prebuilt-report/offline"
-      $(docker.run) $(docker.logs.map) $(docker.src.map) $(docker.src.work) $(imageName) /bin/bash -c "
-        # Copy online prebuilt report
-        mkdir -p /logs/prebuilt-report/online
-        cp -r ./bin/prebuilt-report/* /logs/prebuilt-report/online"
+          -exec cp {} --parents /logs/tarball/logs \;"
     displayName: Copy tarball logs
-    condition: eq(variables['buildOfflineTarball'], true)
+    condition: eq(variables['sb.tarball'], true)
     continueOnError: true
 
   # Copy artifacts to staging - Copy to VSTS owned folder is done outside of docker so copied files
@@ -201,15 +184,15 @@ phases:
     condition: always()
     continueOnError: true
     inputs:
-      PathtoPublish: $(dropDirectory)/logs
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/drop/logs
       ArtifactName: Logs $(artifactName)
       ArtifactType: Container
   - task: PublishBuildArtifacts@1
     displayName: Publish Tarball artifact
-    condition: eq(variables['buildOfflineTarball'], true)
+    condition: eq(variables['sb.tarball'], true)
     continueOnError: true
     inputs:
-      PathtoPublish: $(dropDirectory)/tarball
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/drop/tarball
       ArtifactName: Tarball $(artifactName)
       ArtifactType: Container
 
@@ -220,3 +203,8 @@ phases:
     continueOnError: true
 
   - template: ../steps/docker-cleanup-linux.yml
+
+  - script: df -h
+    displayName: Check space (df -h)
+    condition: always()
+    continueOnError: true

--- a/.vsts.pipelines/phases/ci-linux.yml
+++ b/.vsts.pipelines/phases/ci-linux.yml
@@ -10,7 +10,7 @@ phases:
 - phase: ${{ parameters.phase }}
   variables:
     # Prefix to distinguish artifacts from different legs.
-    artifactName: ${{ format('$(type)_{0}', parameters.phase) }}
+    artifactName: ${{ format('$(type) {0}', parameters.phase) }}
     # Use ":z" to set selinux flag for sharing in build-owned root dir. https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label
     docker.agentSrc.map: -v $(Build.SourcesDirectory):/agentSrc:z
     docker.agentSrc.work: -w /agentSrc

--- a/.vsts.pipelines/phases/ci-osx.yml
+++ b/.vsts.pipelines/phases/ci-osx.yml
@@ -1,0 +1,85 @@
+parameters:
+  matrix:
+    Production: {}
+  phase: osx
+  queueDemands: Agent.OS -equals Darwin
+  queueName: DotNetCore-Mac
+
+phases:
+- phase: ${{ parameters.phase }}
+  variables:
+    # Prefix to distinguish artifacts from different legs.
+    artifactName: ${{ format('$(type)_{0}', parameters.phase) }}
+    logsDirectory: $(Build.ArtifactStagingDirectory)/logs
+    SOURCE_BUILD_SKIP_SUBMODULE_CHECK: true
+    # Default type, can be overridden by matrix legs.
+    type: Production
+  queue:
+    name: ${{ parameters.queueName }}
+    demands: ${{ parameters.queueDemands }}
+    timeoutInMinutes: 240
+    matrix:
+      ${{ insert }}: ${{ parameters.matrix }}
+
+  steps:
+  - checkout: self
+    clean: true
+
+  - script: |
+      ./clean.sh -a
+      # Make sure submodules from other branches are removed: pass extra f.
+      git clean -xdff
+    displayName: Clean
+
+  - template: ../steps/calculate-config-flags-linux.yml
+
+  - script: |
+      ( set -o posix; set )
+    displayName: Print all variables in environment
+
+  - template: ../steps/init-submodules-sh.yml
+
+  # Build source-build.
+  - script: |
+      set -x
+      ./build.sh \
+        /p:Configuration=$(sb.configuration) \
+        /p:PortableBuild=$(sb.portable) \
+        /p:FailOnPrebuiltBaselineError=true \
+        /p:ProdConBlobFeedUrlPrefix=$(prodConBlobFeedUrlPrefix)
+    displayName: Build source-build
+    timeoutInMinutes: 150
+
+  # Run smoke tests.
+  - script: |
+      set -x
+      ./build.sh \
+        /t:RunSmokeTest \
+        /p:Configuration=$(sb.configuration) \
+        /p:ProdConBlobFeedUrlPrefix=$(prodConBlobFeedUrlPrefix)
+    displayName: Run smoke-test
+
+  - script: |
+      set -x
+      # Clean up previous build's staging dir, in case VSTS didn't do it.
+      rm -rf "$(logsDirectory)"
+      # Copy all these files to the logs dir, preserving relative path.
+      mkdir -p "$(logsDirectory)"
+      find . \( \
+        -path './bin/*-report/*' -o \
+        -iname '*.binlog' -o \
+        -iname '*.log' \) \
+        -exec rsync -R {} "$(logsDirectory)" \;
+    displayName: Copy logs to staging directory
+    condition: always()
+    continueOnError: true
+
+  # Publish artifacts.
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Logs artifact
+    condition: always()
+    continueOnError: true
+    inputs:
+      PathtoPublish: $(logsDirectory)
+      ArtifactName: Logs $(artifactName)
+      ArtifactType: Container

--- a/.vsts.pipelines/phases/ci-osx.yml
+++ b/.vsts.pipelines/phases/ci-osx.yml
@@ -9,7 +9,7 @@ phases:
 - phase: ${{ parameters.phase }}
   variables:
     # Prefix to distinguish artifacts from different legs.
-    artifactName: ${{ format('$(type)_{0}', parameters.phase) }}
+    artifactName: ${{ format('$(type) {0}', parameters.phase) }}
     logsDirectory: $(Build.ArtifactStagingDirectory)/logs
     SOURCE_BUILD_SKIP_SUBMODULE_CHECK: true
     # Default type, can be overridden by matrix legs.

--- a/.vsts.pipelines/phases/ci-osx.yml
+++ b/.vsts.pipelines/phases/ci-osx.yml
@@ -18,8 +18,7 @@ phases:
     name: ${{ parameters.queueName }}
     demands: ${{ parameters.queueDemands }}
     timeoutInMinutes: 240
-    matrix:
-      ${{ insert }}: ${{ parameters.matrix }}
+    matrix: ${{ parameters.matrix }}
 
   steps:
   - checkout: self

--- a/.vsts.pipelines/steps/calculate-config-flags-linux.yml
+++ b/.vsts.pipelines/steps/calculate-config-flags-linux.yml
@@ -1,0 +1,36 @@
+steps:
+- script: |
+    setvariable() {
+      echo "Setting '$1' to '$2'"
+      echo "##vso[task.setvariable variable=$1;]$2"
+    }
+
+    echo 'Setting up default configuration variables'
+
+    setvariable sb.configuration Release
+    setvariable sb.portable false
+    setvariable sb.tarball false
+    setvariable sb.tarballOffline false
+
+    echo "Setting up configuration variables for CI type '$TYPE'"
+
+    for x in $TYPE; do
+      case $x in
+        Debug|Release)
+          setvariable sb.configuration $x
+          ;;
+
+        Portable)
+          setvariable sb.portable true
+          ;;
+
+        Online)
+          setvariable sb.tarball true
+          ;;
+        Offline)
+          setvariable sb.tarball true
+          setvariable sb.tarballOffline true
+          ;;
+      esac
+    done
+  displayName: Calculate config flags

--- a/.vsts.pipelines/steps/docker-cleanup-linux.yml
+++ b/.vsts.pipelines/steps/docker-cleanup-linux.yml
@@ -1,10 +1,5 @@
-  steps:
-  # TODO: Remove this redundant step once agent supports "--volumes".
-  - script: docker system prune -a -f
-    displayName: Cleanup Docker (without --volumes, for agent compatibility)
-    condition: always()
-    continueOnError: true
-  - script: docker system prune -a -f --volumes
-    displayName: Cleanup Docker
-    condition: always()
-    continueOnError: true
+steps:
+- script: docker system prune -a -f --volumes
+  displayName: Cleanup Docker
+  condition: always()
+  continueOnError: true

--- a/.vsts.pipelines/steps/init-submodules-sh.yml
+++ b/.vsts.pipelines/steps/init-submodules-sh.yml
@@ -1,0 +1,25 @@
+parameters:
+  commandPrefix: ''
+
+steps:
+  # Fetch vsts commits if building internally.
+  - script: |
+      set -x
+      # Ignore failure for the first command. It will intentionally fail if the commit is only
+      # available in VSTS. "submodule update --init" is the simplest way to set up the submodule
+      # directory. ("submodule init" only sets up .git/config, not the e.g. src/coreclr/.git and
+      # .git/modules/src/coreclr/ directories.)
+      $commandPrefix git submodule update --init --recursive
+      $commandPrefix ./fetch-vsts-commits.sh $(user.PAT)
+    displayName: Fetch internal vsts commits
+    env:
+      commandPrefix: ${{ parameters.commandPrefix }}
+    condition: and(succeeded(), ne(variables['user.PAT'], ''))
+
+  # Initialize submodules.
+  - script: |
+      set -x
+      $commandPrefix git submodule update --init --recursive
+    displayName: Initialize submodules
+    env:
+      commandPrefix: ${{ parameters.commandPrefix }}

--- a/build.proj
+++ b/build.proj
@@ -60,12 +60,23 @@
   </Target>
 
   <Target Name="RunSmokeTest" DependsOnTargets="GetProdConBlobFeedUrl">
+    <PropertyGroup>
+      <SmokeTestCommand>./smoke-test.sh</SmokeTestCommand>
+      <SmokeTestCommand>$(SmokeTestCommand) --minimal</SmokeTestCommand>
+      <SmokeTestCommand>$(SmokeTestCommand) --projectOutput</SmokeTestCommand>
+      <SmokeTestCommand>$(SmokeTestCommand) --configuration $(Configuration)</SmokeTestCommand>
+      <SmokeTestCommand>$(SmokeTestCommand) --archiveRestoredPackages</SmokeTestCommand>
+
+      <!-- Dev certs don't work on this platform. -->
+      <SmokeTestCommand Condition="'$(TargetOS)' == 'OSX'">$(SmokeTestCommand) --excludeWebHttpsTests</SmokeTestCommand>
+    </PropertyGroup>
+
     <!--
       Pass prodConBlobFeedUrl via EnvironmentVariables because it has '//' in it, which is
       translated into '/' if it's passed in the Command arg.
       This is also a problem when passing CLI feeds: https://github.com/dotnet/source-build/issues/561
     -->
-    <Exec Command="./smoke-test.sh --minimal --projectOutput --configuration $(Configuration) --archiveRestoredPackages"
+    <Exec Command="$(SmokeTestCommand)"
           EnvironmentVariables="prodConBlobFeedUrl=$(ProdConBlobFeedUrl)" />
   </Target>
 

--- a/patches/coreclr/0001-Don-t-check-for-libintl.h-on-Darwin-OSX.patch
+++ b/patches/coreclr/0001-Don-t-check-for-libintl.h-on-Darwin-OSX.patch
@@ -1,0 +1,29 @@
+From 76a329da8b4c0cefd7c4fd499041b84963eea6ff Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Fri, 21 Sep 2018 13:17:43 -0500
+Subject: [PATCH] Don't check for libintl.h on Darwin (OSX)
+
+https://github.com/dotnet/coreclr/issues/20092 will allow patch removal.
+---
+ src/pal/src/configure.cmake | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/pal/src/configure.cmake b/src/pal/src/configure.cmake
+index 8b3fb099a4..c8b4d44509 100644
+--- a/src/pal/src/configure.cmake
++++ b/src/pal/src/configure.cmake
+@@ -37,7 +37,10 @@ check_include_files(sys/prctl.h HAVE_PRCTL_H)
+ check_include_files(numa.h HAVE_NUMA_H)
+ check_include_files(pthread_np.h HAVE_PTHREAD_NP_H)
+ check_include_files("sys/auxv.h;asm/hwcap.h" HAVE_AUXV_HWCAP_H)
+-check_include_files("libintl.h" HAVE_LIBINTL_H)
++
++if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
++  check_include_files("libintl.h" HAVE_LIBINTL_H)
++endif()
+ 
+ if(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD AND NOT CMAKE_SYSTEM_NAME STREQUAL NetBSD)
+   set(CMAKE_REQUIRED_FLAGS "-ldl")
+-- 
+2.17.1.windows.2
+

--- a/repos/websdk.proj
+++ b/repos/websdk.proj
@@ -17,6 +17,11 @@
   <ItemGroup>
     <EnvironmentVariables Include="WebSdkVersion=$(WebSdkVersion)" />
     <EnvironmentVariables Include="CoreSdkVersion=$(CoreSdkVersion)" />
+    <!-- Ensure Azure DevOps' BUILD_BUILDNUMBER isn't picked up by providing our own custom build number. -->
+    <EnvironmentVariables Include="PackageBuildNumber=1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <RepositoryReference Include="newtonsoft-json" />
   </ItemGroup>
 


### PR DESCRIPTION
CentOS, Ubuntu 16.04, and OSX legs included.

Fedora 28 and Debian 8.2 builds don't work yet due to the images we're using missing tools/libs, filing issues to track those. (https://github.com/dotnet/source-build/issues/814, https://github.com/dotnet/source-build/issues/815.)

I haven't tried these new defs with internal changes yet (`user.PAT`). I tried to keep the functionality around so hopefully that will just be a quick check.

https://github.com/dotnet/source-build/issues/757