### PR TITLE
Generate poison report (prebuilt leaks) on CentOS

### DIFF
--- a/.vsts.pipelines/builds/ci.yml
+++ b/.vsts.pipelines/builds/ci.yml
@@ -10,6 +10,7 @@ jobs:
   parameters:
     job: centos71
     imageName: microsoft/dotnet-buildtools-prereqs:centos-7-b46d863-20180719033416
+    reportPrebuiltLeaks: true
     matrix:
       Production: {}
       Online: { type: Online }

--- a/.vsts.pipelines/jobs/ci-linux.yml
+++ b/.vsts.pipelines/jobs/ci-linux.yml
@@ -5,6 +5,7 @@ parameters:
   pool:
     name: Hosted Ubuntu 1604
   imageName: null
+  reportPrebuiltLeaks: false
 
 jobs:
 - job: ${{ parameters.job }}
@@ -28,6 +29,7 @@ jobs:
     docker.tb.work: -w /tb
     dropDirectory: $(stagingDirectory)/drop
     imageName: ${{ parameters.imageName }}
+    reportPrebuiltLeaks: ${{ parameters.reportPrebuiltLeaks }}
     rootDirectory: $(Build.SourcesDirectory)/..
     stagingDirectory: $(rootDirectory)/sb/staging
     tarballName: tarball_$(Build.BuildId)
@@ -77,14 +79,19 @@ jobs:
         /p:Configuration=$(sb.configuration) \
         /p:ProdConBlobFeedUrlPrefix=$(prodConBlobFeedUrlPrefix)
     displayName: Run smoke-test
+    condition: and(succeeded(), ne(variables['sb.tarball'], true))
 
   # Create tarball.
   - script: |
       set -x
       df -h
+      args="--skip-build"
+      if [ "$(reportPrebuiltLeaks)" = "true" ]; then
+        args="$args --enable-leak-detection"
+      fi
       $(docker.run) $(docker.tb.map) $(docker.src.map) $(docker.src.work) $(imageName) ./build-source-tarball.sh \
         "/tb/$(tarballName)" \
-        --skip-build
+        $args
     displayName: Create tarball
     condition: and(succeeded(), eq(variables['sb.tarball'], true))
 
@@ -114,10 +121,15 @@ jobs:
       if [ "$(sb.tarballOffline)" = "true" ]; then
         networkArg="--network=none"
       fi
+      poisonArg=
+      if [ "$(sb.tarball)" != "true" ]; then
+        poisonArg="/p:EnablePoison=true"
+      fi
       $(docker.run) $(docker.tb.map) $(docker.tb.work) $networkArg $(imageName) "$(tarballName)/build.sh" \
         /p:Configuration=$(sb.configuration) \
         /p:PortableBuild=$(sb.portable) \
-        /p:FailOnPrebuiltBaselineError=true
+        /p:FailOnPrebuiltBaselineError=true \
+        $poisonArg
     displayName: Build tarball
     timeoutInMinutes: 120
     condition: and(succeeded(), eq(variables['sb.tarball'], true))

--- a/.vsts.pipelines/jobs/ci-linux.yml
+++ b/.vsts.pipelines/jobs/ci-linux.yml
@@ -70,7 +70,7 @@ jobs:
     displayName: Build source-build
     timeoutInMinutes: 120
 
-  # Run smoke tests.
+  # Run smoke tests. This is needed even in tarball legs to create the smoke-test-prereqs archive.
   - script: |
       set -x
       df -h
@@ -79,7 +79,6 @@ jobs:
         /p:Configuration=$(sb.configuration) \
         /p:ProdConBlobFeedUrlPrefix=$(prodConBlobFeedUrlPrefix)
     displayName: Run smoke-test
-    condition: and(succeeded(), ne(variables['sb.tarball'], true))
 
   # Create tarball.
   - script: |

--- a/.vsts.pipelines/jobs/ci-osx.yml
+++ b/.vsts.pipelines/jobs/ci-osx.yml
@@ -13,7 +13,7 @@ jobs:
   timeoutInMinutes: 240
   variables:
     # Prefix to distinguish artifacts from different legs.
-    artifactName: ${{ format('$(type) {0}', parameters.job) }}
+    artifactName: ${{ format('{0} $(type)', parameters.job) }}
     logsDirectory: $(Build.ArtifactStagingDirectory)/logs
     SOURCE_BUILD_SKIP_SUBMODULE_CHECK: true
     # Default type, can be overridden by matrix legs.


### PR DESCRIPTION
These were generated by Jenkins, but not by the AzDO builds so far. This adds them in on CentOS legs, similar to Jenkins. They will be picked up automatically by the rolling build publish infra because the poison report is a `xml` file alongside the other reports.

Also fixes the OSX artifact name, ~and removes the non-tarball smoke-test from tarball builds (because it's redundant vs. the Production legs' smoke-tests and delays the build by a bit)~.

https://github.com/dotnet/source-build/issues/851