### PR TITLE
Add IsDirectDependency and IsAutoReferenced to usage report.

### DIFF
--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/AnnotatedUsage.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/AnnotatedUsage.cs
@@ -16,6 +16,8 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
         public bool EndsUpInOutput { get; set; }
         public bool TestProjectByHeuristic { get; set; }
         public bool TestProjectOnlyByHeuristic { get; set; }
+        public bool IsDirectDependency { get; set; }
+        public bool IsAutoReferenced { get; set; }
 
         public XElement ToXml() => new XElement(
             nameof(AnnotatedUsage),
@@ -25,6 +27,8 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
             ProdConPackageIdCreator.ToXAttributeIfNotNull(nameof(ProdConPackageIdCreator)),
             TestProjectByHeuristic.ToXAttributeIfTrue(nameof(TestProjectByHeuristic)),
             TestProjectOnlyByHeuristic.ToXAttributeIfTrue(nameof(TestProjectOnlyByHeuristic)),
+            IsDirectDependency.ToXAttributeIfTrue(nameof(IsDirectDependency)),
+            IsAutoReferenced.ToXAttributeIfTrue(nameof(IsAutoReferenced)),
             EndsUpInOutput.ToXAttributeIfTrue(nameof(EndsUpInOutput)));
     }
 }

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/Usage.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/Usage.cs
@@ -16,6 +16,10 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
 
         public string AssetsFile { get; set; }
 
+        public bool IsDirectDependency { get; set; }
+
+        public bool IsAutoReferenced { get; set; }
+
         /// <summary>
         /// The Runtime ID this package is for, or null. Runtime packages (are assumed to) have the
         /// id 'runtime.{rid}.{rest of id}'. We can't use a simple regex to grab this value since
@@ -28,6 +32,8 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
             nameof(Usage),
             PackageIdentity.ToXElement().Attributes(),
             AssetsFile.ToXAttributeIfNotNull("File"),
+            IsDirectDependency.ToXAttributeIfTrue(nameof(IsDirectDependency)),
+            IsAutoReferenced.ToXAttributeIfTrue(nameof(IsAutoReferenced)),
             RuntimePackageRid.ToXAttributeIfNotNull("Rid"));
 
         public static Usage Parse(XElement xml) => new Usage
@@ -40,12 +46,16 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
         public static Usage Create(
             string assetsFile,
             PackageIdentity identity,
+            bool isDirectDependency,
+            bool isAutoReferenced,
             IEnumerable<string> possibleRuntimePackageRids)
         {
             return new Usage
             {
                 AssetsFile = assetsFile,
                 PackageIdentity = identity,
+                IsDirectDependency = isDirectDependency,
+                IsAutoReferenced = isAutoReferenced,
                 RuntimePackageRid = possibleRuntimePackageRids
                     .Where(rid => identity.Id.StartsWith($"runtime.{rid}.", StringComparison.Ordinal))
                     .OrderByDescending(rid => rid.Length)

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/Usage.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/Usage.cs
@@ -40,6 +40,8 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
         {
             PackageIdentity = XmlParsingHelpers.ParsePackageIdentity(xml),
             AssetsFile = xml.Attribute("File")?.Value,
+            IsDirectDependency = Convert.ToBoolean(xml.Attribute(nameof(IsDirectDependency))?.Value),
+            IsAutoReferenced = Convert.ToBoolean(xml.Attribute(nameof(IsAutoReferenced))?.Value),
             RuntimePackageRid = xml.Attribute("Rid")?.Value
         };
 

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/WritePackageUsageData.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/WritePackageUsageData.cs
@@ -190,18 +190,18 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
                     }
 
                     var properties = new HashSet<string>(
-                        jObj.SelectTokens("$.targets.*")?.Children()
+                        jObj.SelectTokens("$.targets.*").Children()
                             .Concat(jObj.SelectToken("$.libraries"))
                             .Select(t => ((JProperty)t).Name)
                             .Distinct(), 
                         StringComparer.OrdinalIgnoreCase);
 
-                    var directDependencies = jObj.SelectTokens("$.project.frameworks.*.dependencies")?.Children().Select(dep =>
+                    var directDependencies = jObj.SelectTokens("$.project.frameworks.*.dependencies").Children().Select(dep =>
                         new
                         {
-                            name = ((Newtonsoft.Json.Linq.JProperty)dep).Name,
+                            name = ((JProperty)dep).Name,
                             target = dep.SelectToken("$..target")?.ToString(),
-                            version = VersionRange.Parse(dep.SelectToken("$..version")?.ToString()), //dep.SelectToken("$..version")?.ToString().Replace("[", "").Replace(", )", ""),
+                            version = VersionRange.Parse(dep.SelectToken("$..version")?.ToString()),
                             autoReferenced = dep.SelectToken("$..autoReferenced")?.ToString() == "True",
                         })
                         .ToArray();


### PR DESCRIPTION
Add new properties IsDirectDependency and IsAutoReferenced from project.assets.json. 

IsDirectDependency means that the dependency shows up in the $.project.frameworks.<version>.dependencies section of the document.  IsAutoReferenced comes directly from the dependency. 