### PR TITLE
[release/2.1] Remove test-only prebuilts

### DIFF
--- a/patches/common/0001-Use-roslyn-tools-technique-to-skip-test-restore.patch
+++ b/patches/common/0001-Use-roslyn-tools-technique-to-skip-test-restore.patch
@@ -1,0 +1,60 @@
+From 9c398b4e9f69089094c22b6e59c5aaf4fd2511c8 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Wed, 31 Oct 2018 18:05:22 -0500
+Subject: [PATCH] Use roslyn-tools technique to skip test restore
+
+---
+ build/Empty.targets          | 23 +++++++++++++++++++++++
+ test/Directory.Build.targets | 10 ++++++++++
+ 2 files changed, 33 insertions(+)
+ create mode 100644 build/Empty.targets
+ create mode 100644 test/Directory.Build.targets
+
+diff --git a/build/Empty.targets b/build/Empty.targets
+new file mode 100644
+index 0000000..36b4744
+--- /dev/null
++++ b/build/Empty.targets
+@@ -0,0 +1,23 @@
++<?xml version="1.0" encoding="utf-8"?>
++<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
++<!-- Copied from https://github.com/dotnet/roslyn-tools/blob/c442fe46e02b31e3954a7c669cc309a8b0175115/sdks/RepoToolset/tools/Empty.targets -->
++<Project DefaultTargets="Build">
++
++  <PropertyGroup>
++    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
++  </PropertyGroup>
++
++  <!--
++    Import this file to suppress all targets while allowing the project to participate in the build.
++    Workaround for https://github.com/dotnet/sdk/issues/2071.
++    
++    The targets defined here are not sufficient for the project to be open in Visual Studio without issues though.    
++  -->
++
++  <Target Name="_IsProjectRestoreSupported"/>
++  <Target Name="Restore"/>
++  <Target Name="Build"/>
++  <Target Name="Test"/>
++  <Target Name="Pack"/>
++
++</Project>
+diff --git a/test/Directory.Build.targets b/test/Directory.Build.targets
+new file mode 100644
+index 0000000..037d46b
+--- /dev/null
++++ b/test/Directory.Build.targets
+@@ -0,0 +1,10 @@
++<?xml version="1.0" encoding="utf-8"?>
++<Project>
++  <!-- Projects in this directory are test-related, and shouldn't participate in source-build. -->
++  <PropertyGroup>
++    <_SuppressAllTargets>false</_SuppressAllTargets>
++    <_SuppressAllTargets Condition="'$(DotNetBuildFromSource)' == 'true'">true</_SuppressAllTargets>
++  </PropertyGroup>
++
++  <Import Project="$(MSBuildThisFileDirectory)..\build\Empty.targets" Condition="$(_SuppressAllTargets)"/>
++</Project>
+-- 
+2.17.1.windows.2
+

--- a/patches/common/0001-Use-roslyn-tools-technique-to-skip-test-restore.patch
+++ b/patches/common/0001-Use-roslyn-tools-technique-to-skip-test-restore.patch
@@ -3,6 +3,7 @@ From: Davis Goodin <dagood@microsoft.com>
 Date: Wed, 31 Oct 2018 18:05:22 -0500
 Subject: [PATCH] Use roslyn-tools technique to skip test restore
 
+Patch PR: https://github.com/aspnet/Extensions/pull/445
 ---
  build/Empty.targets          | 23 +++++++++++++++++++++++
  test/Directory.Build.targets | 10 ++++++++++

--- a/patches/corefx/0001-Skip-CoreFx.Private.TestUtilities-in-source-build.patch
+++ b/patches/corefx/0001-Skip-CoreFx.Private.TestUtilities-in-source-build.patch
@@ -6,6 +6,8 @@ Subject: [PATCH] Skip CoreFx.Private.TestUtilities in source-build
 This project referenced the XUnit.Runtime dependency project, causing test-only prebuilt dependencies.
 
 Even though we always pass BuildTests=false, include a condition to handle "true" to make intent clear.
+
+Patch PR: https://github.com/dotnet/corefx/pull/33217
 ---
  dir.props      | 8 ++++++++
  src/ref.builds | 2 +-

--- a/patches/corefx/0001-Skip-CoreFx.Private.TestUtilities-in-source-build.patch
+++ b/patches/corefx/0001-Skip-CoreFx.Private.TestUtilities-in-source-build.patch
@@ -1,0 +1,49 @@
+From 3c58c35b188d80799948917e1e09721ff8316ad2 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Wed, 31 Oct 2018 22:33:26 -0500
+Subject: [PATCH] Skip CoreFx.Private.TestUtilities in source-build
+
+This project referenced the XUnit.Runtime dependency project, causing test-only prebuilt dependencies.
+
+Even though we always pass BuildTests=false, include a condition to handle "true" to make intent clear.
+---
+ dir.props      | 8 ++++++++
+ src/ref.builds | 2 +-
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/dir.props b/dir.props
+index b75c58047b..530c63c821 100644
+--- a/dir.props
++++ b/dir.props
+@@ -306,6 +306,14 @@
+     <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)'==''">$(PackageOutputPath)symbols/</SymbolPackageOutputPath>
+   </PropertyGroup>
+ 
++  <!--
++    Remove test-only dependencies during source-build: disable project that brings in XUnit.Runtime
++    dependencies through 'ReferenceFromRuntime' property.
++  -->
++  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true' and '$(BuildTests)' != 'true'">
++    <ProjectExclusions Include="$(SourceDir)CoreFx.Private.TestUtilities/**/*.csproj" />
++  </ItemGroup>
++
+   <!-- Properties related to multi-file mode for ILC tests -->
+   <PropertyGroup Condition="'$(TargetGroup)' == 'uapaot'">
+     <!-- Only enable multi-file for Release-x64 and Debug-x86 for now -->
+diff --git a/src/ref.builds b/src/ref.builds
+index c7542be16a..79ee0d40a8 100644
+--- a/src/ref.builds
++++ b/src/ref.builds
+@@ -7,7 +7,7 @@
+   </PropertyGroup>
+ 
+   <ItemGroup>
+-    <Project Include="$(MSBuildThisFileDirectory)*\ref\*.*proj" />
++    <Project Include="$(MSBuildThisFileDirectory)*\ref\*.*proj" Exclude="@(ProjectExclusions)" />
+   </ItemGroup>
+   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+ </Project>
+\ No newline at end of file
+-- 
+2.17.1.windows.2
+

--- a/patches/sdk/0001-Exclude-unit-test-projects-from-source-build.patch
+++ b/patches/sdk/0001-Exclude-unit-test-projects-from-source-build.patch
@@ -1,0 +1,24 @@
+From 06d3c0dbd226c3f7cd7aafd89ccf2e42f15dfce8 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Wed, 31 Oct 2018 23:04:45 -0500
+Subject: [PATCH] Exclude unit test projects from source-build
+
+---
+ src/Directory.Build.props | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/Directory.Build.props b/src/Directory.Build.props
+index ca3ebe94..396d7b21 100644
+--- a/src/Directory.Build.props
++++ b/src/Directory.Build.props
+@@ -29,6 +29,7 @@
+   </PropertyGroup>
+ 
+   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
++    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+     <GenerateProgramFile>false</GenerateProgramFile>
+     <XUnitRunnerAdditionalArguments>-parallel none</XUnitRunnerAdditionalArguments>
+-- 
+2.17.1.windows.2
+

