### PR TITLE
Port 2.2.0-preview3 version infrastructure to 2.1

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -27,6 +27,12 @@
     <MicrosoftNETSdkRazorPackageVersion>2.1.2</MicrosoftNETSdkRazorPackageVersion>
   </PropertyGroup>
 
+  <!-- Build stabilization properties as passed in by ProdCon. -->
+  <PropertyGroup>
+    <UseStableVersions Condition="'$(UseStableVersions)' == ''">true</UseStableVersions>
+    <VersionStamp Condition="'$(VersionStamp)' == ''"></VersionStamp>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- Get ILAsm tool version from CoreCLR. -->
     <RemoteDependencyBuildInfo Include="CoreClr">

--- a/repos/cli.proj
+++ b/repos/cli.proj
@@ -100,7 +100,7 @@
 
     <!-- Produce stable versions for RTM only.  When https://github.com/dotnet/source-build/issues/550
          is fixed we will be able to determine this automatically.  -->
-    <EnvironmentVariables Include="DropSuffix=true" />
+    <EnvironmentVariables Include="DropSuffix=$(UseStableVersions)" />
   </ItemGroup>
 
   <Target Name="AddProdConFeed" BeforeTargets="Build" DependsOnTargets="GetProdConBlobFeedUrl">

--- a/repos/dir.props
+++ b/repos/dir.props
@@ -42,12 +42,6 @@
     <ProjectBuildReason Condition="'$(OfflineBuild)' == 'true'">$(ProjectBuildReason) in tarball</ProjectBuildReason>
   </PropertyGroup>
 
-  <!-- for RTM only, default to stabilized builds because that's what matches the official builds -->
-  <!-- once https://github.com/dotnet/source-build/issues/550 is fixed we will be able to determine this automatically -->
-  <PropertyGroup>
-    <UseStableVersions Condition="'$(UseStableVersions)' == ''">true</UseStableVersions>
-  </PropertyGroup>
-
   <ItemGroup>
     <EnvironmentVariables Include="DOTNET_TOOL_DIR=$(DotNetCliToolDir)" />
     <EnvironmentVariables Include="BUILD_TOOLS_TOOL_DIR=$(ProjectDir)Tools/" />
@@ -58,9 +52,12 @@
     <EnvironmentVariables Include="DotNetBuildOffline=true" Condition="'$(OfflineBuild)' == 'true'" />
     <EnvironmentVariables Include="DotNetCoreSdkDir=$(DotNetCliToolDir)" />
     <EnvironmentVariables Include="DotNetBuildToolsDir=$(ProjectDir)Tools/" />
+
     <EnvironmentVariables Include="StabilizePackageVersion=$(UseStableVersions)" Condition="'$(UseStableVersions)' != ''" />
     <EnvironmentVariables Include="PB_IsStable=$(UseStableVersions)" Condition="'$(UseStableVersions)' != ''" />
+
     <EnvironmentVariables Include="PackageVersionStamp=$(VersionStamp)" Condition="'$(VersionStamp)' != ''" />
+    <EnvironmentVariables Include="PB_VersionStamp=$(VersionStamp)" Condition="'$(VersionStamp)' != ''" />
 
     <!-- If MSBuild exits early, make sure debug output like 'MSBuild_*.failure.txt' ends up in a place we can see it. -->
     <EnvironmentVariables Include="MSBUILDDEBUGPATH=$(MSBuildDebugPathTargetDir)" />


### PR DESCRIPTION
Port infra parts of https://github.com/dotnet/source-build/pull/821 that centralize version stabilization/prerelease props and apply them better. This also puts them in the dependencies.props file as they should be to implement https://github.com/dotnet/source-build/issues/550.