### PR TITLE
Add PublishPrebuiltReportData target to make rolling build prebuilt data available

### DIFF
--- a/.vsts.pipelines/jobs/ci-linux.yml
+++ b/.vsts.pipelines/jobs/ci-linux.yml
@@ -202,7 +202,7 @@ jobs:
   # Also publish per-build data to a unique location for future use.
   - template: ../steps/publish-prebuilt-data-sh.yml
     parameters:
-      relativeBlobPath: prebuilt-data/$(Build.SourceBranchName)/rolling/$(Build.SourceVersion)/$(Build.DefinitionName)/$(Build.BuildNumber)/$(artifactName)
+      relativeBlobPath: prebuilt-data/$(Build.SourceBranchName)/rolling/$(Build.SourceVersion)/$(Build.BuildNumber)/$(Build.DefinitionName)/$(artifactName)
 
   # Clean up (very large) working directory. root owner makes it difficult for others to remove.
   - script: $(docker.run) $(docker.root.map) $(imageName) bash -c 'rm -rf /root/sb'

--- a/.vsts.pipelines/jobs/ci-linux.yml
+++ b/.vsts.pipelines/jobs/ci-linux.yml
@@ -28,6 +28,7 @@ jobs:
     docker.tb.work: -w /tb
     dropDirectory: $(stagingDirectory)/drop
     imageName: ${{ parameters.imageName }}
+    prebuiltReportBlobPath: prebuilt-data/$(Build.SourceBranchName)/$(artifactName)
     rootDirectory: $(Build.SourcesDirectory)/..
     stagingDirectory: $(rootDirectory)/sb/staging
     tarballName: tarball_$(Build.BuildId)
@@ -194,6 +195,19 @@ jobs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/drop/tarball
       ArtifactName: Tarball $(artifactName)
       ArtifactType: Container
+
+  # Publish prebuilt report data to blob storage.
+  - script: |
+      set -x
+      $(docker.run) $(docker.src.map) $(docker.src.work) $(imageName) ./build.sh \
+        /t:PublishPrebuiltReportData \
+        '/p:RelativeBlobPath=$(prebuiltReportBlobPath)' \
+        /p:ContainerName=$(publish.blobStorage.container) \
+        /p:AzureAccountName=$(publish.blobStorage.account) \
+        /p:AzureAccessToken=$(publish.blobStorage.accessToken) \
+        /clp:v=D
+    displayName: Publish prebuilt report data
+    condition: and(succeeded(), ne(variables['publish.blobStorage.accessToken'], ''), eq(variables['sb.tarball'], true))
 
   # Clean up (very large) working directory. root owner makes it difficult for others to remove.
   - script: $(docker.run) $(docker.root.map) $(imageName) bash -c 'rm -rf /root/sb'

--- a/.vsts.pipelines/jobs/ci-linux.yml
+++ b/.vsts.pipelines/jobs/ci-linux.yml
@@ -28,7 +28,6 @@ jobs:
     docker.tb.work: -w /tb
     dropDirectory: $(stagingDirectory)/drop
     imageName: ${{ parameters.imageName }}
-    prebuiltReportBlobPath: prebuilt-data/$(Build.SourceBranchName)/$(artifactName)
     rootDirectory: $(Build.SourcesDirectory)/..
     stagingDirectory: $(rootDirectory)/sb/staging
     tarballName: tarball_$(Build.BuildId)
@@ -197,17 +196,13 @@ jobs:
       ArtifactType: Container
 
   # Publish prebuilt report data to blob storage.