--- a/patches/sdk/0001-Exclude-unit-test-projects-from-source-build.patch
+++ b/patches/sdk/0001-Exclude-unit-test-projects-from-source-build.patch
@@ -3,6 +3,7 @@ From: Davis Goodin <dagood@microsoft.com>
 Date: Wed, 31 Oct 2018 23:04:45 -0500
 Subject: [PATCH] Exclude unit test projects from source-build
 
+Patch PR: https://github.com/dotnet/sdk/pull/2642
 ---
  src/Directory.Build.props | 1 +
  1 file changed, 1 insertion(+)

--- a/patches/websdk/0001-Use-roslyn-tools-technique-to-skip-test-restore.patch
+++ b/patches/websdk/0001-Use-roslyn-tools-technique-to-skip-test-restore.patch
@@ -3,6 +3,7 @@ From: Davis Goodin <dagood@microsoft.com>
 Date: Thu, 1 Nov 2018 12:50:42 -0500
 Subject: [PATCH] Use roslyn-tools technique to skip test restore
 
+Patch PR: https://github.com/aspnet/websdk/pull/421
 ---
  build/Empty.targets          | 23 +++++++++++++++++++++++
  test/Directory.Build.targets | 10 ++++++++++

--- a/patches/websdk/0001-Use-roslyn-tools-technique-to-skip-test-restore.patch
+++ b/patches/websdk/0001-Use-roslyn-tools-technique-to-skip-test-restore.patch
@@ -1,0 +1,60 @@
+From 93e0640c274606a6e2a2c9c07c83df0341247a97 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Thu, 1 Nov 2018 12:50:42 -0500
+Subject: [PATCH] Use roslyn-tools technique to skip test restore
+
+---
+ build/Empty.targets          | 23 +++++++++++++++++++++++
+ test/Directory.Build.targets | 10 ++++++++++
+ 2 files changed, 33 insertions(+)
+ create mode 100644 build/Empty.targets
+ create mode 100644 test/Directory.Build.targets
+
+diff --git a/build/Empty.targets b/build/Empty.targets
+new file mode 100644
+index 0000000..36b4744
+--- /dev/null
++++ b/build/Empty.targets
+@@ -0,0 +1,23 @@
++<?xml version="1.0" encoding="utf-8"?>
++<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
++<!-- Copied from https://github.com/dotnet/roslyn-tools/blob/c442fe46e02b31e3954a7c669cc309a8b0175115/sdks/RepoToolset/tools/Empty.targets -->
++<Project DefaultTargets="Build">
++
++  <PropertyGroup>
++    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
++  </PropertyGroup>
++
++  <!--
++    Import this file to suppress all targets while allowing the project to participate in the build.
++    Workaround for https://github.com/dotnet/sdk/issues/2071.
++    
++    The targets defined here are not sufficient for the project to be open in Visual Studio without issues though.    
++  -->
++
++  <Target Name="_IsProjectRestoreSupported"/>
++  <Target Name="Restore"/>
++  <Target Name="Build"/>
++  <Target Name="Test"/>
++  <Target Name="Pack"/>
++
++</Project>
+diff --git a/test/Directory.Build.targets b/test/Directory.Build.targets
+new file mode 100644
+index 0000000..037d46b
+--- /dev/null
++++ b/test/Directory.Build.targets
+@@ -0,0 +1,10 @@
++<?xml version="1.0" encoding="utf-8"?>
++<Project>
++  <!-- Projects in this directory are test-related, and shouldn't participate in source-build. -->
++  <PropertyGroup>
++    <_SuppressAllTargets>false</_SuppressAllTargets>
++    <_SuppressAllTargets Condition="'$(DotNetBuildFromSource)' == 'true'">true</_SuppressAllTargets>
++  </PropertyGroup>
++
++  <Import Project="$(MSBuildThisFileDirectory)..\build\Empty.targets" Condition="$(_SuppressAllTargets)"/>
++</Project>
+-- 
+2.17.1.windows.2
+

--- a/repos/templating.proj
+++ b/repos/templating.proj
@@ -18,6 +18,8 @@
     <MSBuildProperties Include="BUILD_NUMBER=$(BuildNumber)" />
     <MSBuildProperties Include="PackageDateTime=$(PackageDateTime)" />
     <MSBuildProperties Include="PackageBuildQuality=$(PackageBuildQuality)" />
+    <!-- Force SharedTestProjects to be unset, so they aren't restored/built. -->
+    <MSBuildProperties Include="SharedTestProjects=" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools-local/prebuilt-baseline-offline.xml
+++ b/tools-local/prebuilt-baseline-offline.xml
@@ -38,16 +38,11 @@
     <PackageIdentity Id="runtime.linux-x64.Microsoft.NETCore.Runtime.CoreCLR" Version="2.1.6-servicing-27017-03" />
   </NeverRestoredTarballPrebuilts>
   <Usages>
-    <Usage Id="CommandLineParser" Version="2.1.1-beta" />
-    <Usage Id="coveralls.io" Version="1.4" />
-    <Usage Id="FluentAssertions" Version="4.19.0" />
-    <Usage Id="FluentAssertions.Json" Version="4.19.0" />
     <Usage Id="fmdev.ResX" Version="0.2.0" />
     <Usage Id="fmdev.xlftool" Version="0.1.3" />
     <Usage Id="fmdev.XliffParser" Version="0.5.3" />
     <Usage Id="FSharp.Core" Version="4.5.2" />
     <Usage Id="Libuv" Version="1.9.1" />
-    <Usage Id="Microsoft.3rdpartytools.MarkdownLog" Version="0.10.0-alpha-experimental" />
     <Usage Id="Microsoft.Build" Version="14.3.0" />
     <Usage Id="Microsoft.Build" Version="15.1.548" />
     <Usage Id="Microsoft.Build" Version="15.3.409" />
@@ -85,30 +80,24 @@
     <Usage Id="Microsoft.CodeAnalysis.CSharp" Version="2.6.0-beta3-62316-02" />
     <Usage Id="Microsoft.CodeAnalysis.VisualBasic" Version="1.3.0" />
     <Usage Id="Microsoft.CodeAnalysis.VisualBasic" Version="2.6.0-beta3-62316-02" />
-    <Usage Id="Microsoft.CodeCoverage" Version="1.0.3" />
     <Usage Id="Microsoft.CSharp" Version="4.0.1" />
     <Usage Id="Microsoft.CSharp" Version="4.3.0" />
     <Usage Id="Microsoft.Data.Edm" Version="5.6.4" />
     <Usage Id="Microsoft.Data.OData" Version="5.6.4" />
     <Usage Id="Microsoft.Data.Services.Client" Version="5.6.4" />
     <Usage Id="Microsoft.Diagnostics.Tracing.EventSource.Redist" Version="1.1.16-beta" />
-    <Usage Id="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.5" />
     <Usage Id="Microsoft.DiaSymReader.Native" Version="1.4.1" />
