### PR TITLE
Use consistent logging verbosity everywhere

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -24,6 +24,10 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <LogVerbosity Condition="'$(LogVerbosity)'==''">minimal</LogVerbosity>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <BuildInParallel Condition="'$(BuildInParallel)'==''">false</BuildInParallel>
   </PropertyGroup>
 

--- a/repos/application-insights.proj
+++ b/repos/application-insights.proj
@@ -16,6 +16,7 @@
       <!-- Re-assign EnlistmentRoot property so output directories end up under src/application-insights -->
       <BuildCommandArgs>$(BuildCommandArgs) /p:EnlistmentRoot=$(ProjectDirectory)/src</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) /p:RelativeOutputPathBase=</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /v:$(LogVerbosity)</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) $(RedirectRepoOutputToLog)</BuildCommandArgs>
     </PropertyGroup>
 

--- a/repos/cli.proj
+++ b/repos/cli.proj
@@ -32,11 +32,10 @@
     <BuildCommandArgs>$(BuildCommandArgs) /p:IncludeSharedFrameworksForBackwardsCompatibilityTests=false</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:IncludeMSBuildSdkResolver=false</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:DefaultTargetLatestAspNetCoreRuntimePatch=true</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /v:$(LogVerbosity)</BuildCommandArgs>
 
     <BuildCommandArgs Condition="'$(OS)' == 'Windows_NT'">$(BuildCommandArgs) '/p:CLITargets=\&quot;\&quot;\&quot;Prepare;Compile;Package\&quot;\&quot;\&quot;'</BuildCommandArgs>
     <BuildCommandArgs Condition="'$(OS)' != 'Windows_NT'">$(BuildCommandArgs) '/p:CLITargets=&quot;Prepare;Compile;Package&quot;'</BuildCommandArgs>
-
-    <BuildCommandArgs>$(BuildCommandArgs) /v:detailed</BuildCommandArgs>
 
     <BuildCommand>$(ProjectDirectory)build$(ShellExtension) $(BuildCommandArgs)</BuildCommand>
 

--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -34,6 +34,7 @@
     <DependencyVersionInputRepoApiImplemented Condition="'$(DependencyVersionInputRepoApiImplemented)' == ''">$(RepoApiImplemented)</DependencyVersionInputRepoApiImplemented>
     <SourceOverrideRepoApiImplemented Condition="'$(SourceOverrideRepoApiImplemented)' == ''">$(RepoApiImplemented)</SourceOverrideRepoApiImplemented>
     <OutputPlacementRepoApiImplemented Condition="'$(OutputPlacementRepoApiImplemented)' == ''">$(RepoApiImplemented)</OutputPlacementRepoApiImplemented>
+    <LogVerbosityRepoApiImplemented Condition="'$(LogVerbosityRepoApiImplemented)' == ''">$(RepoApiImplemented)</LogVerbosityRepoApiImplemented>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SourceOverrideRepoApiImplemented)' != 'true'">
@@ -55,6 +56,10 @@
   <!-- Output placement arguments -->
   <PropertyGroup Condition="'$(OutputPlacementRepoApiImplemented)' == 'true'">
     <RepoApiArgs>$(RepoApiArgs) /p:DotNetOutputBlobFeedDir=$(SourceBuiltBlobFeedDir)</RepoApiArgs>
+  </PropertyGroup>
+  <!-- Logging arguments -->
+  <PropertyGroup Condition="'$(LogVerbosityRepoApiImplemented)' == 'true'">
+    <RepoApiArgs>$(RepoApiArgs) /v:$(LogVerbosity)</RepoApiArgs>
   </PropertyGroup>
 
   <Import Project="$(ProjectDirectory)dependencies.props"
@@ -272,7 +277,7 @@
     <Message Importance="High" Text="  Log: $(RepoConsoleLogFile)" />
     <Message Importance="High" Text="  With Environment Variables:" />
     <Message Importance="High" Text="    %(EnvironmentVariables.Identity)" />
