### PR TITLE
Change where application-insights writes its output

### DIFF
--- a/repos/application-insights.proj
+++ b/repos/application-insights.proj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
-    <PackagesOutput>$(SubmoduleDirectory)/bin/$(Configuration)</PackagesOutput>
+    <PackagesOutput>$(ProjectDirectory)/bin/$(Configuration)</PackagesOutput>
     <RepoApiImplemented>false</RepoApiImplemented>
     <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
   </PropertyGroup>
@@ -13,6 +13,9 @@
     <PropertyGroup>
       <BuildCommandArgs>$(ProjectDirectory)/Microsoft.ApplicationInsights.csproj</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) /p:Configuration=$(Configuration)</BuildCommandArgs>
+      <!-- Re-assign EnlistmentRoot property so output directories end up under src/application-insights -->
+      <BuildCommandArgs>$(BuildCommandArgs) /p:EnlistmentRoot=$(ProjectDirectory)/src</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /p:RelativeOutputPathBase=</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) $(RedirectRepoOutputToLog)</BuildCommandArgs>
     </PropertyGroup>
 


### PR DESCRIPTION
App-insights places its output under a path one directory up from its source based on finding an EnlistmentRoot.marker file.  This puts this output right under the source-build/src directory.  Override the EnlistmentRoot property to place it under the source-build/src/application-insights directory.  

Also need to override the RelativeOutputPathBase property because it is calculated from the EnlistmentRoot property.  This is used to differentiate between outputs in app-insight's mapping scheme, but is not needed for source-build.