### PR TITLE
Use Hosted macOS pool, set up our own prereqs

### DIFF
--- a/.vsts.pipelines/jobs/ci-osx.yml
+++ b/.vsts.pipelines/jobs/ci-osx.yml
@@ -3,8 +3,7 @@ parameters:
   matrix:
     Production: {}
   pool:
-    name: DotNetCore-Mac
-    demands: Agent.OS -equals Darwin
+    name: Hosted macOS
 
 jobs:
 - job: ${{ parameters.job }}
@@ -35,6 +34,27 @@ jobs:
   - script: |
       ( set -o posix; set )
     displayName: Print all variables in environment
+
+  # Install native dependencies not present in hosted pool.
+  - script: |
+      setvariable() {
+        (
+          set +x
+          echo "Setting '$1' to '$2'"
+          echo "##vso[task.setvariable variable=$1;]$2"
+        )
+      }
+      set -x
+      # Based on https://github.com/sbomer/coreclr/blob/dc2fa1b96415f87d694e5b6e751e38ca6fbd09a1/unix-pipeline.yml#L36-L39
+      brew install icu4c openssl
+      brew link --force icu4c
+      # Follow https://github.com/dotnet/corefx/blob/master/Documentation/building/unix-instructions.md#user-content-macos
+      brew install cmake pkgconfig openssl
+      brew_openssl_paths=$(brew info openssl | cut -d ' ' -f 1 | grep '^/.*/openssl/')
+      # Use 'for' to get last/latest openssl install dir.
+      for openssl_path in $brew_openssl_paths; do :; done
+      setvariable OPENSSL_ROOT_DIR "$openssl_path"
+    displayName: Install native dependencies
 
   - template: ../steps/init-submodules-sh.yml
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/835

Parsing `brew info openssl` might be overkill (or even a bad idea?) but I'm hoping it will make us somewhat resilient to changes in how the hosted pool is set up.