### PR TITLE
Install Python in Windows CI

### DIFF
--- a/.vsts.pipelines/jobs/ci-local.yml
+++ b/.vsts.pipelines/jobs/ci-local.yml
@@ -47,6 +47,7 @@ jobs:
     - template: ../steps/setup-macos-native.yml
   - ${{ if eq(parameters.setupWindows, true) }}:
     - template: ../steps/setup-windows-bash.yml
+    - template: ../steps/setup-windows-python.yml
 
   - template: ../steps/calculate-config-flags.yml
 

--- a/.vsts.pipelines/steps/setup-windows-python.yml
+++ b/.vsts.pipelines/steps/setup-windows-python.yml
@@ -23,6 +23,9 @@ steps:
     Add-Type -AssemblyName System.IO.Compression.FileSystem
     [System.IO.Compression.ZipFile]::ExtractToDirectory($pythonZip, $pythonDir)
 
+    # Work around https://bugs.python.org/issue34841 causing CoreCLR to fail on script dir import
+    rm "$pythonDir\python37._pth"
+
     echo "Adding $pythonDir to PATH as AzDO variable for python.exe..."
     $env:PATH = "$pythonDir;" + $env:PATH
     echo "##vso[task.setvariable variable=PATH;]$($env:PATH)"

--- a/.vsts.pipelines/steps/setup-windows-python.yml
+++ b/.vsts.pipelines/steps/setup-windows-python.yml
@@ -1,0 +1,29 @@
+# The dotnet-*-temp pools don't have Python installed in PATH. Install and set it up here.
+steps:
+- powershell: |
+    $url = 'https://www.python.org/ftp/python/3.7.1/python-3.7.1-embed-amd64.zip'
+    $checksum = 'C9E6FF79B0B9BAA948E3819334D70FDC9CE2B195DC4948C9D668334AB4FF244E'
+
+    echo "Creating Python bin dir to add to PATH..."
+    $pythonDir = "$(Build.ArtifactStagingDirectory)\python"
+    mkdir -f $pythonDir
+
+    echo "Downloading python from $url..."
+    $pythonZip = "$pythonDir\python.zip"
+    [Net.ServicePointManager]::SecurityProtocol =
+      [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+    Invoke-WebRequest $url -OutFile $pythonZip
+    $zipChecksum = (Get-FileHash $pythonZip -Algorithm SHA256).Hash
+
+    if ($zipChecksum -ne $checksum)
+    {
+      throw "Downloaded zip SHA256 checksum $zipChecksum doesn't match expected $checksum"
+    }
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($pythonZip, $pythonDir)
+
+    echo "Adding $pythonDir to PATH as AzDO variable for python.exe..."
+    $env:PATH = "$pythonDir;" + $env:PATH
+    echo "##vso[task.setvariable variable=PATH;]$($env:PATH)"
+  displayName: Set up Python


### PR DESCRIPTION
Currently, the CoreCLR build silently fails in 2.1 because it can't find Python. This was caught in the auto-merge to 2.2 where the CoreCLR build fails correctly/loudly. Fix this by installing `python` to a build-local location, similar to creating a `bash` to use.