-  - script: |
-      set -x
-      $(docker.run) $(docker.src.map) $(docker.src.work) $(imageName) ./build.sh \
-        /t:PublishPrebuiltReportData \
-        '/p:RelativeBlobPath=$(prebuiltReportBlobPath)' \
-        /p:ContainerName=$(publish.blobStorage.container) \
-        /p:AzureAccountName=$(publish.blobStorage.account) \
-        /p:AzureAccessToken=$(publish.blobStorage.accessToken) \
-        /clp:v=D
-    displayName: Publish prebuilt report data
-    condition: and(succeeded(), ne(variables['publish.blobStorage.accessToken'], ''), eq(variables['sb.tarball'], true))
+  - template: ../steps/publish-prebuilt-data-sh.yml
+    parameters:
+      relativeBlobPath: prebuilt-data/$(Build.SourceBranchName)/latest/$(artifactName)
+  # Also publish per-build data to a unique location for future use.
+  - template: ../steps/publish-prebuilt-data-sh.yml
+    parameters:
+      relativeBlobPath: prebuilt-data/$(Build.SourceBranchName)/rolling/$(Build.SourceVersion)/$(Build.DefinitionName)/$(Build.BuildNumber)/$(artifactName)
 
   # Clean up (very large) working directory. root owner makes it difficult for others to remove.
   - script: $(docker.run) $(docker.root.map) $(imageName) bash -c 'rm -rf /root/sb'

--- a/.vsts.pipelines/steps/publish-prebuilt-data-sh.yml
+++ b/.vsts.pipelines/steps/publish-prebuilt-data-sh.yml
@@ -1,0 +1,19 @@
+parameters:
+  relativeBlobPath: ''
+
+steps:
+  - script: |
+      set -x
+      # Publish tarball's prebuilt data. Use ./build.sh from production build.
+      $(docker.run) $(docker.tb.map) $(docker.src.map) $(docker.src.work) $(imageName) ./build.sh \
+        /t:PublishPrebuiltReportData \
+        /p:ProjectDir=/tb/$(tarballName)/ \
+        "/p:RelativeBlobPath=$relativeBlobPath" \
+        /p:ContainerName=$(publish.blobStorage.container) \
+        /p:AzureAccountName=$(publish.blobStorage.account) \
+        /p:AzureAccessToken=$(publish.blobStorage.accessToken) \
+        /clp:v=D
+    displayName: ${{ format('Publish prebuilt report data ({0})', parameters.relativeBlobPath) }}
+    env:
+      relativeBlobPath: ${{ parameters.relativeBlobPath }}
+    condition: and(succeeded(), ne(variables['publish.blobStorage.accessToken'], ''), eq(variables['sb.tarball'], true))

--- a/build.proj
+++ b/build.proj
@@ -137,6 +137,30 @@
           EnvironmentVariables="prodConBlobFeedUrl=$(ProdConBlobFeedUrl)" />
   </Target>
 
+  <UsingTask AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.CloudTestTasks.dll" TaskName="UploadToAzure" />
+
+  <Target Name="PublishPrebuiltReportData">
+    <Error Text="RelativeBlobPath must be set to a non-empty string." Condition="'$(RelativeBlobPath)' == ''" />
+    <Error Text="ContainerName must be set to a non-empty string." Condition="'$(ContainerName)' == ''" />
+    <Error Text="AzureAccountName must be set to a non-empty string." Condition="'$(AzureAccountName)' == ''" />
+    <Error Text="AzureAccessToken must be set to a non-empty string." Condition="'$(AzureAccessToken)' == ''" />
+
+    <ItemGroup>
+      <ItemsToPublish Include="$(PackageReportDir)*.xml" />
+      <ItemsToPublish>
+        <RelativeBlobPath>$(RelativeBlobPath)/%(Filename)%(Extension)</RelativeBlobPath>
+      </ItemsToPublish>
+    </ItemGroup>
+
+    <Message Text="Uploading files to '$(AzureAccountName)' blob storage at $(ContainerName)/$(RelativeBlobPath)" />
+
+    <UploadToAzure AccountName="$(AzureAccountName)"
+                   AccountKey="$(AzureAccessToken)"
+                   ContainerName="$(ContainerName)"
+                   Items="@(ItemsToPublish)"
+                   Overwrite="true" />
+  </Target>
+
   <Import Project="$(ProjectDir)dependencies.targets" />
 
   <Import Project="$(ToolsDir)VersionTools.targets" />


### PR DESCRIPTION
Publishes the prebuilt report data for tarball builds to a blob storage location. Just needs the `publish.blobStorage.*` variables specified in the internal build def.

https://github.com/dotnet/source-build/issues/851