### PR TITLE
Set IgnoreStandardErrorWarningFormat on Execs

### DIFF
--- a/repos/application-insights.proj
+++ b/repos/application-insights.proj
@@ -18,14 +18,17 @@
 
     <Exec Command="$(DotnetToolCommand) restore /bl:restore.binlog $(BuildCommandArgs)  "
           EnvironmentVariables="@(EnvironmentVariables)"
-          WorkingDirectory="$(ProjectDirectory)" />
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
 
     <Exec Command="$(DotnetToolCommand) build /bl:build.binlog $(BuildCommandArgs)"
           EnvironmentVariables="@(EnvironmentVariables)"
-          WorkingDirectory="$(ProjectDirectory)" />
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
 
     <Exec Command="$(DotnetToolCommand) pack /bl:pack.binlog $(BuildCommandArgs)"
           EnvironmentVariables="@(EnvironmentVariables)"
-          WorkingDirectory="$(ProjectDirectory)" />
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
   </Target>
 </Project>

--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -245,7 +245,10 @@
     <ItemGroup>
       <EnvironmentVariables Condition="'$(NUGET_PACKAGES)'!=''" Include="NUGET_PACKAGES=$(NUGET_PACKAGES)" />
     </ItemGroup>
-    <Exec Command="$(BuildCommand) $(RepoApiArgs) $(RedirectRepoOutputToLog)" WorkingDirectory="$(ProjectDirectory)" EnvironmentVariables="@(EnvironmentVariables)" />
+    <Exec Command="$(BuildCommand) $(RepoApiArgs) $(RedirectRepoOutputToLog)"
+          WorkingDirectory="$(ProjectDirectory)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          IgnoreStandardErrorWarningFormat="true" />
   </Target>
 
   <Target Name="ReportRepoError">
@@ -261,7 +264,10 @@
     <Message Importance="High" Text="  Log: $(RepoConsoleLogFile)" />
     <Message Importance="High" Text="  With Environment Variables:" />
     <Message Importance="High" Text="    %(EnvironmentVariables.Identity)" />
-    <Exec Command="$(BuildPackagesCommand) $(RedirectRepoOutputToLog)" WorkingDirectory="$(ProjectDirectory)" EnvironmentVariables="@(EnvironmentVariables)" />
+    <Exec Command="$(BuildPackagesCommand) $(RedirectRepoOutputToLog)"
+          WorkingDirectory="$(ProjectDirectory)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          IgnoreStandardErrorWarningFormat="true" />
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Packaging $(ProjectBuildReason)...done" />
     <OnError ExecuteTargets="ReportRepoError" />
   </Target>
@@ -309,13 +315,10 @@
   </Target>
 
   <Target Name="Clean" Condition="'$(CleanCommand)' != ''" >
-    <Exec Command="$(CleanCommand) $(RedirectRepoOutputToLog)" WorkingDirectory="$(ProjectDirectory)" EnvironmentVariables="@(EnvironmentVariables)" />
-  </Target>
-
-  <Target Name="Update"
-          BeforeTargets="Build"
-          Condition="'$(DependencyVersionInputRepoApiImplemented)' != 'true' AND '$(UpdateCommand)' != ''">
-    <Exec Command="$(UpdateCommand) $(RedirectRepoOutputToLog)" WorkingDirectory="$(ProjectDirectory)" EnvironmentVariables="@(EnvironmentVariables)" />
+    <Exec Command="$(CleanCommand) $(RedirectRepoOutputToLog)"
+          WorkingDirectory="$(ProjectDirectory)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          IgnoreStandardErrorWarningFormat="true" />
   </Target>
 
   <Target Name="SetNuGetPackagesEnvironment" Condition="'$(ArchiveDownloadedPackages)' == 'true'">

--- a/repos/netcorecli-fsc.proj
+++ b/repos/netcorecli-fsc.proj
@@ -12,7 +12,8 @@
   <Target Name="Restore" BeforeTargets="Build" DependsOnTargets="UpdateNuGetConfig">
     <Exec Command="$(DotnetToolCommand) restore FSharp.NET.Sdk.csproj $(OutputArgs) $(RedirectRepoOutputToLog)"
           WorkingDirectory="$(ProjectDirectory)"
-          EnvironmentVariables="@(EnvironmentVariables)" />
+          EnvironmentVariables="@(EnvironmentVariables)"
+          IgnoreStandardErrorWarningFormat="true" />
   </Target>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />

