### PR TITLE
Assert each build produces packages

### DIFF
--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -334,9 +334,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <_PackagesNotCreatedReason Include="^ Silent submodule build failure: check $(RepoConsoleLogFile)" />
-      <_PackagesNotCreatedReason Include="^ $(RepositoryName) doesn't build nuget packages: add SkipEnsurePackagesCreated=true property to $(MSBuildProjectFile)" />
-      <_PackagesNotCreatedReason Include="^ Identities already present in dirty 'bin' directory: perform clean build or check $(_PackageVersionPropsBackupPath)" />
+      <_PackagesNotCreatedReason Include="^ There may have been a silent failure in the submodule build. To confirm, check the build log file for undetected errors that may have prevented package creation: $(RepoConsoleLogFile)" />
+      <_PackagesNotCreatedReason Include="^ This error might be a false positive if $(RepositoryName) intentionally builds no nuget packages. If so, set the SkipEnsurePackagesCreated property to true in $(MSBuildProjectFullPath)" />
+      <_PackagesNotCreatedReason Include="^ The 'bin' directory might be dirty from a previous build and the package files already existed. If so, perform a clean build, or check which packages were already in 'bin' by opening $(_PackageVersionPropsBackupPath)" />
     </ItemGroup>
 
     <Error Condition="'@(JustSourceBuiltPackages)' == ''"

--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -166,26 +166,26 @@
 
   <Target Name="CreateBuildOutputProps"
           BeforeTargets="Build">
+    <PropertyGroup>
+      <_PackageVersionPropsBackupPath>$(PackageVersionPropsPath).pre.$(RepositoryName).xml</_PackageVersionPropsBackupPath>
+    </PropertyGroup>
+
     <ItemGroup>
-      <_PreviouslySourceBuiltPackages Include="$(SourceBuiltPackagesPath)*.nupkg"
+      <PreviouslySourceBuiltPackages Include="$(SourceBuiltPackagesPath)*.nupkg"
                                       Exclude="$(SourceBuiltPackagesPath)*.symbols.nupkg" />
     </ItemGroup>
-    <WriteBuildOutputProps NuGetPackages="@(_PreviouslySourceBuiltPackages)"
+
+    <WriteBuildOutputProps NuGetPackages="@(PreviouslySourceBuiltPackages)"
                            ExtraPackageInfo="@(ExtraPackageVersionPropsPackageInfo)"
                            OutputPath="$(PackageVersionPropsPath)" />
 
-    <WriteBuildOutputProps NuGetPackages="@(_PreviouslySourceBuiltPackages)"
+    <WriteBuildOutputProps NuGetPackages="@(PreviouslySourceBuiltPackages)"
                            IncludeCreationTimeProperty="true"
-                           OutputPath="$(PackageVersionPropsPath).pre.$(RepositoryName).xml" />
+                           OutputPath="$(_PackageVersionPropsBackupPath)" />
 
-    <ReadLinesFromFile File="$(PackageVersionPropsPath)">
-      <Output TaskParameter="Lines" ItemName="VersionProperties" />
-    </ReadLinesFromFile>
+    <Message Importance="High" Text="$(RepositoryName) using package version properties saved at $(_PackageVersionPropsBackupPath) " />
 
-    <Message Importance="High" Text="$(RepositoryName) is using versions $(PackageVersionPropsPath)" />
-    <Message Importance="High" Text="%(VersionProperties.Identity)" />
-
-    <ReadNuGetPackageInfos PackagePaths="@(_PreviouslySourceBuiltPackages)">
+    <ReadNuGetPackageInfos PackagePaths="@(PreviouslySourceBuiltPackages)">
       <Output TaskParameter="PackageInfoItems" ItemName="_PreviouslySourceBuiltPackageInfos" />
     </ReadNuGetPackageInfos>
 
@@ -320,6 +320,34 @@
     <ZipFileExtractToDirectory SourceArchive="@(_ToolPackage)"
                                DestinationDirectory="$(ToolPackageExtractDir)$(BuiltToolPackageId)\"
                                OverwriteDestination="true" />
