### PR TITLE
[release/2.2] Add aspnet/Razor submodule for Microsoft.NET.Sdk.Razor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -66,3 +66,6 @@
 [submodule "src/linker"]
 	path = src/linker
 	url = https://github.com/mono/linker.git
+[submodule "src/aspnet-razor"]
+	path = src/aspnet-razor
+	url = https://github.com/aspnet/Razor

--- a/patches/aspnet-razor/0001-Remove-Internal.AspNetCore.Sdk-avoid-prebuilt.patch
+++ b/patches/aspnet-razor/0001-Remove-Internal.AspNetCore.Sdk-avoid-prebuilt.patch
@@ -1,0 +1,25 @@
+From c5c693544b006014e6dfd7e8161e091a1ff19ca5 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Wed, 24 Oct 2018 12:27:13 -0500
+Subject: [PATCH] Remove Internal.AspNetCore.Sdk: avoid prebuilt
+
+Internal.AspNetCore.Sdk is not used for the very specific build source-build needs to perform. Remove it to avoid adding prebuilt packages.
+---
+ Directory.Build.props | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/Directory.Build.props b/Directory.Build.props
+index 8260b6f3..6a18283d 100644
+--- a/Directory.Build.props
++++ b/Directory.Build.props
+@@ -20,7 +20,6 @@
+   </PropertyGroup>
+ 
+   <ItemGroup>
+-    <PackageReference Include="Internal.AspNetCore.Sdk" PrivateAssets="All" Version="$(InternalAspNetCoreSdkPackageVersion)" />
+   </ItemGroup>
+ 
+ </Project>
+-- 
+2.17.1.windows.2
+

--- a/patches/aspnet-razor/0002-Add-reference-assemblies-to-allow-net46-build.patch
+++ b/patches/aspnet-razor/0002-Add-reference-assemblies-to-allow-net46-build.patch
@@ -1,0 +1,40 @@
+From 3981984734d2733ac690055e22b581f867c2a481 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Wed, 24 Oct 2018 12:42:27 -0500
+Subject: [PATCH] Add reference assemblies to allow net46 build
+
+---
+ build/sources.props                                        | 1 +
+ src/Microsoft.NET.Sdk.Razor/Microsoft.NET.Sdk.Razor.csproj | 4 ++++
+ 2 files changed, 5 insertions(+)
+
+diff --git a/build/sources.props b/build/sources.props
+index 02efac45..677ae724 100644
+--- a/build/sources.props
++++ b/build/sources.props
+@@ -9,6 +9,7 @@
+       https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json;
+       https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json;
+       https://dotnet.myget.org/F/msbuild/api/v3/index.json;
++      https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json;
+       https://dotnet.myget.org/F/roslyn/api/v3/index.json;
+       https://vside.myget.org/F/vssdk/api/v3/index.json;
+       https://vside.myget.org/F/vsmac/api/v3/index.json
+diff --git a/src/Microsoft.NET.Sdk.Razor/Microsoft.NET.Sdk.Razor.csproj b/src/Microsoft.NET.Sdk.Razor/Microsoft.NET.Sdk.Razor.csproj
+index a295f16f..4ce6e4fe 100644
+--- a/src/Microsoft.NET.Sdk.Razor/Microsoft.NET.Sdk.Razor.csproj
++++ b/src/Microsoft.NET.Sdk.Razor/Microsoft.NET.Sdk.Razor.csproj
+@@ -21,6 +21,10 @@
+     <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" Version="$(MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion)" />
+   </ItemGroup>
+ 
++  <ItemGroup>
++    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-alpha-003" PrivateAssets="all" />
++  </ItemGroup>
++
+   <ItemGroup>
+     <Compile Include="..\Microsoft.AspNetCore.Razor.Tools\ServerProtocol\*.cs">
+       <Link>Shared\ServerProtocol\%(FileName)</Link>
+-- 
+2.17.1.windows.2
+

--- a/repos/aspnet-razor.proj
+++ b/repos/aspnet-razor.proj
@@ -5,7 +5,7 @@
     <RazorSdkProjectDir>$(ProjectDirectory)src/Microsoft.NET.Sdk.Razor/</RazorSdkProjectDir>
     <RazorSdkProjectFile>$(RazorSdkProjectDir)Microsoft.NET.Sdk.Razor.csproj</RazorSdkProjectFile>
 
-    <BuildNumber>30932</BuildNumber>
+    <BuildNumber>35497</BuildNumber>
 
     <BuildCommandArgs>pack</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) $(RazorSdkProjectFile)</BuildCommandArgs>

