### PR TITLE
Fix AzDO master CI: Pass "--no-restore" to smoke-test "dotnet new"

### DIFF
--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -133,6 +133,13 @@ function doCommand() {
 
     newArgs="new $proj -lang $lang"
 
+    # XXX temporary workaround XXX
+    # this is a temporary workaround before templates are updated to use netcoreapp3.0.
+    # see issue https://github.com/dotnet/source-build/issues/635 for more details.
+    # This part ensures packages won't fail to restore before we can edit the csproj.
+    newArgs="$newArgs --no-restore"
+    # XXX temporary workaround XXX
+
     while :; do
         if [ $# -le 0 ]; then
             break


### PR DESCRIPTION
In `master`, we have a workaround to replace `netcoreapp2.2` with `netcoreapp3.0`, and this happens between `dotnet new` and `dotnet restore`. `dotnet new` normally restores as part of project setup, before we have a chance to edit it, and that fails.

Jenkins ignores the error messages because we "hide" them in a log file, but the params AzDO uses doesn't and the `Exec` detects them. In theory we could change the parameters, but fixing the underlying problem means we're more likely to catch problems with smoke-test.

Copy the `# XXX temporary workaround XXX` surrounding comments from the other parts of the workaround.