### PR TITLE
Add aspnet-razor dotnet/standard dependency

### DIFF
--- a/repos/aspnet-razor.proj
+++ b/repos/aspnet-razor.proj
@@ -23,5 +23,9 @@
     <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
   </PropertyGroup>
 
+  <ItemGroup>
+    <RepositoryReference Include="standard" />
+  </ItemGroup>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
 </Project>

--- a/repos/known-good.proj
+++ b/repos/known-good.proj
@@ -12,7 +12,6 @@
 
     <!-- Tier 1 -->
     <RepositoryReference Include="application-insights" />
-    <RepositoryReference Include="aspnet-razor" />
     <RepositoryReference Include="common" />
     <RepositoryReference Include="netcorecli-fsc" />
     <RepositoryReference Include="newtonsoft-json" />
@@ -23,6 +22,7 @@
     <RepositoryReference Include="roslyn" />
 
     <!-- Tier 2 -->
+    <RepositoryReference Include="aspnet-razor" />
     <RepositoryReference Include="msbuild" />
     <RepositoryReference Include="nuget-client" />
     <RepositoryReference Include="websdk" />


### PR DESCRIPTION
When I added this repo to source-build, I didn't consider its dependencies. It turns out the text-only `Microsoft.NET.Sdk.Razor` package build has a dependency on `NETStandard.Library` `2.0.3`, which we source-build. In the production build, building it out of order pollutes the package cache with an online version.

This should fix the warning from https://github.com/dotnet/source-build/issues/857. (Local build hasn't completed yet to validate though.)