### PR TITLE
[release/2.1] Add aspnet/Razor submodule for Microsoft.NET.Sdk.Razor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -66,3 +66,6 @@
 [submodule "src/linker"]
 	path = src/linker
 	url = https://github.com/mono/linker.git
+[submodule "src/aspnet-razor"]
+	path = src/aspnet-razor
+	url = https://github.com/aspnet/Razor

--- a/patches/aspnet-razor/0001-Remove-Internal.AspNetCore.Sdk-avoid-prebuilt.patch
+++ b/patches/aspnet-razor/0001-Remove-Internal.AspNetCore.Sdk-avoid-prebuilt.patch
@@ -1,0 +1,25 @@
+From c5c693544b006014e6dfd7e8161e091a1ff19ca5 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Wed, 24 Oct 2018 12:27:13 -0500
+Subject: [PATCH] Remove Internal.AspNetCore.Sdk: avoid prebuilt
+
+Internal.AspNetCore.Sdk is not used for the very specific build source-build needs to perform. Remove it to avoid adding prebuilt packages.
+---
+ Directory.Build.props | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/Directory.Build.props b/Directory.Build.props
+index 8260b6f3..6a18283d 100644
+--- a/Directory.Build.props
++++ b/Directory.Build.props
+@@ -20,7 +20,6 @@
+   </PropertyGroup>
+ 
+   <ItemGroup>
+-    <PackageReference Include="Internal.AspNetCore.Sdk" PrivateAssets="All" Version="$(InternalAspNetCoreSdkPackageVersion)" />
+   </ItemGroup>
+ 
+ </Project>
+-- 
+2.17.1.windows.2
+

--- a/repos/aspnet-razor.proj
+++ b/repos/aspnet-razor.proj
@@ -10,8 +10,7 @@
     <BuildCommandArgs>pack</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) $(RazorSdkProjectFile)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:Configuration=$(Configuration)</BuildCommandArgs>
-    <!-- A nonfinal build adds "-t000" to the package version. (Prerelease builds are "final".) -->
-    <BuildCommandArgs>$(BuildCommandArgs) /p:IsFinalBuild=true</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:IsFinalBuild=$(UseStableVersions)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:BuildNumber=$(BuildNumber)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /bl</BuildCommandArgs>
 

--- a/repos/aspnet-razor.proj
+++ b/repos/aspnet-razor.proj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+  <PropertyGroup>
+    <RazorSdkProjectDir>$(ProjectDirectory)src/Microsoft.NET.Sdk.Razor/</RazorSdkProjectDir>
+    <RazorSdkProjectFile>$(RazorSdkProjectDir)Microsoft.NET.Sdk.Razor.csproj</RazorSdkProjectFile>
+
+    <BuildNumber>30932</BuildNumber>
+
+    <BuildCommandArgs>pack</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) $(RazorSdkProjectFile)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:Configuration=$(Configuration)</BuildCommandArgs>
+    <!-- A nonfinal build adds "-t000" to the package version. (Prerelease builds are "final".) -->
+    <BuildCommandArgs>$(BuildCommandArgs) /p:IsFinalBuild=true</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:BuildNumber=$(BuildNumber)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /bl</BuildCommandArgs>
+
+    <BuildCommand>$(DotnetToolCommand) $(BuildCommandArgs)</BuildCommand>
+
+    <PackagesOutput>$(RazorSdkProjectDir)bin/$(Configuration)/</PackagesOutput>
+
+    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
+
+    <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
+</Project>

--- a/repos/cli.proj
+++ b/repos/cli.proj
@@ -58,6 +58,7 @@
 
   <ItemGroup>
     <RepositoryReference Include="application-insights" />
+    <RepositoryReference Include="aspnet-razor" />
     <RepositoryReference Include="cli-migrate" />
     <RepositoryReference Include="clicommandlineparser" />
     <RepositoryReference Include="core-setup" />

--- a/repos/known-good.proj
+++ b/repos/known-good.proj
@@ -12,6 +12,7 @@
 
     <!-- Tier 1 -->
     <RepositoryReference Include="application-insights" />
+    <RepositoryReference Include="aspnet-razor" />
     <RepositoryReference Include="common" />
     <RepositoryReference Include="netcorecli-fsc" />
     <RepositoryReference Include="newtonsoft-json" />

--- a/tools-local/prebuilt-baseline-offline.xml
+++ b/tools-local/prebuilt-baseline-offline.xml
@@ -2,6 +2,7 @@
   <CreatedByRid>centos.7-x64</CreatedByRid>
   <ProjectDirectories>
     <Dir>src/application-insights/</Dir>
+    <Dir>src/aspnet-razor/</Dir>
     <Dir>src/cli-migrate/</Dir>
     <Dir>src/cli/</Dir>
     <Dir>src/clicommandlineparser/</Dir>

--- a/tools-local/prebuilt-baseline-online.xml
+++ b/tools-local/prebuilt-baseline-online.xml
@@ -2,6 +2,7 @@
   <CreatedByRid>centos.7-x64</CreatedByRid>
   <ProjectDirectories>
     <Dir>src/application-insights/</Dir>
+    <Dir>src/aspnet-razor/</Dir>
     <Dir>src/cli-migrate/</Dir>
     <Dir>src/cli/</Dir>
     <Dir>src/clicommandlineparser/</Dir>
@@ -117,7 +118,6 @@
     <Usage Id="Microsoft.Net.Compilers" Version="2.8.0-beta4-62824-10" />
     <Usage Id="Microsoft.Net.Compilers.netcore" Version="2.6.0-beta3-62316-02" />
     <Usage Id="Microsoft.Net.Compilers.Targets.NetCore" Version="0.1.5-dev" />
-    <Usage Id="Microsoft.NET.Sdk.Razor" Version="2.1.2" />
     <Usage Id="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <Usage Id="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <Usage Id="Microsoft.NET.Test.Sdk" Version="15.6.0" />


### PR DESCRIPTION
Add https://github.com/aspnet/Razor to source-build to produce `Microsoft.NET.Sdk.Razor 2.1.2`.

For 2.2, after the auto-merge, I'll apply https://github.com/dotnet/source-build/compare/be27588b9c51c8c9bef9ef60f329eef41cf868f1...dagood:add-razor-sdk-2.2 to get the DLLs building. I decompiled the source-built DLLs and they're identical to the ones on the gallery. Doing a local build of those changes and this 2.1 PR to validate prebuilt baselines.

Once the aspnet repos are merged into aspnet/AspNetCore (not as submodules) these are the steps I'm thinking we'll need to do:
* Remove `src/aspnet-razor`, add `src/aspnetcore`.
* Rename project file to match.
  * Update base path.
  * Add handling of the global.json (present in AspNetCore but not Razor).
* Update patches for new paths.
  * (We actually don't have a mechanism to patch a submodule of a submodule, so we can't go ahead and use AspNetCore right now. The large number of submodules it would add before consolidation is a hindrance for some dev scenarios, too.)

FYI @natemcmaster 

Part of https://github.com/dotnet/source-build/issues/822