-    <Usage Id="Microsoft.DiaSymReader.Native" Version="1.5.0" />
     <Usage Id="Microsoft.DiaSymReader.Native" Version="1.7.0" />
     <Usage Id="Microsoft.DotNet.Archive" Version="0.2.0-beta-63027-01" />
     <Usage Id="Microsoft.DotNet.Build.Tasks.Feed" Version="2.1.0-rc1-03130-05" />
     <Usage Id="Microsoft.DotNet.BuildTools.CoreCLR" Version="1.0.4-prerelease" />
     <Usage Id="Microsoft.DotNet.Cli.CommandLine" Version="0.1.1-alpha-167" />
     <Usage Id="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
-    <Usage Id="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
     <Usage Id="Microsoft.DotNet.PlatformAbstractions" Version="1.0.3" />
     <Usage Id="Microsoft.DotNet.PlatformAbstractions" Version="2.0.0" />
-    <Usage Id="Microsoft.DotNet.PlatformAbstractions" Version="2.0.4" />
     <Usage Id="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0-preview2-26306-03" />
     <Usage Id="Microsoft.DotNet.VersionTools" Version="2.1.0-rc1-03130-05" />
     <Usage Id="Microsoft.Extensions.CommandLineUtils" Version="1.1.0" />
-    <Usage Id="Microsoft.Extensions.DependencyModel" Version="1.0.0" />
     <Usage Id="Microsoft.Extensions.DependencyModel" Version="1.0.3" />
     <Usage Id="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
     <Usage Id="Microsoft.Extensions.DependencyModel" Version="2.1.0-preview2-26306-03" />
@@ -133,12 +122,6 @@
     <Usage Id="Microsoft.TargetingPack.NETFramework.v4.6" Version="1.0.1" />
     <Usage Id="Microsoft.TargetingPack.NETFramework.v4.6.1" Version="1.0.1" />
     <Usage Id="Microsoft.TemplateEngine.Cli.Localization" Version="1.0.2-beta3" />
-    <Usage Id="Microsoft.TestPlatform.ObjectModel" Version="15.0.0" />
-    <Usage Id="Microsoft.TestPlatform.ObjectModel" Version="15.3.0" />
-    <Usage Id="Microsoft.TestPlatform.ObjectModel" Version="15.6.0" />
-    <Usage Id="Microsoft.TestPlatform.TestHost" Version="15.0.0" />
-    <Usage Id="Microsoft.TestPlatform.TestHost" Version="15.3.0" />
-    <Usage Id="Microsoft.TestPlatform.TestHost" Version="15.6.0" />
     <Usage Id="Microsoft.VisualBasic" Version="10.0.1" />
     <Usage Id="Microsoft.VisualBasic" Version="10.1.0" />
     <Usage Id="Microsoft.VisualStudio.QualityTools" Version="15.6.0-preview-1270639" />
@@ -153,7 +136,6 @@
     <Usage Id="Microsoft.Win32.Primitives" Version="4.3.0" />
     <Usage Id="Microsoft.Win32.Registry" Version="4.0.0" />
     <Usage Id="Microsoft.Win32.Registry" Version="4.3.0" />
-    <Usage Id="Microsoft.xunit.netcore.extensions" Version="2.1.0-rc1-03131-06" />
     <Usage Id="NETStandard.Library.NETFramework" Version="2.0.1-servicing-26011-01" />
     <Usage Id="Newtonsoft.Json" Version="6.0.4" />
     <Usage Id="Newtonsoft.Json" Version="8.0.3" />
@@ -184,11 +166,9 @@
     <Usage Id="NuGet.Versioning" Version="4.3.0-preview1-2500" />
     <Usage Id="NuGet.Versioning" Version="4.3.0-preview2-4095" />
     <Usage Id="NuGet.Versioning" Version="4.7.0-preview1-4992" />
-    <Usage Id="OpenCover" Version="4.6.519" />
     <Usage Id="optimization.linux-x64.PGO.CoreCLR" Version="2.1.0-release-20180815-0105" />
     <Usage Id="optimization.windows_nt-x64.PGO.CoreCLR" Version="2.1.0-release-20180815-0105" />
     <Usage Id="optimization.windows_nt-x86.PGO.CoreCLR" Version="2.1.0-release-20180815-0105" />
-    <Usage Id="ReportGenerator" Version="3.0.1" />
     <Usage Id="runtime.any.System.Collections" Version="4.0.11" Rid="any" />
     <Usage Id="runtime.any.System.Collections" Version="4.3.0" Rid="any" />
     <Usage Id="runtime.any.System.Diagnostics.Tools" Version="4.0.1" Rid="any" />
@@ -337,7 +317,6 @@
     <Usage Id="System.ComponentModel.Annotations" Version="4.1.0" />
     <Usage Id="System.ComponentModel.Annotations" Version="4.3.0" />
     <Usage Id="System.ComponentModel.EventBasedAsync" Version="4.0.11" />
-    <Usage Id="System.ComponentModel.EventBasedAsync" Version="4.3.0" />
     <Usage Id="System.ComponentModel.Primitives" Version="4.1.0" />
     <Usage Id="System.ComponentModel.Primitives" Version="4.3.0" />
     <Usage Id="System.ComponentModel.TypeConverter" Version="4.1.0" />
@@ -347,7 +326,6 @@
     <Usage Id="System.Composition.Hosting" Version="1.1.0" />
     <Usage Id="System.Composition.Runtime" Version="1.1.0" />
     <Usage Id="System.Composition.TypedParts" Version="1.1.0" />
-    <Usage Id="System.Console" Version="4.0.0-rc2-24027" />
     <Usage Id="System.Console" Version="4.0.0" />
     <Usage Id="System.Console" Version="4.3.0" />
     <Usage Id="System.Diagnostics.Contracts" Version="4.0.1" />
@@ -367,19 +345,16 @@
     <Usage Id="System.Diagnostics.TraceSource" Version="4.3.0" />
     <Usage Id="System.Diagnostics.Tracing" Version="4.1.0" />
     <Usage Id="System.Diagnostics.Tracing" Version="4.3.0" />
-    <Usage Id="System.Drawing.Common.TestData" Version="1.0.7" />
     <Usage Id="System.Dynamic.Runtime" Version="4.0.11" />
     <Usage Id="System.Dynamic.Runtime" Version="4.3.0" />
     <Usage Id="System.Globalization.Calendars" Version="4.0.1" />
     <Usage Id="System.Globalization.Calendars" Version="4.3.0" />
     <Usage Id="System.Globalization.Extensions" Version="4.0.1" />
     <Usage Id="System.Globalization.Extensions" Version="4.3.0" />
-    <Usage Id="System.IO" Version="4.1.0-rc2-24027" />
     <Usage Id="System.IO" Version="4.1.0" />
     <Usage Id="System.IO" Version="4.3.0" />
     <Usage Id="System.IO.Compression" Version="4.1.0" />
     <Usage Id="System.IO.Compression" Version="4.3.0" />