-    <Exec Command="$(BuildPackagesCommand) $(RedirectRepoOutputToLog)"
+    <Exec Command="$(BuildPackagesCommand) /v:$(LogVerbosity) $(RedirectRepoOutputToLog)"
           WorkingDirectory="$(ProjectDirectory)"
           EnvironmentVariables="@(EnvironmentVariables)"
           IgnoreStandardErrorWarningFormat="true" />
@@ -351,7 +356,7 @@
   </Target>
 
   <Target Name="Clean" Condition="'$(CleanCommand)' != ''" >
-    <Exec Command="$(CleanCommand) $(RedirectRepoOutputToLog)"
+    <Exec Command="$(CleanCommand) /v:$(LogVerbosity) $(RedirectRepoOutputToLog)"
           WorkingDirectory="$(ProjectDirectory)"
           EnvironmentVariables="@(EnvironmentVariables)"
           IgnoreStandardErrorWarningFormat="true" />

--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -34,7 +34,6 @@
     <DependencyVersionInputRepoApiImplemented Condition="'$(DependencyVersionInputRepoApiImplemented)' == ''">$(RepoApiImplemented)</DependencyVersionInputRepoApiImplemented>
     <SourceOverrideRepoApiImplemented Condition="'$(SourceOverrideRepoApiImplemented)' == ''">$(RepoApiImplemented)</SourceOverrideRepoApiImplemented>
     <OutputPlacementRepoApiImplemented Condition="'$(OutputPlacementRepoApiImplemented)' == ''">$(RepoApiImplemented)</OutputPlacementRepoApiImplemented>
-    <LogVerbosityRepoApiImplemented Condition="'$(LogVerbosityRepoApiImplemented)' == ''">$(RepoApiImplemented)</LogVerbosityRepoApiImplemented>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SourceOverrideRepoApiImplemented)' != 'true'">
@@ -56,10 +55,6 @@
   <!-- Output placement arguments -->
   <PropertyGroup Condition="'$(OutputPlacementRepoApiImplemented)' == 'true'">
     <RepoApiArgs>$(RepoApiArgs) /p:DotNetOutputBlobFeedDir=$(SourceBuiltBlobFeedDir)</RepoApiArgs>
-  </PropertyGroup>
-  <!-- Logging arguments -->
-  <PropertyGroup Condition="'$(LogVerbosityRepoApiImplemented)' == 'true'">
-    <RepoApiArgs>$(RepoApiArgs) /v:$(LogVerbosity)</RepoApiArgs>
   </PropertyGroup>
 
   <Import Project="$(ProjectDirectory)dependencies.props"

--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -253,7 +253,7 @@
     <ItemGroup>
       <EnvironmentVariables Condition="'$(NUGET_PACKAGES)'!=''" Include="NUGET_PACKAGES=$(NUGET_PACKAGES)" />
     </ItemGroup>
-    <Exec Command="$(BuildCommand) $(RepoApiArgs) $(RedirectRepoOutputToLog)"
+    <Exec Command="$(BuildCommand) /v:$(LogVerbosity) $(RepoApiArgs) $(RedirectRepoOutputToLog)"
           WorkingDirectory="$(ProjectDirectory)"
           EnvironmentVariables="@(EnvironmentVariables)"
           IgnoreStandardErrorWarningFormat="true" />

--- a/repos/netcorecli-fsc.proj
+++ b/repos/netcorecli-fsc.proj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
-    <OutputArgs>/bl /p:OutputPath=$(OutputPath)$(RepositoryName)/ /p:BaseIntermediateOutputPath=$(IntermediatePath)$(RepositoryName)</OutputArgs>
+    <OutputArgs>/bl /v:$(LogVerbosity) /p:OutputPath=$(OutputPath)$(RepositoryName)/ /p:BaseIntermediateOutputPath=$(IntermediatePath)$(RepositoryName)</OutputArgs>
     <BuildCommand>$(DotnetToolCommand) pack -c $(Configuration) --output $(SourceBuiltPackagesPath) --no-build FSharp.NET.Sdk.csproj /p:NuspecFile=FSharp.NET.Sdk.nuspec $(OutputArgs) $(RedirectRepoOutputToLog)</BuildCommand>
     <PackagesOutput>$(SourceBuiltPackagesPath)</PackagesOutput>
     <RepoApiImplemented>false</RepoApiImplemented>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <Target Name="Restore" BeforeTargets="Build" DependsOnTargets="UpdateNuGetConfig">
