### PR TITLE
[release/2.2] Fix SDK version: include prerelease

### DIFF
--- a/repos/cli.proj
+++ b/repos/cli.proj
@@ -100,7 +100,7 @@
 
     <!-- Produce stable versions for RTM only.  When https://github.com/dotnet/source-build/issues/550
          is fixed we will be able to determine this automatically.  -->
-    <EnvironmentVariables Include="DropSuffix=true" />
+    <EnvironmentVariables Include="DropSuffix=$(UseStableVersions)" />
   </ItemGroup>
 
   <Target Name="AddProdConFeed" BeforeTargets="Build" DependsOnTargets="GetProdConBlobFeedUrl">


### PR DESCRIPTION
Building this locally now, but it seems like a simple fix.