-    <Usage Id="System.IO.Compression.TestData" Version="1.0.6-prerelease" />
     <Usage Id="System.IO.Compression.ZipFile" Version="4.0.1" />
     <Usage Id="System.IO.Compression.ZipFile" Version="4.3.0" />
     <Usage Id="System.IO.FileSystem" Version="4.0.1" />
@@ -390,16 +365,13 @@
     <Usage Id="System.IO.FileSystem.Watcher" Version="4.3.0" />
     <Usage Id="System.IO.MemoryMappedFiles" Version="4.0.0" />
     <Usage Id="System.IO.MemoryMappedFiles" Version="4.3.0" />
-    <Usage Id="System.IO.Packaging.TestData" Version="1.0.0-prerelease" />
     <Usage Id="System.IO.Pipes" Version="4.0.0" />
     <Usage Id="System.IO.Pipes" Version="4.3.0" />
     <Usage Id="System.IO.Pipes.AccessControl" Version="4.3.0" />
     <Usage Id="System.IO.UnmanagedMemoryStream" Version="4.0.1" />
     <Usage Id="System.IO.UnmanagedMemoryStream" Version="4.3.0" />
-    <Usage Id="System.Linq" Version="4.1.0-rc2-24027" />
     <Usage Id="System.Linq" Version="4.1.0" />
     <Usage Id="System.Linq" Version="4.3.0" />
-    <Usage Id="System.Linq.Expressions" Version="4.0.11-rc2-24027" />
     <Usage Id="System.Linq.Expressions" Version="4.1.0" />
     <Usage Id="System.Linq.Expressions" Version="4.1.1" />
     <Usage Id="System.Linq.Expressions" Version="4.3.0" />
@@ -423,28 +395,22 @@
     <Usage Id="System.Net.Security" Version="4.3.1" />
     <Usage Id="System.Net.Sockets" Version="4.1.0" />
     <Usage Id="System.Net.Sockets" Version="4.3.0" />
-    <Usage Id="System.Net.TestData" Version="1.0.0-prerelease" />
     <Usage Id="System.Net.WebHeaderCollection" Version="4.0.1" />
     <Usage Id="System.Net.WebHeaderCollection" Version="4.3.0" />
     <Usage Id="System.Numerics.Vectors" Version="4.1.1" />
     <Usage Id="System.Numerics.Vectors" Version="4.3.0" />
-    <Usage Id="System.ObjectModel" Version="4.0.12-rc2-24027" />
     <Usage Id="System.ObjectModel" Version="4.0.12" />
     <Usage Id="System.ObjectModel" Version="4.3.0" />
     <Usage Id="System.Private.DataContractSerialization" Version="4.1.1" />
     <Usage Id="System.Private.DataContractSerialization" Version="4.3.0" />
-    <Usage Id="System.Reflection" Version="4.1.0-rc2-24027" />
     <Usage Id="System.Reflection" Version="4.1.0" />
     <Usage Id="System.Reflection" Version="4.3.0" />
     <Usage Id="System.Reflection.DispatchProxy" Version="4.0.1" />
     <Usage Id="System.Reflection.DispatchProxy" Version="4.3.0" />
-    <Usage Id="System.Reflection.Emit" Version="4.0.1-rc2-24027" />
     <Usage Id="System.Reflection.Emit" Version="4.0.1" />
     <Usage Id="System.Reflection.Emit" Version="4.3.0" />
-    <Usage Id="System.Reflection.Emit.ILGeneration" Version="4.0.1-rc2-24027" />
     <Usage Id="System.Reflection.Emit.ILGeneration" Version="4.0.1" />
     <Usage Id="System.Reflection.Emit.ILGeneration" Version="4.3.0" />
-    <Usage Id="System.Reflection.Emit.Lightweight" Version="4.0.1-rc2-24027" />
     <Usage Id="System.Reflection.Emit.Lightweight" Version="4.0.1" />
     <Usage Id="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <Usage Id="System.Reflection.Metadata" Version="1.3.0" />
@@ -452,16 +418,13 @@
     <Usage Id="System.Reflection.Metadata" Version="1.4.2" />
     <Usage Id="System.Reflection.Metadata" Version="1.5.0" />
     <Usage Id="System.Reflection.Metadata" Version="1.6.0" />
-    <Usage Id="System.Reflection.TypeExtensions" Version="4.1.0-rc2-24027" />
     <Usage Id="System.Reflection.TypeExtensions" Version="4.1.0" />
     <Usage Id="System.Reflection.TypeExtensions" Version="4.3.0" />
     <Usage Id="System.Resources.Reader" Version="4.0.0" />
     <Usage Id="System.Resources.Reader" Version="4.3.0" />
     <Usage Id="System.Resources.Writer" Version="4.0.0" />
-    <Usage Id="System.Runtime" Version="4.1.0-rc2-24027" />
     <Usage Id="System.Runtime" Version="4.1.0" />
     <Usage Id="System.Runtime" Version="4.3.0" />
-    <Usage Id="System.Runtime.Extensions" Version="4.1.0-rc2-24027" />
     <Usage Id="System.Runtime.Extensions" Version="4.1.0" />
     <Usage Id="System.Runtime.Extensions" Version="4.3.0" />
     <Usage Id="System.Runtime.InteropServices" Version="4.1.0" />
@@ -474,7 +437,6 @@
     <Usage Id="System.Runtime.Numerics" Version="4.3.0" />
     <Usage Id="System.Runtime.Serialization.Formatters" Version="4.3.0" />
     <Usage Id="System.Runtime.Serialization.Json" Version="4.0.2" />
-    <Usage Id="System.Runtime.Serialization.Json" Version="4.3.0" />
     <Usage Id="System.Runtime.Serialization.Primitives" Version="4.1.1" />
     <Usage Id="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <Usage Id="System.Runtime.Serialization.Xml" Version="4.1.1" />
@@ -497,7 +459,6 @@
     <Usage Id="System.Security.Cryptography.ProtectedData" Version="4.3.0" />
     <Usage Id="System.Security.Cryptography.X509Certificates" Version="4.1.0" />
     <Usage Id="System.Security.Cryptography.X509Certificates" Version="4.3.0" />
-    <Usage Id="System.Security.Cryptography.X509Certificates.TestData" Version="1.0.2-prerelease" />
     <Usage Id="System.Security.Principal" Version="4.0.1" />
     <Usage Id="System.Security.Principal" Version="4.3.0" />
     <Usage Id="System.Security.Principal.Windows" Version="4.0.0" />
@@ -508,8 +469,6 @@
     <Usage Id="System.Text.Encoding.CodePages" Version="4.4.0" />
     <Usage Id="System.Text.RegularExpressions" Version="4.1.0" />
     <Usage Id="System.Text.RegularExpressions" Version="4.3.0" />
-    <Usage Id="System.Text.RegularExpressions.TestData" Version="1.0.2" />
-    <Usage Id="System.Threading" Version="4.0.11-rc2-24027" />
     <Usage Id="System.Threading" Version="4.0.11" />
     <Usage Id="System.Threading" Version="4.3.0" />
     <Usage Id="System.Threading.Overlapped" Version="4.0.1" />