-    <Exec Command="$(DotnetToolCommand) restore FSharp.NET.Sdk.csproj $(OutputArgs) $(RedirectRepoOutputToLog)"
+    <Exec Command="$(DotnetToolCommand) restore FSharp.NET.Sdk.csproj $(OutputArgs) /v:$(LogVerbosity) $(RedirectRepoOutputToLog)"
           WorkingDirectory="$(ProjectDirectory)"
           EnvironmentVariables="@(EnvironmentVariables)"
           IgnoreStandardErrorWarningFormat="true" />

--- a/repos/newtonsoft-json.proj
+++ b/repos/newtonsoft-json.proj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <Target Name="Restore" BeforeTargets="Build" DependsOnTargets="UpdateNuGetConfig">
-    <Exec Command="$(DotnetToolCommand) restore $(NewtonsoftJsonProjectPath) $(DotnetToolCommandArguments) $(RedirectRepoOutputToLog)"
+    <Exec Command="$(DotnetToolCommand) restore $(NewtonsoftJsonProjectPath) $(DotnetToolCommandArguments) /v:$(LogVerbosity) $(RedirectRepoOutputToLog)"
           WorkingDirectory="$(ProjectDirectory)"
           EnvironmentVariables="@(EnvironmentVariables)"
           IgnoreStandardErrorWarningFormat="true" />

--- a/repos/nuget-client.proj
+++ b/repos/nuget-client.proj
@@ -32,6 +32,7 @@
       <BuildCommandBase>$(BuildCommandBase) /p:Configuration=$(Configuration)</BuildCommandBase>
       <BuildCommandBase>$(BuildCommandBase) /p:BuildRTM=false</BuildCommandBase>
       <BuildCommandBase>$(BuildCommandBase) /p:BuildNumber=$(NuGetClientBuildNumber)</BuildCommandBase>
+      <BuildCommandBase>$(BuildCommandBase) /v:$(LogVerbosity)</BuildCommandBase>
     </PropertyGroup>
 
     <Exec Command="$(BuildCommandBase) /t:RestoreXPLAT /bl:restore.binlog $(RedirectRepoOutputToLog)"
@@ -49,6 +50,7 @@
       <PackCommand>$(PackCommand) /p:PackageOutputPath=$(PackagesOutput)</PackCommand>
       <PackCommand>$(PackCommand) /p:NoPackageAnalysis=true</PackCommand>
       <PackCommand>$(PackCommand) /flp:v=detailed</PackCommand>
+      <PackCommand>$(PackCommand) /v:$(LogVerbosity)</PackCommand>
       <PackCommand>$(PackCommand) /bl:pack.binlog</PackCommand>
       <PackCommand>$(PackCommand) $(RedirectRepoOutputToLog)</PackCommand>
     </PropertyGroup>

--- a/repos/roslyn.proj
+++ b/repos/roslyn.proj
@@ -49,6 +49,7 @@
       <RestoreArgs>restore</RestoreArgs>
       <RestoreArgs Condition="'$(OS)' != 'Windows_NT'">$(RestoreArgs) --disable-parallel</RestoreArgs>
       <RestoreArgs>$(RestoreArgs) $(ProjectDirectory)/SourceBuild.sln</RestoreArgs>
+      <RestoreArgs>$(RestoreArgs) /v:$(LogVerbosity)</RestoreArgs>
       <RestoreArgs>$(RestoreArgs) $(RedirectRepoOutputToLog)</RestoreArgs>
     </PropertyGroup>
 
