### PR TITLE
Add build format to YAML

### DIFF
--- a/.vsts.pipelines/builds/ci.yml
+++ b/.vsts.pipelines/builds/ci.yml
@@ -5,6 +5,7 @@
 #   Online: The leg produces a tarball then builds it while connected to the internet.
 #   Offline: The leg produces a tarball then builds it offline. Network disconnected using Docker.
 
+name: $(Date:yyyyMMdd).$(Rev:.r)
 jobs:
 - template: ../jobs/ci-linux.yml
   parameters:

--- a/.vsts.pipelines/builds/ci.yml
+++ b/.vsts.pipelines/builds/ci.yml
@@ -5,7 +5,7 @@
 #   Online: The leg produces a tarball then builds it while connected to the internet.
 #   Offline: The leg produces a tarball then builds it offline. Network disconnected using Docker.
 
-name: $(Date:yyyyMMdd).$(Rev:.r)
+name: $(Date:yyyyMMdd)$(Rev:.r)
 jobs:
 - template: ../jobs/ci-linux.yml
   parameters:


### PR DESCRIPTION
This might fix the build number on rebuilds, and if not, it clarifies the scope of the AzDO bug.