@@ -525,7 +484,6 @@
     <Usage Id="System.Threading.ThreadPool" Version="4.0.10" />
     <Usage Id="System.Threading.ThreadPool" Version="4.3.0" />
     <Usage Id="System.ValueTuple" Version="4.3.0" />
-    <Usage Id="System.ValueTuple" Version="4.3.1" />
     <Usage Id="System.ValueTuple" Version="4.4.0" />
     <Usage Id="System.Xml.ReaderWriter" Version="4.0.11" />
     <Usage Id="System.Xml.ReaderWriter" Version="4.3.0" />
@@ -545,32 +503,5 @@
     <Usage Id="XliffTasks" Version="0.2.0-beta-000081" />
     <Usage Id="XliffTasks" Version="0.2.0-beta-62730-03" />
     <Usage Id="XliffTasks" Version="0.2.0-beta-63004-01" />
-    <Usage Id="xunit.abstractions" Version="2.0.1-rc2" />
-    <Usage Id="xunit.abstractions" Version="2.0.1" />
-    <Usage Id="xunit.analyzers" Version="0.7.0" />
-    <Usage Id="xunit.assert" Version="2.2.0-beta2-build3300" />
-    <Usage Id="xunit.assert" Version="2.3.0" />
-    <Usage Id="xunit.assert" Version="2.3.1" />
-    <Usage Id="xunit.console" Version="2.3.1" />
-    <Usage Id="xunit.console.netcore" Version="1.0.3-prerelease-00921-01" />
-    <Usage Id="xunit.core" Version="2.2.0-beta2-build3300" />
-    <Usage Id="xunit.core" Version="2.3.0" />
-    <Usage Id="xunit.core" Version="2.3.1" />
-    <Usage Id="xunit.extensibility.core" Version="2.2.0-beta2-build3300" />
-    <Usage Id="xunit.extensibility.core" Version="2.3.0" />
-    <Usage Id="xunit.extensibility.core" Version="2.3.1" />
-    <Usage Id="xunit.extensibility.execution" Version="2.2.0-beta2-build3300" />
-    <Usage Id="xunit.extensibility.execution" Version="2.3.0" />
-    <Usage Id="xunit.extensibility.execution" Version="2.3.1" />
-    <Usage Id="xunit.performance.api" Version="1.0.0-beta-build0019" />
-    <Usage Id="xunit.performance.core" Version="1.0.0-beta-build0019" />
-    <Usage Id="xunit.performance.execution" Version="1.0.0-beta-build0019" />
-    <Usage Id="xunit.performance.metrics" Version="1.0.0-beta-build0019" />
-    <Usage Id="xunit.runner.console" Version="2.3.1" />
-    <Usage Id="xunit.runner.reporters" Version="2.3.1" />
-    <Usage Id="xunit.runner.utility" Version="2.2.0-beta2-build3300" />
-    <Usage Id="xunit.runner.utility" Version="2.3.1" />
-    <Usage Id="xunit.runner.visualstudio" Version="2.3.0" />
-    <Usage Id="xunit.runner.visualstudio" Version="2.3.1" />
   </Usages>
 </UsageData>

--- a/tools-local/prebuilt-baseline-online.xml
+++ b/tools-local/prebuilt-baseline-online.xml
@@ -31,17 +31,12 @@
     <Dir></Dir>
   </ProjectDirectories>
   <Usages>
-    <Usage Id="CommandLineParser" Version="2.1.1-beta" />
-    <Usage Id="coveralls.io" Version="1.4" />
-    <Usage Id="FluentAssertions" Version="4.19.0" />
-    <Usage Id="FluentAssertions.Json" Version="4.19.0" />
     <Usage Id="fmdev.ResX" Version="0.2.0" />
     <Usage Id="fmdev.xlftool" Version="0.1.3" />
     <Usage Id="fmdev.XliffParser" Version="0.5.3" />
     <Usage Id="FSharp.Core" Version="4.5.2" />
     <Usage Id="Libuv" Version="1.9.1" />
     <Usage Id="MicroBuild.Core" Version="0.2.0" />
-    <Usage Id="Microsoft.3rdpartytools.MarkdownLog" Version="0.10.0-alpha-experimental" />
     <Usage Id="Microsoft.Build" Version="14.3.0" />
     <Usage Id="Microsoft.Build" Version="15.1.548" />
     <Usage Id="Microsoft.Build" Version="15.3.409" />
@@ -80,29 +75,23 @@
     <Usage Id="Microsoft.CodeAnalysis.CSharp" Version="2.6.0-beta3-62316-02" />
     <Usage Id="Microsoft.CodeAnalysis.VisualBasic" Version="1.3.0" />
     <Usage Id="Microsoft.CodeAnalysis.VisualBasic" Version="2.6.0-beta3-62316-02" />
-    <Usage Id="Microsoft.CodeCoverage" Version="1.0.3" />
     <Usage Id="Microsoft.CSharp" Version="4.0.1" />
     <Usage Id="Microsoft.CSharp" Version="4.3.0" />
     <Usage Id="Microsoft.Data.Edm" Version="5.6.4" />
     <Usage Id="Microsoft.Data.OData" Version="5.6.4" />
     <Usage Id="Microsoft.Data.Services.Client" Version="5.6.4" />
     <Usage Id="Microsoft.Diagnostics.Tracing.EventSource.Redist" Version="1.1.16-beta" />
-    <Usage Id="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.5" />
     <Usage Id="Microsoft.DiaSymReader.Native" Version="1.4.1" />
-    <Usage Id="Microsoft.DiaSymReader.Native" Version="1.5.0" />
     <Usage Id="Microsoft.DiaSymReader.Native" Version="1.7.0" />
     <Usage Id="Microsoft.Docker.Sdk" Version="1.1.0" />
     <Usage Id="Microsoft.DotNet.Archive" Version="0.2.0-beta-63027-01" />
     <Usage Id="Microsoft.DotNet.Build.Tasks.Feed" Version="2.1.0-rc1-03130-05" />
     <Usage Id="Microsoft.DotNet.BuildTools" Version="2.1.0-rc1-03131-06" />
     <Usage Id="Microsoft.DotNet.BuildTools.CoreCLR" Version="1.0.4-prerelease" />
-    <Usage Id="Microsoft.DotNet.BuildTools.TestSuite" Version="2.1.0-rc1-03131-06" />
     <Usage Id="Microsoft.DotNet.Cli.CommandLine" Version="0.1.1-alpha-167" />
     <Usage Id="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
-    <Usage Id="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
     <Usage Id="Microsoft.DotNet.PlatformAbstractions" Version="1.0.3" />
     <Usage Id="Microsoft.DotNet.PlatformAbstractions" Version="2.0.0" />
-    <Usage Id="Microsoft.DotNet.PlatformAbstractions" Version="2.0.4" />
     <Usage Id="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0-preview2-26306-03" />
     <Usage Id="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4-20181009-2100240" />
     <Usage Id="Microsoft.DotNet.VersionTools" Version="2.1.0-rc1-03130-05" />
@@ -110,7 +99,6 @@
     <Usage Id="Microsoft.DotNet.Web.ProjectTemplates.2.1" Version="2.1.6" />
     <Usage Id="Microsoft.DotNet.Web.Spa.ProjectTemplates" Version="2.1.6" />
     <Usage Id="Microsoft.Extensions.CommandLineUtils" Version="1.1.0" />
