### PR TITLE
Remove prebuilt usages classified as tests

### DIFF
--- a/patches/templating/0001-Skip-test-related-projects-if-PB_SkipTests-set.patch
+++ b/patches/templating/0001-Skip-test-related-projects-if-PB_SkipTests-set.patch
@@ -1,0 +1,36 @@
+From 5019f96deaebf22f2f7883c2ee16b0d6839ffaa4 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Tue, 6 Nov 2018 12:43:44 -0600
+Subject: [PATCH] Skip test-related projects if PB_SkipTests set
+
+Setting SharedTestProjects='' worked, but that approach is more difficult with
+OuterRingProjects where a semicolon-delimited string would need to be passed.
+Instead, patch PB_SkipTests handling to be more extensive.
+---
+ build.proj | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/build.proj b/build.proj
+index 0870ec97..b923f863 100644
+--- a/build.proj
++++ b/build.proj
+@@ -40,10 +40,14 @@
+     <OuterRingProjects>
+         src/Microsoft.TemplateEngine.Edge/Microsoft.TemplateEngine.Edge.csproj;
+         src/Microsoft.TemplateEngine.IDE/Microsoft.TemplateEngine.IDE.csproj;
+-        test/Microsoft.TemplateEngine.Mocks/Microsoft.TemplateEngine.Mocks.csproj
+     </OuterRingProjects>
+ 
+-    <SharedTestProjects>
++    <OuterRingProjects Condition="'$(PB_SkipTests)' != 'true'">
++        $(OuterRingProjects)
++        test/Microsoft.TemplateEngine.Mocks/Microsoft.TemplateEngine.Mocks.csproj;
++    </OuterRingProjects>
++
++    <SharedTestProjects Condition="'$(PB_SkipTests)' != 'true'">
+         test/Microsoft.TemplateEngine.TestHelper/Microsoft.TemplateEngine.TestHelper.csproj
+     </SharedTestProjects>
+ 
+-- 
+2.17.1.windows.2
+

--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -453,6 +453,7 @@
       BaselineDataFile="$(BaselineDataFile)"
       OutputBaselineFile="$(PackageReportDir)generated-new-baseline.xml"
       OutputReportFile="$(PackageReportDir)baseline-comparison.xml"
+      AllowTestProjectUsage="$(AllowTestProjectUsage)"
       ContinueOnError="$(ContinueOnPrebuiltBaselineError)" />
   </Target>
 

--- a/repos/templating.proj
+++ b/repos/templating.proj
@@ -18,8 +18,7 @@
     <MSBuildProperties Include="BUILD_NUMBER=$(BuildNumber)" />
     <MSBuildProperties Include="PackageDateTime=$(PackageDateTime)" />
     <MSBuildProperties Include="PackageBuildQuality=$(PackageBuildQuality)" />
-    <!-- Force SharedTestProjects to be unset, so they aren't restored/built. -->
-    <MSBuildProperties Include="SharedTestProjects=" />
+    <MSBuildProperties Include="PB_SKIPTESTS=true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/WritePackageUsageData.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/WritePackageUsageData.cs
@@ -140,8 +140,8 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
 
             string[] assetFiles = Directory
                 .GetFiles(RootDir, "project.assets.json", SearchOption.AllDirectories)
-                .Select(path => path.Substring(RootDir.Length))
                 .Except(IgnoredProjectAssetsJsonFiles.NullAsEmpty())
+                .Select(path => path.Substring(RootDir.Length))
                 .ToArray();
 
             if (!string.IsNullOrEmpty(ProjectAssetsJsonArchiveFile))


### PR DESCRIPTION
After these changes, a production+offline build that I did had no test heuristic attributes in `annotated-usage.xml` at all. I added a bit to baseline validation that will fail CI if any of these get back in. (And I guess it will make sure in this CI run that I did it right. 😄)

https://github.com/dotnet/source-build/issues/846