--- a/repos/aspnet-razor.proj
+++ b/repos/aspnet-razor.proj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+  <PropertyGroup>
+    <RazorSdkProjectDir>$(ProjectDirectory)src/Microsoft.NET.Sdk.Razor/</RazorSdkProjectDir>
+    <RazorSdkProjectFile>$(RazorSdkProjectDir)Microsoft.NET.Sdk.Razor.csproj</RazorSdkProjectFile>
+
+    <BuildNumber>30932</BuildNumber>
+
+    <BuildCommandArgs>pack</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) $(RazorSdkProjectFile)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:Configuration=$(Configuration)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:IsFinalBuild=$(UseStableVersions)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:BuildNumber=$(BuildNumber)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /bl</BuildCommandArgs>
+
+    <BuildCommand>$(DotnetToolCommand) $(BuildCommandArgs)</BuildCommand>
+
+    <PackagesOutput>$(RazorSdkProjectDir)bin/$(Configuration)/</PackagesOutput>
+
+    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
+
+    <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
+</Project>

--- a/repos/cli.proj
+++ b/repos/cli.proj
@@ -58,6 +58,7 @@
 
   <ItemGroup>
     <RepositoryReference Include="application-insights" />
+    <RepositoryReference Include="aspnet-razor" />
     <RepositoryReference Include="cli-migrate" />
     <RepositoryReference Include="clicommandlineparser" />
     <RepositoryReference Include="core-setup" />

--- a/repos/known-good.proj
+++ b/repos/known-good.proj
@@ -12,6 +12,7 @@
 
     <!-- Tier 1 -->
     <RepositoryReference Include="application-insights" />
+    <RepositoryReference Include="aspnet-razor" />
     <RepositoryReference Include="common" />
     <RepositoryReference Include="netcorecli-fsc" />
     <RepositoryReference Include="newtonsoft-json" />

--- a/tools-local/prebuilt-baseline-offline.xml
+++ b/tools-local/prebuilt-baseline-offline.xml
@@ -121,7 +121,6 @@
     <Usage Id="Microsoft.Net.Compilers" Version="2.8.0-beta4-62824-10" />
     <Usage Id="Microsoft.Net.Compilers.netcore" Version="2.6.0-beta3-62316-02" />
     <Usage Id="Microsoft.Net.Compilers.Targets.NetCore" Version="0.1.5-dev" />
-    <Usage Id="Microsoft.NET.Sdk.Razor" Version="2.2.0-preview3-35497" />
     <Usage Id="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <Usage Id="Microsoft.NETCore.App" Version="1.0.3" />
     <Usage Id="Microsoft.NETCore.Compilers" Version="2.8.0-beta2-62719-08" />

--- a/tools-local/prebuilt-baseline-offline.xml
+++ b/tools-local/prebuilt-baseline-offline.xml
@@ -2,6 +2,7 @@
   <CreatedByRid>centos.7-x64</CreatedByRid>
   <ProjectDirectories>
     <Dir>src/application-insights/</Dir>
+    <Dir>src/aspnet-razor/</Dir>
     <Dir>src/cli-migrate/</Dir>
     <Dir>src/cli/</Dir>
     <Dir>src/clicommandlineparser/</Dir>

--- a/tools-local/prebuilt-baseline-online.xml
+++ b/tools-local/prebuilt-baseline-online.xml
@@ -2,6 +2,7 @@
   <CreatedByRid>centos.7-x64</CreatedByRid>
   <ProjectDirectories>
     <Dir>src/application-insights/</Dir>
+    <Dir>src/aspnet-razor/</Dir>
     <Dir>src/cli-migrate/</Dir>
     <Dir>src/cli/</Dir>
     <Dir>src/clicommandlineparser/</Dir>
@@ -111,6 +112,7 @@
     <Usage Id="Microsoft.DotNet.Web.Spa.ProjectTemplates" Version="2.2.0-preview3-35497" />
     <Usage Id="Microsoft.Extensions.CommandLineUtils" Version="1.1.0" />
     <Usage Id="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
+    <Usage Id="Microsoft.Extensions.CommandLineUtils.Sources" Version="2.2.0-preview3-35301" />
     <Usage Id="Microsoft.Extensions.DependencyModel" Version="1.0.0" />
     <Usage Id="Microsoft.Extensions.DependencyModel" Version="1.0.3" />
     <Usage Id="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
@@ -122,7 +124,6 @@
     <Usage Id="Microsoft.Net.Compilers" Version="2.8.0-beta4-62824-10" />
     <Usage Id="Microsoft.Net.Compilers.netcore" Version="2.6.0-beta3-62316-02" />
     <Usage Id="Microsoft.Net.Compilers.Targets.NetCore" Version="0.1.5-dev" />
-    <Usage Id="Microsoft.NET.Sdk.Razor" Version="2.2.0-preview3-35497" />
     <Usage Id="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <Usage Id="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <Usage Id="Microsoft.NET.Test.Sdk" Version="15.6.0" />


### PR DESCRIPTION
Brings https://github.com/dotnet/source-build/pull/834 into `release/2.2` and updates the aspnet-razor submodule to `2.2.0-preview3`. A patch adds in reference assemblies so the build task DLLs (not in 2.1) can build for net46.

Finishes off https://github.com/dotnet/source-build/issues/822.