-    <Usage Id="Microsoft.Extensions.DependencyModel" Version="1.0.0" />
     <Usage Id="Microsoft.Extensions.DependencyModel" Version="1.0.3" />
     <Usage Id="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
     <Usage Id="Microsoft.Extensions.DependencyModel" Version="2.1.0-preview2-26306-03" />
@@ -120,9 +108,6 @@
     <Usage Id="Microsoft.Net.Compilers" Version="2.8.0-beta4-62824-10" />
     <Usage Id="Microsoft.Net.Compilers.netcore" Version="2.6.0-beta3-62316-02" />
     <Usage Id="Microsoft.Net.Compilers.Targets.NetCore" Version="0.1.5-dev" />
-    <Usage Id="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <Usage Id="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <Usage Id="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <Usage Id="Microsoft.NETCore.App" Version="1.0.3" />
     <Usage Id="Microsoft.NETCore.App" Version="1.0.5" />
     <Usage Id="Microsoft.NETCore.App" Version="1.1.1" />
@@ -186,12 +171,6 @@
     <Usage Id="Microsoft.TargetingPack.NETFramework.v4.6" Version="1.0.1" />
     <Usage Id="Microsoft.TargetingPack.NETFramework.v4.6.1" Version="1.0.1" />
     <Usage Id="Microsoft.TemplateEngine.Cli.Localization" Version="1.0.2-beta3" />
-    <Usage Id="Microsoft.TestPlatform.ObjectModel" Version="15.0.0" />
-    <Usage Id="Microsoft.TestPlatform.ObjectModel" Version="15.3.0" />
-    <Usage Id="Microsoft.TestPlatform.ObjectModel" Version="15.6.0" />
-    <Usage Id="Microsoft.TestPlatform.TestHost" Version="15.0.0" />
-    <Usage Id="Microsoft.TestPlatform.TestHost" Version="15.3.0" />
-    <Usage Id="Microsoft.TestPlatform.TestHost" Version="15.6.0" />
     <Usage Id="Microsoft.VisualBasic" Version="10.0.1" />
     <Usage Id="Microsoft.VisualBasic" Version="10.1.0" />
     <Usage Id="Microsoft.VisualStudio.QualityTools" Version="15.6.0-preview-1270639" />
@@ -207,7 +186,6 @@
     <Usage Id="Microsoft.Win32.Primitives" Version="4.3.0" />
     <Usage Id="Microsoft.Win32.Registry" Version="4.0.0" />
     <Usage Id="Microsoft.Win32.Registry" Version="4.3.0" />
-    <Usage Id="Microsoft.xunit.netcore.extensions" Version="2.1.0-rc1-03131-06" />
     <Usage Id="NETStandard.Library" Version="1.6.0" />
     <Usage Id="NETStandard.Library" Version="1.6.1" />
     <Usage Id="NETStandard.Library" Version="2.0.0" />
@@ -243,12 +221,10 @@
     <Usage Id="NuGet.Versioning" Version="4.3.0-preview2-4095" />
     <Usage Id="NuGet.Versioning" Version="4.7.0-preview1-4992" />
     <Usage Id="NUnit3.DotNetNew.Template" Version="1.5.3" />
-    <Usage Id="OpenCover" Version="4.6.519" />
     <Usage Id="optimization.linux-x64.PGO.CoreCLR" Version="2.1.0-release-20180815-0105" />
     <Usage Id="optimization.PGO.CoreCLR" Version="2.1.0-release-20180815-0105" />
     <Usage Id="optimization.windows_nt-x64.PGO.CoreCLR" Version="2.1.0-release-20180815-0105" />
     <Usage Id="optimization.windows_nt-x86.PGO.CoreCLR" Version="2.1.0-release-20180815-0105" />
-    <Usage Id="ReportGenerator" Version="3.0.1" />
     <Usage Id="RoslynTools.RepoToolset" Version="1.0.0-beta2-62805-03" />
     <Usage Id="runtime.any.System.Collections" Version="4.0.11" Rid="any" />
     <Usage Id="runtime.any.System.Collections" Version="4.3.0" Rid="any" />
@@ -405,7 +381,6 @@
     <Usage Id="System.Buffers" Version="4.0.0" />
     <Usage Id="System.Buffers" Version="4.3.0" />
     <Usage Id="System.CodeDom" Version="4.4.0" />
-    <Usage Id="System.Collections" Version="4.0.11-rc2-24027" />
     <Usage Id="System.Collections" Version="4.0.11" />
     <Usage Id="System.Collections" Version="4.3.0" />
     <Usage Id="System.Collections.Concurrent" Version="4.0.12" />
@@ -424,7 +399,6 @@
     <Usage Id="System.ComponentModel.Annotations" Version="4.1.0" />
     <Usage Id="System.ComponentModel.Annotations" Version="4.3.0" />
     <Usage Id="System.ComponentModel.EventBasedAsync" Version="4.0.11" />
-    <Usage Id="System.ComponentModel.EventBasedAsync" Version="4.3.0" />
     <Usage Id="System.ComponentModel.Primitives" Version="4.1.0" />
     <Usage Id="System.ComponentModel.Primitives" Version="4.3.0" />
     <Usage Id="System.ComponentModel.TypeConverter" Version="4.1.0" />
@@ -435,11 +409,9 @@
     <Usage Id="System.Composition.Hosting" Version="1.1.0" />
     <Usage Id="System.Composition.Runtime" Version="1.1.0" />
     <Usage Id="System.Composition.TypedParts" Version="1.1.0" />
-    <Usage Id="System.Console" Version="4.0.0-rc2-24027" />
     <Usage Id="System.Console" Version="4.0.0" />
     <Usage Id="System.Console" Version="4.3.0" />
     <Usage Id="System.Diagnostics.Contracts" Version="4.0.1" />
-    <Usage Id="System.Diagnostics.Debug" Version="4.0.11-rc2-24027" />
     <Usage Id="System.Diagnostics.Debug" Version="4.0.11" />
     <Usage Id="System.Diagnostics.Debug" Version="4.3.0" />
     <Usage Id="System.Diagnostics.DiagnosticSource" Version="4.0.0" />
@@ -454,29 +426,24 @@
     <Usage Id="System.Diagnostics.StackTrace" Version="4.3.0" />
     <Usage Id="System.Diagnostics.TextWriterTraceListener" Version="4.0.0" />
     <Usage Id="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />
-    <Usage Id="System.Diagnostics.Tools" Version="4.0.1-rc2-24027" />
     <Usage Id="System.Diagnostics.Tools" Version="4.0.1" />
     <Usage Id="System.Diagnostics.Tools" Version="4.3.0" />
     <Usage Id="System.Diagnostics.TraceSource" Version="4.0.0" />
     <Usage Id="System.Diagnostics.TraceSource" Version="4.3.0" />
     <Usage Id="System.Diagnostics.Tracing" Version="4.1.0" />
     <Usage Id="System.Diagnostics.Tracing" Version="4.3.0" />