@@ -87,6 +88,7 @@
       <PublishCommandArgs>$(PublishCommandArgs) /p:TargetFramework=netcoreapp2.0</PublishCommandArgs>
       <PublishCommandArgs>$(PublishCommandArgs) /t:PublishWithoutBuilding</PublishCommandArgs>
       <PublishCommandArgs>$(PublishCommandArgs) /bl:publish.binlog</PublishCommandArgs>
+      <PublishCommandArgs>$(PublishCommandArgs) /v:$(LogVerbosity)</PublishCommandArgs>
     </PropertyGroup>
 
     <Exec Command="$(DotnetToolCommand) $(PublishCommandArgs) %(PublishWithoutBuildingProject.Identity) $(RedirectRepoOutputToLog)"
@@ -102,6 +104,7 @@
       <PackCommandArgs>$(PackCommandArgs) -p:PackageOutputPath=$(PackagesOutput)</PackCommandArgs>
       <PackCommandArgs>$(PackCommandArgs) -p:NuGetPackageKind=release</PackCommandArgs>
       <PackCommandArgs>$(PackCommandArgs) /bl:pack.binlog</PackCommandArgs>
+      <PackCommandArgs>$(PackCommandArgs) /v:$(LogVerbosity)</PackCommandArgs>
     </PropertyGroup>
 
     <Exec Command="$(DotnetToolCommand) $(PackCommandArgs) -p:NuspecFile=%(NuSpecFiles.Identity) $(RedirectRepoOutputToLog)"

--- a/repos/templating.proj
+++ b/repos/templating.proj
@@ -30,6 +30,7 @@
   <Target Name="RepoBuild">
     <PropertyGroup>
       <BuildCommandArgs>/t:Build</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /v:$(LogVerbosity)</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) /bl</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) @(MSBuildProperties->'/p:%(Identity)', ' ')</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) $(ProjectDirectory)build.proj</BuildCommandArgs>

--- a/repos/xliff-tasks.proj
+++ b/repos/xliff-tasks.proj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <BuildCommandArgs>pack</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) $(ProjectDirectory)src\XliffTasks\XliffTasks.csproj</BuildCommandArgs>
-    <BuildCommandArgs>$(BuildCommandArgs) /v:normal</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /v:$(LogVerbosity)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /flp:Verbosity=Diag</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /bl</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) $(RedirectRepoOutputToLog)</BuildCommandArgs>

--- a/tools-local/init-build.proj
+++ b/tools-local/init-build.proj
@@ -52,7 +52,7 @@
       Using the MSBuild task here would cause, for example, GIT_COMMIT EnvironmentVariables items to
       be created that don't contain any commit, and they would stick around until the real build.
     -->
-    <Exec Command="$(DotNetCliToolDir)dotnet msbuild /v:Quiet /nologo $(MSBuildThisFileFullPath) /t:CreateGitInfoProps" />
+    <Exec Command="$(DotNetCliToolDir)dotnet msbuild /v:$(LogVerbosity) /nologo $(MSBuildThisFileFullPath) /t:CreateGitInfoProps" />
   </Target>
 
   <Target Name="CreateGitInfoProps" DependsOnTargets="GetRepoProjects">


### PR DESCRIPTION
Instead of custom verbosity levels for each project/build, use a standard logging verbosity level everywhere. This lets us enable detailed logging everywhere, or have consistently smaller logs.

To override, use:

    /p:LogVerbosity=quiet|minimal|normal|detailed|diagnostic

as a build argument to the main build script.

Comparing the build logs before and after this change, I didn't spot any noticeable change in the default logging verbosity, with one exception:

The logging level of the 'cli' project the has been reduced from `detailed` to `minimal` to match the logging level used everywhere else.

(The reason I would like to include this is change is so that I can bump up the logging verbosity in my local builds. The build logs can then be (hopefully) used by static analysis tools to figure out what code was compiled and with what flags. And then the static analysis tools can scan the code that was compiled, looking for bugs and issues.)