### PR TITLE
Improve source-built cache conflict warning

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,5 +26,5 @@ SDKPATH="$CLIPATH/sdk/$SDK_VERSION"
 
 set -x
 
-$CLIPATH/dotnet $SDKPATH/MSBuild.dll $SCRIPT_ROOT/build.proj /flp:v=diag /clp:v=m "$@"
+$CLIPATH/dotnet $SDKPATH/MSBuild.dll $SCRIPT_ROOT/build.proj /bl /flp:v=diag /clp:v=m "$@"
 

--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -189,8 +189,15 @@
       <Output TaskParameter="PackageInfoItems" ItemName="_PreviouslySourceBuiltPackageInfos" />
     </ReadNuGetPackageInfos>
 
+    <ItemGroup>
+      <_KnownOriginPackagePaths Include="$(PrebuiltSourceBuiltPackagesPath)*.nupkg" />
+      <_KnownOriginPackagePaths Include="$(PrebuiltPackagesPath)*.nupkg" />
+      <_KnownOriginPackagePaths Include="$(ReferencePackagesDir)*.nupkg" />
+    </ItemGroup>
+
     <GetSourceBuiltNupkgCacheConflicts SourceBuiltPackageInfos="@(_PreviouslySourceBuiltPackageInfos)"
-                                       PackageCacheDir="$(PackagesDir)">
+                                       PackageCacheDir="$(PackagesDir)"
+                                       KnownOriginPackagePaths="@(_KnownOriginPackagePaths)">
       <Output TaskParameter="ConflictingPackageInfos" ItemName="ConflictingPackageInfos" />
     </GetSourceBuiltNupkgCacheConflicts>
   </Target>
@@ -213,7 +220,8 @@
     <WriteUsageReports DataFile="$(_ReportDataFile)"
                        OutputDirectory="$(_ReportDir)" />
 
-    <Warning Text="Detected package id/version(s) in the cache that were source-built, but contents don't match. They were probably downloaded. See $(_ReportDir) for usage details. @(ConflictingPackageInfos->'%(PackageId) %(PackageVersion)', ', ')" />
+    <Warning Text="Detected packages in the cache that should be source-built, but contents don't match. See $(_ReportDir) for usage details:" />
+    <Warning Text="%(ConflictingPackageInfos.PackageId)/%(ConflictingPackageInfos.PackageVersion) : %(ConflictingPackageInfos.WarningMessage)" />
   </Target>
 
   <Target Name="CreateRestoreSourceProps"

--- a/support/tarball/build.sh
+++ b/support/tarball/build.sh
@@ -14,7 +14,7 @@ export NUGET_PACKAGES="$SCRIPT_ROOT/packages/"
 MSBUILD_ARGUMENTS=("/p:OfflineBuild=true" "/flp:v=detailed")
 
 echo "Rebuild reference assemblies"
-$CLI_ROOT/dotnet $CLI_ROOT/sdk/$CLI_VERSION/MSBuild.dll $SCRIPT_ROOT/tools-local/init-build.proj /t:BuildReferenceAssemblies ${MSBUILD_ARGUMENTS[@]} "$@"
+$CLI_ROOT/dotnet $CLI_ROOT/sdk/$CLI_VERSION/MSBuild.dll /bl:initBuildReferenceAssemblies.binlog $SCRIPT_ROOT/tools-local/init-build.proj /t:BuildReferenceAssemblies ${MSBUILD_ARGUMENTS[@]} "$@"
 
 echo "Expanding BuildTools dependencies into packages directory..."
 # init-tools tries to copy from its script directory to Tools, which in this case is a copy to
@@ -38,5 +38,5 @@ REF_PACKAGE_SOURCE="$SCRIPT_ROOT/reference-packages/packages"
     exit 1
 )
 
-$CLI_ROOT/dotnet $CLI_ROOT/sdk/$CLI_VERSION/MSBuild.dll $SCRIPT_ROOT/tools-local/init-build.proj /t:WriteDynamicPropsToStaticPropsFiles /p:GeneratingStaticPropertiesFile=true ${MSBUILD_ARGUMENTS[@]} "$@"
-$CLI_ROOT/dotnet $CLI_ROOT/sdk/$CLI_VERSION/MSBuild.dll $SCRIPT_ROOT/build.proj ${MSBUILD_ARGUMENTS[@]} "$@"
+$CLI_ROOT/dotnet $CLI_ROOT/sdk/$CLI_VERSION/MSBuild.dll /bl:initWriteDynamicPropsToStaticPropsFiles.binlog $SCRIPT_ROOT/tools-local/init-build.proj /t:WriteDynamicPropsToStaticPropsFiles /p:GeneratingStaticPropertiesFile=true ${MSBUILD_ARGUMENTS[@]} "$@"
+$CLI_ROOT/dotnet $CLI_ROOT/sdk/$CLI_VERSION/MSBuild.dll /bl:build.binlog $SCRIPT_ROOT/build.proj ${MSBUILD_ARGUMENTS[@]} "$@"


### PR DESCRIPTION
> Try to find where the conflicting package came from and include the path in the message.
> 
> For example, this identifies that Microsoft.NETCore.Targets in the tarball build is being used from prebuilt/source-built. Before this change, it would incorrectly suggest the package was restored from the internet.
> 
> Add source-build infrastructure MSBuild binlogging for better diagnosis.

https://github.com/dotnet/source-build/issues/792