-    <Usage Id="System.Drawing.Common.TestData" Version="1.0.7" />
     <Usage Id="System.Dynamic.Runtime" Version="4.0.11" />
     <Usage Id="System.Dynamic.Runtime" Version="4.3.0" />
-    <Usage Id="System.Globalization" Version="4.0.11-rc2-24027" />
     <Usage Id="System.Globalization" Version="4.0.11" />
     <Usage Id="System.Globalization" Version="4.3.0" />
     <Usage Id="System.Globalization.Calendars" Version="4.0.1" />
     <Usage Id="System.Globalization.Calendars" Version="4.3.0" />
     <Usage Id="System.Globalization.Extensions" Version="4.0.1" />
     <Usage Id="System.Globalization.Extensions" Version="4.3.0" />
-    <Usage Id="System.IO" Version="4.1.0-rc2-24027" />
     <Usage Id="System.IO" Version="4.1.0" />
     <Usage Id="System.IO" Version="4.3.0" />
     <Usage Id="System.IO.Compression" Version="4.1.0" />
     <Usage Id="System.IO.Compression" Version="4.3.0" />
-    <Usage Id="System.IO.Compression.TestData" Version="1.0.6-prerelease" />
     <Usage Id="System.IO.Compression.ZipFile" Version="4.0.1" />
     <Usage Id="System.IO.Compression.ZipFile" Version="4.3.0" />
     <Usage Id="System.IO.FileSystem" Version="4.0.1" />
@@ -487,16 +454,13 @@
     <Usage Id="System.IO.FileSystem.Watcher" Version="4.3.0" />
     <Usage Id="System.IO.MemoryMappedFiles" Version="4.0.0" />
     <Usage Id="System.IO.MemoryMappedFiles" Version="4.3.0" />
-    <Usage Id="System.IO.Packaging.TestData" Version="1.0.0-prerelease" />
     <Usage Id="System.IO.Pipes" Version="4.0.0" />
     <Usage Id="System.IO.Pipes" Version="4.3.0" />
     <Usage Id="System.IO.Pipes.AccessControl" Version="4.3.0" />
     <Usage Id="System.IO.UnmanagedMemoryStream" Version="4.0.1" />
     <Usage Id="System.IO.UnmanagedMemoryStream" Version="4.3.0" />
-    <Usage Id="System.Linq" Version="4.1.0-rc2-24027" />
     <Usage Id="System.Linq" Version="4.1.0" />
     <Usage Id="System.Linq" Version="4.3.0" />
-    <Usage Id="System.Linq.Expressions" Version="4.0.11-rc2-24027" />
     <Usage Id="System.Linq.Expressions" Version="4.1.0" />
     <Usage Id="System.Linq.Expressions" Version="4.1.1" />
     <Usage Id="System.Linq.Expressions" Version="4.3.0" />
@@ -522,33 +486,26 @@
     <Usage Id="System.Net.Security" Version="4.3.1" />
     <Usage Id="System.Net.Sockets" Version="4.1.0" />
     <Usage Id="System.Net.Sockets" Version="4.3.0" />
-    <Usage Id="System.Net.TestData" Version="1.0.0-prerelease" />
     <Usage Id="System.Net.WebHeaderCollection" Version="4.0.1" />
     <Usage Id="System.Net.WebHeaderCollection" Version="4.3.0" />
     <Usage Id="System.Numerics.Vectors" Version="4.1.1" />
     <Usage Id="System.Numerics.Vectors" Version="4.3.0" />
-    <Usage Id="System.ObjectModel" Version="4.0.12-rc2-24027" />
     <Usage Id="System.ObjectModel" Version="4.0.12" />
     <Usage Id="System.ObjectModel" Version="4.3.0" />
     <Usage Id="System.Private.DataContractSerialization" Version="4.1.1" />
     <Usage Id="System.Private.DataContractSerialization" Version="4.3.0" />
     <Usage Id="System.Private.Uri" Version="4.0.1" />
     <Usage Id="System.Private.Uri" Version="4.3.0" />
-    <Usage Id="System.Reflection" Version="4.1.0-rc2-24027" />
     <Usage Id="System.Reflection" Version="4.1.0" />
     <Usage Id="System.Reflection" Version="4.3.0" />
     <Usage Id="System.Reflection.DispatchProxy" Version="4.0.1" />
     <Usage Id="System.Reflection.DispatchProxy" Version="4.3.0" />
-    <Usage Id="System.Reflection.Emit" Version="4.0.1-rc2-24027" />
     <Usage Id="System.Reflection.Emit" Version="4.0.1" />
     <Usage Id="System.Reflection.Emit" Version="4.3.0" />
-    <Usage Id="System.Reflection.Emit.ILGeneration" Version="4.0.1-rc2-24027" />
     <Usage Id="System.Reflection.Emit.ILGeneration" Version="4.0.1" />
     <Usage Id="System.Reflection.Emit.ILGeneration" Version="4.3.0" />
-    <Usage Id="System.Reflection.Emit.Lightweight" Version="4.0.1-rc2-24027" />
     <Usage Id="System.Reflection.Emit.Lightweight" Version="4.0.1" />
     <Usage Id="System.Reflection.Emit.Lightweight" Version="4.3.0" />
-    <Usage Id="System.Reflection.Extensions" Version="4.0.1-rc2-24027" />
     <Usage Id="System.Reflection.Extensions" Version="4.0.1" />
     <Usage Id="System.Reflection.Extensions" Version="4.3.0" />
     <Usage Id="System.Reflection.Metadata" Version="1.3.0" />
@@ -556,22 +513,17 @@
     <Usage Id="System.Reflection.Metadata" Version="1.4.2" />
     <Usage Id="System.Reflection.Metadata" Version="1.5.0" />
     <Usage Id="System.Reflection.Metadata" Version="1.6.0" />
-    <Usage Id="System.Reflection.Primitives" Version="4.0.1-rc2-24027" />
     <Usage Id="System.Reflection.Primitives" Version="4.0.1" />
     <Usage Id="System.Reflection.Primitives" Version="4.3.0" />
-    <Usage Id="System.Reflection.TypeExtensions" Version="4.1.0-rc2-24027" />
     <Usage Id="System.Reflection.TypeExtensions" Version="4.1.0" />
     <Usage Id="System.Reflection.TypeExtensions" Version="4.3.0" />
     <Usage Id="System.Resources.Reader" Version="4.0.0" />
     <Usage Id="System.Resources.Reader" Version="4.3.0" />
-    <Usage Id="System.Resources.ResourceManager" Version="4.0.1-rc2-24027" />
     <Usage Id="System.Resources.ResourceManager" Version="4.0.1" />
     <Usage Id="System.Resources.ResourceManager" Version="4.3.0" />
     <Usage Id="System.Resources.Writer" Version="4.0.0" />
-    <Usage Id="System.Runtime" Version="4.1.0-rc2-24027" />
     <Usage Id="System.Runtime" Version="4.1.0" />
     <Usage Id="System.Runtime" Version="4.3.0" />
-    <Usage Id="System.Runtime.Extensions" Version="4.1.0-rc2-24027" />
     <Usage Id="System.Runtime.Extensions" Version="4.1.0" />
     <Usage Id="System.Runtime.Extensions" Version="4.3.0" />
     <Usage Id="System.Runtime.Handles" Version="4.0.1" />