+  </Target>
+
+  <Target Name="EnsurePackagesCreated"
+          AfterTargets="CopyPackage"
+          Condition="'$(SkipEnsurePackagesCreated)' != 'true'">
+    <ItemGroup>
+      <JustSourceBuiltPackages
+        Include="$(SourceBuiltPackagesPath)*.nupkg"
+        Exclude="
+          $(SourceBuiltPackagesPath)*.symbols.nupkg;
+          @(PreviouslySourceBuiltPackages)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <_PackagesNotCreatedReason Include="^ Silent submodule build failure: check $(RepoConsoleLogFile)" />
+      <_PackagesNotCreatedReason Include="^ $(RepositoryName) doesn't build nuget packages: add SkipEnsurePackagesCreated=true property to $(MSBuildProjectFile)" />
+      <_PackagesNotCreatedReason Include="^ Identities already present in dirty 'bin' directory: perform clean build or check $(_PackageVersionPropsBackupPath)" />
+    </ItemGroup>
+
+    <Error Condition="'@(JustSourceBuiltPackages)' == ''"
+           Text="$(RepositoryName) produced no new source-built package identities. Known possible causes:%0A@(_PackagesNotCreatedReason, '%0A')" />
+
+    <ReadNuGetPackageInfos PackagePaths="@(JustSourceBuiltPackages)">
+      <Output TaskParameter="PackageInfoItems" ItemName="_JustSourceBuiltPackageInfos" />
+    </ReadNuGetPackageInfos>
+
+    <Message Importance="High" Text="New NuGet package(s) after building $(RepositoryName):" />
+    <Message Importance="High" Text="  -> %(_JustSourceBuiltPackageInfos.PackageId) %(_JustSourceBuiltPackageInfos.PackageVersion)" />
   </Target>
 
   <Target Name="Clean" Condition="'$(CleanCommand)' != ''" >

--- a/repos/known-good.proj
+++ b/repos/known-good.proj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <RepoApiImplemented>false</RepoApiImplemented>
     <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>
+    <SkipEnsurePackagesCreated>true</SkipEnsurePackagesCreated>
   </PropertyGroup>
 
   <!-- This project file serves a couple of purpose.


### PR DESCRIPTION
> Detects new packages after each repo and prints a hopefully useful error if none were produced.
>
> As a side benefit, stop printing the entire package version props file before every single repo: instead, print the list of package identities each build produced.

The big benefit is catching silent failures in CI and local builds. There might still be a way for a silent failure to happen that leaves partial packages available--detailed baselining would fix this, but we would have to carefully maintain it (investigate whether a change is "real"). I don't see enough value to do that now.

Users who try to `git clone ; build ; [make changes]; build` (fine for normal repos, but we don't support incremental builds) will hit this error, so I tried to make the message actionable.

Example:

```
C:\git\source-build\repos\dir.targets(342,5): error : linker produced no new source-built package identities. Known possible causes: [C:\git\source-build\repos\linker.proj]
C:\git\source-build\repos\dir.targets(342,5): error : ^ There may have been a silent failure in the submodule build. To confirm, check the build log file for undetected errors that may have prevented package creation: C:\git\source-build\bin/logs/linker.log [C:\git\source-build\repos\linker.proj]
C:\git\source-build\repos\dir.targets(342,5): error : ^ This error might be a false positive if linker intentionally builds no nuget packages. If so, set the SkipEnsurePackagesCreated property to true in C:\git\source-build\repos\linker.proj [C:\git\source-build\repos\linker.proj]
C:\git\source-build\repos\dir.targets(342,5): error : ^ The 'bin' directory might be dirty from a previous build and the package files already existed. If so, perform a clean build, or check which packages were already in 'bin' by opening C:\git\source-build\bin/obj/x64/Release/PackageVersions.props.pre.linker.xml [C:\git\source-build\repos\linker.proj]
```

https://github.com/dotnet/source-build/issues/909