### PR TITLE
Publish bin/msbuild-debug dir in CI

### DIFF
--- a/.vsts.pipelines/jobs/ci-linux.yml
+++ b/.vsts.pipelines/jobs/ci-linux.yml
@@ -146,6 +146,7 @@ jobs:
         mkdir -p /logs/source-build/logs
         find . \( \
           -path './bin/*-report/*' -o \
+          -path './bin/msbuild-debug/*' -o \
           -iname '*.binlog' -o \
           -iname '*.log' \) \
           -exec cp {} --parents /logs/source-build/logs \;"
@@ -159,6 +160,7 @@ jobs:
         cd \"$(tarballName)\"
         find . \( \
           -path './bin/*-report/*' -o \
+          -path './bin/msbuild-debug/*' -o \
           -iname '*.binlog' -o \
           -iname '*.log' \) \
           -exec cp {} --parents /logs/tarball/logs \;"

--- a/.vsts.pipelines/jobs/ci-osx.yml
+++ b/.vsts.pipelines/jobs/ci-osx.yml
@@ -66,6 +66,7 @@ jobs:
       mkdir -p "$(logsDirectory)"
       find . \( \
         -path './bin/*-report/*' -o \
+        -path './bin/msbuild-debug/*' -o \
         -iname '*.binlog' -o \
         -iname '*.log' \) \
         -exec rsync -R {} "$(logsDirectory)" \;


### PR DESCRIPTION
MSBuild says it's saving diagnostic info here when `Child node "2" exited prematurely` errors happen in CI. Save the directory to allow devs to hunt down flakiness.

We have this set up in Jenkins and haven't seen anything in this dir yet, but worth adding to our AzDO definitions too. Recently an "exited prematurely" error happened during CoreFX managed build in a CentOS leg here: https://dnceng.visualstudio.com/public/_build/results?buildId=34807&view=logs.