@@ -586,7 +538,6 @@
     <Usage Id="System.Runtime.Numerics" Version="4.3.0" />
     <Usage Id="System.Runtime.Serialization.Formatters" Version="4.3.0" />
     <Usage Id="System.Runtime.Serialization.Json" Version="4.0.2" />
-    <Usage Id="System.Runtime.Serialization.Json" Version="4.3.0" />
     <Usage Id="System.Runtime.Serialization.Primitives" Version="4.1.1" />
     <Usage Id="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <Usage Id="System.Runtime.Serialization.Xml" Version="4.1.1" />
@@ -609,13 +560,11 @@
     <Usage Id="System.Security.Cryptography.ProtectedData" Version="4.3.0" />
     <Usage Id="System.Security.Cryptography.X509Certificates" Version="4.1.0" />
     <Usage Id="System.Security.Cryptography.X509Certificates" Version="4.3.0" />
-    <Usage Id="System.Security.Cryptography.X509Certificates.TestData" Version="1.0.2-prerelease" />
     <Usage Id="System.Security.Principal" Version="4.0.1" />
     <Usage Id="System.Security.Principal" Version="4.3.0" />
     <Usage Id="System.Security.Principal.Windows" Version="4.0.0" />
     <Usage Id="System.Security.Principal.Windows" Version="4.3.0" />
     <Usage Id="System.Spatial" Version="5.6.4" />
-    <Usage Id="System.Text.Encoding" Version="4.0.11-rc2-24027" />
     <Usage Id="System.Text.Encoding" Version="4.0.11" />
     <Usage Id="System.Text.Encoding" Version="4.3.0" />
     <Usage Id="System.Text.Encoding.CodePages" Version="4.0.1" />
@@ -625,13 +574,10 @@
     <Usage Id="System.Text.Encoding.Extensions" Version="4.3.0" />
     <Usage Id="System.Text.RegularExpressions" Version="4.1.0" />
     <Usage Id="System.Text.RegularExpressions" Version="4.3.0" />
-    <Usage Id="System.Text.RegularExpressions.TestData" Version="1.0.2" />
-    <Usage Id="System.Threading" Version="4.0.11-rc2-24027" />
     <Usage Id="System.Threading" Version="4.0.11" />
     <Usage Id="System.Threading" Version="4.3.0" />
     <Usage Id="System.Threading.Overlapped" Version="4.0.1" />
     <Usage Id="System.Threading.Overlapped" Version="4.3.0" />
-    <Usage Id="System.Threading.Tasks" Version="4.0.11-rc2-24027" />
     <Usage Id="System.Threading.Tasks" Version="4.0.11" />
     <Usage Id="System.Threading.Tasks" Version="4.3.0" />
     <Usage Id="System.Threading.Tasks.Dataflow" Version="4.6.0" />
@@ -647,7 +593,6 @@
     <Usage Id="System.Threading.Timer" Version="4.0.1" />
     <Usage Id="System.Threading.Timer" Version="4.3.0" />
     <Usage Id="System.ValueTuple" Version="4.3.0" />
-    <Usage Id="System.ValueTuple" Version="4.3.1" />
     <Usage Id="System.ValueTuple" Version="4.4.0" />
     <Usage Id="System.Xml.ReaderWriter" Version="4.0.11" />
     <Usage Id="System.Xml.ReaderWriter" Version="4.3.0" />
@@ -667,34 +612,5 @@
     <Usage Id="XliffTasks" Version="0.2.0-beta-000081" />
     <Usage Id="XliffTasks" Version="0.2.0-beta-62730-03" />
     <Usage Id="XliffTasks" Version="0.2.0-beta-63004-01" />
-    <Usage Id="xunit" Version="2.2.0-beta2-build3300" />
-    <Usage Id="xunit" Version="2.3.1" />
-    <Usage Id="xunit.abstractions" Version="2.0.1-rc2" />
-    <Usage Id="xunit.abstractions" Version="2.0.1" />
-    <Usage Id="xunit.analyzers" Version="0.7.0" />
-    <Usage Id="xunit.assert" Version="2.2.0-beta2-build3300" />
-    <Usage Id="xunit.assert" Version="2.3.0" />
-    <Usage Id="xunit.assert" Version="2.3.1" />
-    <Usage Id="xunit.console" Version="2.3.1" />
-    <Usage Id="xunit.console.netcore" Version="1.0.3-prerelease-00921-01" />
-    <Usage Id="xunit.core" Version="2.2.0-beta2-build3300" />
-    <Usage Id="xunit.core" Version="2.3.0" />
-    <Usage Id="xunit.core" Version="2.3.1" />
-    <Usage Id="xunit.extensibility.core" Version="2.2.0-beta2-build3300" />
-    <Usage Id="xunit.extensibility.core" Version="2.3.0" />
-    <Usage Id="xunit.extensibility.core" Version="2.3.1" />
-    <Usage Id="xunit.extensibility.execution" Version="2.2.0-beta2-build3300" />
-    <Usage Id="xunit.extensibility.execution" Version="2.3.0" />
-    <Usage Id="xunit.extensibility.execution" Version="2.3.1" />
-    <Usage Id="xunit.performance.api" Version="1.0.0-beta-build0019" />
-    <Usage Id="xunit.performance.core" Version="1.0.0-beta-build0019" />
-    <Usage Id="xunit.performance.execution" Version="1.0.0-beta-build0019" />
-    <Usage Id="xunit.performance.metrics" Version="1.0.0-beta-build0019" />
-    <Usage Id="xunit.runner.console" Version="2.3.1" />
-    <Usage Id="xunit.runner.reporters" Version="2.3.1" />
-    <Usage Id="xunit.runner.utility" Version="2.2.0-beta2-build3300" />
-    <Usage Id="xunit.runner.utility" Version="2.3.1" />
-    <Usage Id="xunit.runner.visualstudio" Version="2.3.0" />
-    <Usage Id="xunit.runner.visualstudio" Version="2.3.1" />
   </Usages>
 </UsageData>


### PR DESCRIPTION
* Patch CoreFX to exclude test-related project depending on XUnit.Runtime dependency project.
  * https://github.com/dotnet/corefx/pull/33217
* Patch Common and WebSDK to use the roslyn-tools "empty target override" approach to avoid test project restore.
  * https://github.com/aspnet/Extensions/pull/445 (Common)
  * https://github.com/aspnet/websdk/pull/421
* Patch SDK to add `ExcludeFromSourceBuild=true` to test projects.
  * https://github.com/dotnet/sdk/pull/2642
* Add Templating build arg that overrides `SharedTestProjects` to empty to avoid restoring the shared test project's dependencies.
  * Not a patch, no action needed by repo.
* Update prebuilt baselines.

In a full build I did, there are no `TestProjectOnlyByHeuristic` elements left in the tarball's `annotated-usage.xml` with these changes. (There are still `TestProjectByHeuristic` elements, which will require more investigation.)

I'm planning to get PR's/issues opened to link from the patches before merging this PR.

https://github.com/dotnet/source-build/issues/731