--- a/repos/newtonsoft-json.proj
+++ b/repos/newtonsoft-json.proj
@@ -19,7 +19,8 @@
   <Target Name="Restore" BeforeTargets="Build" DependsOnTargets="UpdateNuGetConfig">
     <Exec Command="$(DotnetToolCommand) restore $(NewtonsoftJsonProjectPath) $(DotnetToolCommandArguments) $(RedirectRepoOutputToLog)"
           WorkingDirectory="$(ProjectDirectory)"
-          EnvironmentVariables="@(EnvironmentVariables)" />
+          EnvironmentVariables="@(EnvironmentVariables)"
+          IgnoreStandardErrorWarningFormat="true" />
   </Target>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />

--- a/repos/nuget-client.proj
+++ b/repos/nuget-client.proj
@@ -36,11 +36,13 @@
 
     <Exec Command="$(BuildCommandBase) /t:RestoreXPLAT /bl:restore.binlog $(RedirectRepoOutputToLog)"
           EnvironmentVariables="@(EnvironmentVariables)"
-          WorkingDirectory="$(ProjectDirectory)" />
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
 
     <Exec Command="$(BuildCommandBase) /t:BuildXPLAT /bl:build.binlog $(RedirectRepoOutputToLog)"
           EnvironmentVariables="@(EnvironmentVariables)"
-          WorkingDirectory="$(ProjectDirectory)" />
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
 
     <PropertyGroup>
       <PackCommand>$(BuildCommandBase) /t:PackXPlat</PackCommand>
@@ -53,7 +55,8 @@
 
     <Exec Command="$(PackCommand)"
           EnvironmentVariables="@(EnvironmentVariables)"
-          WorkingDirectory="$(ProjectDirectory)" />
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
   </Target>
 
   <Target Name="InitSubmodules" Condition="Exists('$(ProjectDirectory).git')">

--- a/repos/roslyn.proj
+++ b/repos/roslyn.proj
@@ -56,7 +56,8 @@
 
     <Exec Command="$(DotnetToolCommand) $(RestoreArgs)"
           WorkingDirectory="$(ProjectDirectory)"
-          EnvironmentVariables="@(EnvironmentVariables)" />
+          EnvironmentVariables="@(EnvironmentVariables)"
+          IgnoreStandardErrorWarningFormat="true" />
 
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Restoring 'roslyn'...done" />
   </Target>
@@ -90,7 +91,8 @@
 
     <Exec Command="$(DotnetToolCommand) $(PublishCommandArgs) %(PublishWithoutBuildingProject.Identity) $(RedirectRepoOutputToLog)"
           WorkingDirectory="$(ProjectDirectory)"
-          EnvironmentVariables="@(EnvironmentVariables)" />
+          EnvironmentVariables="@(EnvironmentVariables)"
+          IgnoreStandardErrorWarningFormat="true" />
 
     <PropertyGroup>
       <PackCommandArgs>pack --no-build</PackCommandArgs>
@@ -104,7 +106,8 @@
 
     <Exec Command="$(DotnetToolCommand) $(PackCommandArgs) -p:NuspecFile=%(NuSpecFiles.Identity) $(RedirectRepoOutputToLog)"
           WorkingDirectory="$(ProjectDirectory)"
-          EnvironmentVariables="@(EnvironmentVariables)" />
+          EnvironmentVariables="@(EnvironmentVariables)"
+          IgnoreStandardErrorWarningFormat="true" />
 
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Packaging 'roslyn'...done" />
   </Target>

--- a/repos/templating.proj
+++ b/repos/templating.proj
@@ -38,7 +38,8 @@
 
     <Exec Command="$(DotnetToolCommand) msbuild $(BuildCommandArgs)"
           WorkingDirectory="$(ProjectDirectory)"
-          EnvironmentVariables="@(EnvironmentVariables)" />
+          EnvironmentVariables="@(EnvironmentVariables)"
+          IgnoreStandardErrorWarningFormat="true" />
 
     <!-- The templates are built to a different folder than the packages, copy them into the packages folder. -->
     <ItemGroup>


### PR DESCRIPTION
> For every Exec that takes RedirectRepoOutputToLog, ignore standard error/warning format. If it isn't ignored, there might be problems that are ignored by redirecting to the logs that aren't ignored if redirecting is turned off. Configure Exec not to detect these at all to behave the same whether redirecting or not.

Should fix the type of problem seen in https://github.com/dotnet/source-build/issues/854 with `/p:MinimalConsoleLogOutput=false`. I was able to repro on `release/2.2`, merge this PR into 2.2, (clean,) then run successfully.