### PR TITLE
[release/2.1] Update prebuilt baselines: add IsDirectDependency

### DIFF
--- a/tools-local/prebuilt-baseline-offline.xml
+++ b/tools-local/prebuilt-baseline-offline.xml
@@ -39,39 +39,39 @@
   </NeverRestoredTarballPrebuilts>
   <Usages>
     <Usage Id="fmdev.ResX" Version="0.2.0" />
-    <Usage Id="fmdev.xlftool" Version="0.1.3" />
+    <Usage Id="fmdev.xlftool" Version="0.1.3" IsDirectDependency="true" />
     <Usage Id="fmdev.XliffParser" Version="0.5.3" />
-    <Usage Id="FSharp.Core" Version="4.5.2" />
+    <Usage Id="FSharp.Core" Version="4.5.2" IsDirectDependency="true" />
     <Usage Id="Libuv" Version="1.9.1" />
-    <Usage Id="Microsoft.Build" Version="14.3.0" />
+    <Usage Id="Microsoft.Build" Version="14.3.0" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build" Version="15.1.548" />
-    <Usage Id="Microsoft.Build" Version="15.3.409" />
-    <Usage Id="Microsoft.Build" Version="15.4.8" />
+    <Usage Id="Microsoft.Build" Version="15.3.409" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Build" Version="15.4.8" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build" Version="15.6.82" />
-    <Usage Id="Microsoft.Build" Version="15.7.0-preview-000143" />
+    <Usage Id="Microsoft.Build" Version="15.7.0-preview-000143" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build.Framework" Version="14.3.0" />
     <Usage Id="Microsoft.Build.Framework" Version="15.1.548" />
-    <Usage Id="Microsoft.Build.Framework" Version="15.1.1012" />
-    <Usage Id="Microsoft.Build.Framework" Version="15.3.409" />
+    <Usage Id="Microsoft.Build.Framework" Version="15.1.1012" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Build.Framework" Version="15.3.409" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build.Framework" Version="15.4.8" />
     <Usage Id="Microsoft.Build.Framework" Version="15.6.82" />
-    <Usage Id="Microsoft.Build.Framework" Version="15.6.85" />
-    <Usage Id="Microsoft.Build.Framework" Version="15.7.0-preview-000143" />
+    <Usage Id="Microsoft.Build.Framework" Version="15.6.85" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Build.Framework" Version="15.7.0-preview-000143" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build.Localization" Version="15.9.20" />
-    <Usage Id="Microsoft.Build.Runtime" Version="15.3.409" />
-    <Usage Id="Microsoft.Build.Tasks.Core" Version="14.3.0" />
-    <Usage Id="Microsoft.Build.Tasks.Core" Version="15.1.1012" />
-    <Usage Id="Microsoft.Build.Tasks.Core" Version="15.3.409" />
+    <Usage Id="Microsoft.Build.Runtime" Version="15.3.409" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Build.Tasks.Core" Version="14.3.0" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Build.Tasks.Core" Version="15.1.1012" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Build.Tasks.Core" Version="15.3.409" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build.Tasks.Core" Version="15.6.82" />
-    <Usage Id="Microsoft.Build.Tasks.Core" Version="15.7.0-preview-000143" />
+    <Usage Id="Microsoft.Build.Tasks.Core" Version="15.7.0-preview-000143" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build.Utilities.Core" Version="14.3.0" />
     <Usage Id="Microsoft.Build.Utilities.Core" Version="15.1.548" />
-    <Usage Id="Microsoft.Build.Utilities.Core" Version="15.1.1012" />
-    <Usage Id="Microsoft.Build.Utilities.Core" Version="15.3.409" />
-    <Usage Id="Microsoft.Build.Utilities.Core" Version="15.4.8" />
+    <Usage Id="Microsoft.Build.Utilities.Core" Version="15.1.1012" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Build.Utilities.Core" Version="15.3.409" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Build.Utilities.Core" Version="15.4.8" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build.Utilities.Core" Version="15.6.82" />
-    <Usage Id="Microsoft.Build.Utilities.Core" Version="15.7.0-preview-000143" />
-    <Usage Id="Microsoft.Cci" Version="4.0.0-rc3-24214-00" />
+    <Usage Id="Microsoft.Build.Utilities.Core" Version="15.7.0-preview-000143" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Cci" Version="4.0.0-rc3-24214-00" IsDirectDependency="true" />
     <Usage Id="Microsoft.CodeAnalysis.Analyzers" Version="1.1.0" />
     <Usage Id="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
     <Usage Id="Microsoft.CodeAnalysis.Common" Version="1.3.0" />
@@ -87,29 +87,29 @@
     <Usage Id="Microsoft.Data.Services.Client" Version="5.6.4" />
     <Usage Id="Microsoft.Diagnostics.Tracing.EventSource.Redist" Version="1.1.16-beta" />
     <Usage Id="Microsoft.DiaSymReader.Native" Version="1.4.1" />
-    <Usage Id="Microsoft.DiaSymReader.Native" Version="1.7.0" />
-    <Usage Id="Microsoft.DotNet.Archive" Version="0.2.0-beta-63027-01" />
-    <Usage Id="Microsoft.DotNet.Build.Tasks.Feed" Version="2.1.0-rc1-03130-05" />
+    <Usage Id="Microsoft.DiaSymReader.Native" Version="1.7.0" IsDirectDependency="true" />
+    <Usage Id="Microsoft.DotNet.Archive" Version="0.2.0-beta-63027-01" IsDirectDependency="true" />
+    <Usage Id="Microsoft.DotNet.Build.Tasks.Feed" Version="2.1.0-rc1-03130-05" IsDirectDependency="true" />
     <Usage Id="Microsoft.DotNet.BuildTools.CoreCLR" Version="1.0.4-prerelease" />
-    <Usage Id="Microsoft.DotNet.Cli.CommandLine" Version="0.1.1-alpha-167" />
-    <Usage Id="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
+    <Usage Id="Microsoft.DotNet.Cli.CommandLine" Version="0.1.1-alpha-167" IsDirectDependency="true" />
+    <Usage Id="Microsoft.DotNet.Cli.Utils" Version="1.0.1" IsDirectDependency="true" />
     <Usage Id="Microsoft.DotNet.PlatformAbstractions" Version="1.0.3" />
-    <Usage Id="Microsoft.DotNet.PlatformAbstractions" Version="2.0.0" />
+    <Usage Id="Microsoft.DotNet.PlatformAbstractions" Version="2.0.0" IsDirectDependency="true" />
     <Usage Id="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0-preview2-26306-03" />
-    <Usage Id="Microsoft.DotNet.VersionTools" Version="2.1.0-rc1-03130-05" />
-    <Usage Id="Microsoft.Extensions.CommandLineUtils" Version="1.1.0" />
+    <Usage Id="Microsoft.DotNet.VersionTools" Version="2.1.0-rc1-03130-05" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Extensions.CommandLineUtils" Version="1.1.0" IsDirectDependency="true" />
     <Usage Id="Microsoft.Extensions.DependencyModel" Version="1.0.3" />
-    <Usage Id="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
-    <Usage Id="Microsoft.Extensions.DependencyModel" Version="2.1.0-preview2-26306-03" />
-    <Usage Id="Microsoft.Internal.Dia" Version="14.0.0" />
-    <Usage Id="Microsoft.Internal.Intellitrace" Version="15.5.0-preview-20171207-01" />
-    <Usage Id="Microsoft.Internal.TestPlatform.Extensions" Version="15.6.0-preview-1270639" />
-    <Usage Id="Microsoft.Net.Compilers" Version="2.8.0-beta4-62824-10" />
-    <Usage Id="Microsoft.Net.Compilers.netcore" Version="2.6.0-beta3-62316-02" />
-    <Usage Id="Microsoft.Net.Compilers.Targets.NetCore" Version="0.1.5-dev" />
-    <Usage Id="Microsoft.NETCore.App" Version="1.0.3" />
-    <Usage Id="Microsoft.NETCore.App" Version="1.1.2" />
-    <Usage Id="Microsoft.NETCore.Compilers" Version="2.8.0-beta2-62719-08" />
+    <Usage Id="Microsoft.Extensions.DependencyModel" Version="2.0.0" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Extensions.DependencyModel" Version="2.1.0-preview2-26306-03" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Internal.Dia" Version="14.0.0" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Internal.Intellitrace" Version="15.5.0-preview-20171207-01" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Internal.TestPlatform.Extensions" Version="15.6.0-preview-1270639" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Net.Compilers" Version="2.8.0-beta4-62824-10" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Net.Compilers.netcore" Version="2.6.0-beta3-62316-02" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Net.Compilers.Targets.NetCore" Version="0.1.5-dev" IsDirectDependency="true" />
+    <Usage Id="Microsoft.NETCore.App" Version="1.0.3" IsDirectDependency="true" IsAutoReferenced="true" />
+    <Usage Id="Microsoft.NETCore.App" Version="1.1.2" IsDirectDependency="true" IsAutoReferenced="true" />
+    <Usage Id="Microsoft.NETCore.Compilers" Version="2.8.0-beta2-62719-08" IsDirectDependency="true" />
     <Usage Id="Microsoft.NETCore.Compilers" Version="2.8.0-beta4-62824-10" />
     <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="1.0.3" />
     <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="1.1.2" />
@@ -119,28 +119,28 @@
     <Usage Id="Microsoft.NETCore.Runtime.CoreCLR" Version="1.1.2" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net40" Version="1.0.0-alpha-003" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net46" Version="1.0.0-alpha-003" />
-    <Usage Id="Microsoft.TargetingPack.NETFramework.v4.6" Version="1.0.1" />
-    <Usage Id="Microsoft.TargetingPack.NETFramework.v4.6.1" Version="1.0.1" />
-    <Usage Id="Microsoft.TemplateEngine.Cli.Localization" Version="1.0.2-beta3" />
+    <Usage Id="Microsoft.TargetingPack.NETFramework.v4.6" Version="1.0.1" IsDirectDependency="true" />
+    <Usage Id="Microsoft.TargetingPack.NETFramework.v4.6.1" Version="1.0.1" IsDirectDependency="true" />
+    <Usage Id="Microsoft.TemplateEngine.Cli.Localization" Version="1.0.2-beta3" IsDirectDependency="true" />
     <Usage Id="Microsoft.VisualBasic" Version="10.0.1" />
     <Usage Id="Microsoft.VisualBasic" Version="10.1.0" />
-    <Usage Id="Microsoft.VisualStudio.QualityTools" Version="15.6.0-preview-1270639" />
-    <Usage Id="Microsoft.VisualStudio.QualityTools.DataCollectors" Version="15.6.0-preview-1270639" />
+    <Usage Id="Microsoft.VisualStudio.QualityTools" Version="15.6.0-preview-1270639" IsDirectDependency="true" />
+    <Usage Id="Microsoft.VisualStudio.QualityTools.DataCollectors" Version="15.6.0-preview-1270639" IsDirectDependency="true" />
     <Usage Id="Microsoft.VisualStudio.RemoteControl" Version="14.0.262-masterA5CACE98" />
-    <Usage Id="Microsoft.VisualStudio.Sdk.BuildTasks.14.0" Version="14.0.12-pre" />
-    <Usage Id="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" />
-    <Usage Id="Microsoft.VisualStudio.Telemetry" Version="15.6.815-master284DF69C" />
+    <Usage Id="Microsoft.VisualStudio.Sdk.BuildTasks.14.0" Version="14.0.12-pre" IsDirectDependency="true" />
+    <Usage Id="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" IsDirectDependency="true" />
+    <Usage Id="Microsoft.VisualStudio.Telemetry" Version="15.6.815-master284DF69C" IsDirectDependency="true" />
     <Usage Id="Microsoft.VisualStudio.Utilities.Internal" Version="14.0.74-masterCEEA65A3" />
-    <Usage Id="Microsoft.VSSDK.BuildTools" Version="15.0.26201" />
+    <Usage Id="Microsoft.VSSDK.BuildTools" Version="15.0.26201" IsDirectDependency="true" />
     <Usage Id="Microsoft.Win32.Primitives" Version="4.0.1" />
     <Usage Id="Microsoft.Win32.Primitives" Version="4.3.0" />
     <Usage Id="Microsoft.Win32.Registry" Version="4.0.0" />
     <Usage Id="Microsoft.Win32.Registry" Version="4.3.0" />
-    <Usage Id="NETStandard.Library.NETFramework" Version="2.0.1-servicing-26011-01" />
+    <Usage Id="NETStandard.Library.NETFramework" Version="2.0.1-servicing-26011-01" IsDirectDependency="true" />
     <Usage Id="Newtonsoft.Json" Version="6.0.4" />
-    <Usage Id="Newtonsoft.Json" Version="8.0.3" />
-    <Usage Id="Newtonsoft.Json" Version="10.0.3" />
-    <Usage Id="NuGet.CommandLine" Version="3.4.3" />
+    <Usage Id="Newtonsoft.Json" Version="8.0.3" IsDirectDependency="true" />
+    <Usage Id="Newtonsoft.Json" Version="10.0.3" IsDirectDependency="true" />
+    <Usage Id="NuGet.CommandLine" Version="3.4.3" IsDirectDependency="true" />
     <Usage Id="NuGet.Common" Version="4.0.0-rtm-2283" />
     <Usage Id="NuGet.Common" Version="4.3.0-preview1-2500" />
     <Usage Id="NuGet.Common" Version="4.3.0-preview2-4095" />
@@ -158,8 +158,8 @@
     <Usage Id="NuGet.Packaging" Version="4.3.0-preview2-4095" />
     <Usage Id="NuGet.Packaging.Core" Version="4.3.0-preview1-2500" />
     <Usage Id="NuGet.Packaging.Core" Version="4.3.0-preview2-4095" />
-    <Usage Id="NuGet.ProjectModel" Version="4.3.0-preview1-2500" />
-    <Usage Id="NuGet.ProjectModel" Version="4.3.0-preview2-4095" />
+    <Usage Id="NuGet.ProjectModel" Version="4.3.0-preview1-2500" IsDirectDependency="true" />
+    <Usage Id="NuGet.ProjectModel" Version="4.3.0-preview2-4095" IsDirectDependency="true" />
     <Usage Id="NuGet.Protocol" Version="4.3.0-preview1-2500" />
     <Usage Id="NuGet.Protocol" Version="4.3.0-preview2-4095" />
     <Usage Id="NuGet.Versioning" Version="4.0.0-rtm-2283" />
@@ -295,7 +295,7 @@
     <Usage Id="runtime.win7-x86.runtime.native.System.IO.Compression" Version="4.3.0" Rid="win7-x86" />
     <Usage Id="runtime.win7.System.Private.Uri" Version="4.0.1" Rid="win7" />
     <Usage Id="runtime.win7.System.Private.Uri" Version="4.3.0" Rid="win7" />
-    <Usage Id="StyleCop.Analyzers" Version="1.0.1" />
+    <Usage Id="StyleCop.Analyzers" Version="1.0.1" IsDirectDependency="true" />
     <Usage Id="System.AppContext" Version="4.1.0" />
     <Usage Id="System.AppContext" Version="4.3.0" />
     <Usage Id="System.Buffers" Version="4.0.0" />
@@ -310,7 +310,7 @@
     <Usage Id="System.Collections.Immutable" Version="1.5.0" />
     <Usage Id="System.Collections.NonGeneric" Version="4.0.1" />
     <Usage Id="System.Collections.NonGeneric" Version="4.3.0" />
-    <Usage Id="System.Collections.Specialized" Version="4.0.1" />
+    <Usage Id="System.Collections.Specialized" Version="4.0.1" IsDirectDependency="true" />
     <Usage Id="System.Collections.Specialized" Version="4.3.0" />
     <Usage Id="System.ComponentModel" Version="4.0.1" />
     <Usage Id="System.ComponentModel" Version="4.3.0" />
@@ -332,17 +332,17 @@
     <Usage Id="System.Diagnostics.DiagnosticSource" Version="4.0.0" />
     <Usage Id="System.Diagnostics.DiagnosticSource" Version="4.3.0" />
     <Usage Id="System.Diagnostics.DiagnosticSource" Version="4.3.1" />
-    <Usage Id="System.Diagnostics.DiagnosticSource" Version="4.4.0" />
+    <Usage Id="System.Diagnostics.DiagnosticSource" Version="4.4.0" IsDirectDependency="true" />
     <Usage Id="System.Diagnostics.FileVersionInfo" Version="4.0.0" />
-    <Usage Id="System.Diagnostics.FileVersionInfo" Version="4.3.0" />
-    <Usage Id="System.Diagnostics.Process" Version="4.1.0" />
+    <Usage Id="System.Diagnostics.FileVersionInfo" Version="4.3.0" IsDirectDependency="true" />
+    <Usage Id="System.Diagnostics.Process" Version="4.1.0" IsDirectDependency="true" />
     <Usage Id="System.Diagnostics.Process" Version="4.3.0" />
     <Usage Id="System.Diagnostics.StackTrace" Version="4.0.1" />
     <Usage Id="System.Diagnostics.StackTrace" Version="4.3.0" />
     <Usage Id="System.Diagnostics.TextWriterTraceListener" Version="4.0.0" />
-    <Usage Id="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />
+    <Usage Id="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" IsDirectDependency="true" />
     <Usage Id="System.Diagnostics.TraceSource" Version="4.0.0" />
-    <Usage Id="System.Diagnostics.TraceSource" Version="4.3.0" />
+    <Usage Id="System.Diagnostics.TraceSource" Version="4.3.0" IsDirectDependency="true" />
     <Usage Id="System.Diagnostics.Tracing" Version="4.1.0" />
     <Usage Id="System.Diagnostics.Tracing" Version="4.3.0" />
     <Usage Id="System.Dynamic.Runtime" Version="4.0.11" />
@@ -358,7 +358,7 @@
     <Usage Id="System.IO.Compression.ZipFile" Version="4.0.1" />
     <Usage Id="System.IO.Compression.ZipFile" Version="4.3.0" />
     <Usage Id="System.IO.FileSystem" Version="4.0.1" />
-    <Usage Id="System.IO.FileSystem" Version="4.3.0" />
+    <Usage Id="System.IO.FileSystem" Version="4.3.0" IsDirectDependency="true" />
     <Usage Id="System.IO.FileSystem.Primitives" Version="4.0.1" />
     <Usage Id="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <Usage Id="System.IO.FileSystem.Watcher" Version="4.0.0" />
@@ -367,7 +367,7 @@
     <Usage Id="System.IO.MemoryMappedFiles" Version="4.3.0" />
     <Usage Id="System.IO.Pipes" Version="4.0.0" />
     <Usage Id="System.IO.Pipes" Version="4.3.0" />
-    <Usage Id="System.IO.Pipes.AccessControl" Version="4.3.0" />
+    <Usage Id="System.IO.Pipes.AccessControl" Version="4.3.0" IsDirectDependency="true" />
     <Usage Id="System.IO.UnmanagedMemoryStream" Version="4.0.1" />
     <Usage Id="System.IO.UnmanagedMemoryStream" Version="4.3.0" />
     <Usage Id="System.Linq" Version="4.1.0" />
@@ -387,7 +387,7 @@
     <Usage Id="System.Net.Http" Version="4.3.3" />
     <Usage Id="System.Net.NameResolution" Version="4.0.0" />
     <Usage Id="System.Net.NameResolution" Version="4.3.0" />
-    <Usage Id="System.Net.Requests" Version="4.0.11" />
+    <Usage Id="System.Net.Requests" Version="4.0.11" IsDirectDependency="true" />
     <Usage Id="System.Net.Requests" Version="4.3.0" />
     <Usage Id="System.Net.Security" Version="4.0.0" />
     <Usage Id="System.Net.Security" Version="4.0.1" />
@@ -402,7 +402,7 @@
     <Usage Id="System.ObjectModel" Version="4.0.12" />
     <Usage Id="System.ObjectModel" Version="4.3.0" />
     <Usage Id="System.Private.DataContractSerialization" Version="4.1.1" />
-    <Usage Id="System.Private.DataContractSerialization" Version="4.3.0" />
+    <Usage Id="System.Private.DataContractSerialization" Version="4.3.0" IsDirectDependency="true" />
     <Usage Id="System.Reflection" Version="4.1.0" />
     <Usage Id="System.Reflection" Version="4.3.0" />
     <Usage Id="System.Reflection.DispatchProxy" Version="4.0.1" />
@@ -416,9 +416,9 @@
     <Usage Id="System.Reflection.Metadata" Version="1.3.0" />
     <Usage Id="System.Reflection.Metadata" Version="1.4.1" />
     <Usage Id="System.Reflection.Metadata" Version="1.4.2" />
-    <Usage Id="System.Reflection.Metadata" Version="1.5.0" />
+    <Usage Id="System.Reflection.Metadata" Version="1.5.0" IsDirectDependency="true" />
     <Usage Id="System.Reflection.Metadata" Version="1.6.0" />
-    <Usage Id="System.Reflection.TypeExtensions" Version="4.1.0" />
+    <Usage Id="System.Reflection.TypeExtensions" Version="4.1.0" IsDirectDependency="true" />
     <Usage Id="System.Reflection.TypeExtensions" Version="4.3.0" />
     <Usage Id="System.Resources.Reader" Version="4.0.0" />
     <Usage Id="System.Resources.Reader" Version="4.3.0" />
@@ -440,7 +440,7 @@
     <Usage Id="System.Runtime.Serialization.Primitives" Version="4.1.1" />
     <Usage Id="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <Usage Id="System.Runtime.Serialization.Xml" Version="4.1.1" />
-    <Usage Id="System.Security.AccessControl" Version="4.3.0" />
+    <Usage Id="System.Security.AccessControl" Version="4.3.0" IsDirectDependency="true" />
     <Usage Id="System.Security.Claims" Version="4.0.1" />
     <Usage Id="System.Security.Claims" Version="4.3.0" />
     <Usage Id="System.Security.Cryptography.Algorithms" Version="4.2.0" />
@@ -484,7 +484,7 @@
     <Usage Id="System.Threading.ThreadPool" Version="4.0.10" />
     <Usage Id="System.Threading.ThreadPool" Version="4.3.0" />
     <Usage Id="System.ValueTuple" Version="4.3.0" />
-    <Usage Id="System.ValueTuple" Version="4.4.0" />
+    <Usage Id="System.ValueTuple" Version="4.4.0" IsDirectDependency="true" />
     <Usage Id="System.Xml.ReaderWriter" Version="4.0.11" />
     <Usage Id="System.Xml.ReaderWriter" Version="4.3.0" />
     <Usage Id="System.Xml.XDocument" Version="4.0.11" />
@@ -498,10 +498,10 @@
     <Usage Id="System.Xml.XPath.XDocument" Version="4.0.1" />
     <Usage Id="System.Xml.XPath.XDocument" Version="4.3.0" />
     <Usage Id="System.Xml.XPath.XmlDocument" Version="4.0.1" />
-    <Usage Id="vswhere" Version="2.0.2" />
-    <Usage Id="WindowsAzure.Storage" Version="7.2.1" />
-    <Usage Id="XliffTasks" Version="0.2.0-beta-000081" />
-    <Usage Id="XliffTasks" Version="0.2.0-beta-62730-03" />
-    <Usage Id="XliffTasks" Version="0.2.0-beta-63004-01" />
+    <Usage Id="vswhere" Version="2.0.2" IsDirectDependency="true" />
+    <Usage Id="WindowsAzure.Storage" Version="7.2.1" IsDirectDependency="true" />
+    <Usage Id="XliffTasks" Version="0.2.0-beta-000081" IsDirectDependency="true" />
+    <Usage Id="XliffTasks" Version="0.2.0-beta-62730-03" IsDirectDependency="true" />
+    <Usage Id="XliffTasks" Version="0.2.0-beta-63004-01" IsDirectDependency="true" />
   </Usages>
 </UsageData>

--- a/tools-local/prebuilt-baseline-online.xml
+++ b/tools-local/prebuilt-baseline-online.xml
@@ -32,40 +32,40 @@
   </ProjectDirectories>
   <Usages>
     <Usage Id="fmdev.ResX" Version="0.2.0" />
-    <Usage Id="fmdev.xlftool" Version="0.1.3" />
+    <Usage Id="fmdev.xlftool" Version="0.1.3" IsDirectDependency="true" />
     <Usage Id="fmdev.XliffParser" Version="0.5.3" />
-    <Usage Id="FSharp.Core" Version="4.5.2" />
+    <Usage Id="FSharp.Core" Version="4.5.2" IsDirectDependency="true" />
     <Usage Id="Libuv" Version="1.9.1" />
-    <Usage Id="MicroBuild.Core" Version="0.2.0" />
-    <Usage Id="Microsoft.Build" Version="14.3.0" />
+    <Usage Id="MicroBuild.Core" Version="0.2.0" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Build" Version="14.3.0" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build" Version="15.1.548" />
-    <Usage Id="Microsoft.Build" Version="15.3.409" />
-    <Usage Id="Microsoft.Build" Version="15.4.8" />
+    <Usage Id="Microsoft.Build" Version="15.3.409" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Build" Version="15.4.8" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build" Version="15.6.82" />
-    <Usage Id="Microsoft.Build" Version="15.7.0-preview-000143" />
+    <Usage Id="Microsoft.Build" Version="15.7.0-preview-000143" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build.Framework" Version="14.3.0" />
     <Usage Id="Microsoft.Build.Framework" Version="15.1.548" />
-    <Usage Id="Microsoft.Build.Framework" Version="15.1.1012" />
-    <Usage Id="Microsoft.Build.Framework" Version="15.3.409" />
+    <Usage Id="Microsoft.Build.Framework" Version="15.1.1012" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Build.Framework" Version="15.3.409" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build.Framework" Version="15.4.8" />
     <Usage Id="Microsoft.Build.Framework" Version="15.6.82" />
-    <Usage Id="Microsoft.Build.Framework" Version="15.6.85" />
-    <Usage Id="Microsoft.Build.Framework" Version="15.7.0-preview-000143" />
+    <Usage Id="Microsoft.Build.Framework" Version="15.6.85" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Build.Framework" Version="15.7.0-preview-000143" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build.Localization" Version="15.9.20" />
-    <Usage Id="Microsoft.Build.Runtime" Version="15.3.409" />
-    <Usage Id="Microsoft.Build.Tasks.Core" Version="14.3.0" />
-    <Usage Id="Microsoft.Build.Tasks.Core" Version="15.1.1012" />
-    <Usage Id="Microsoft.Build.Tasks.Core" Version="15.3.409" />
+    <Usage Id="Microsoft.Build.Runtime" Version="15.3.409" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Build.Tasks.Core" Version="14.3.0" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Build.Tasks.Core" Version="15.1.1012" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Build.Tasks.Core" Version="15.3.409" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build.Tasks.Core" Version="15.6.82" />
-    <Usage Id="Microsoft.Build.Tasks.Core" Version="15.7.0-preview-000143" />
+    <Usage Id="Microsoft.Build.Tasks.Core" Version="15.7.0-preview-000143" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build.Utilities.Core" Version="14.3.0" />
     <Usage Id="Microsoft.Build.Utilities.Core" Version="15.1.548" />
-    <Usage Id="Microsoft.Build.Utilities.Core" Version="15.1.1012" />
-    <Usage Id="Microsoft.Build.Utilities.Core" Version="15.3.409" />
-    <Usage Id="Microsoft.Build.Utilities.Core" Version="15.4.8" />
+    <Usage Id="Microsoft.Build.Utilities.Core" Version="15.1.1012" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Build.Utilities.Core" Version="15.3.409" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Build.Utilities.Core" Version="15.4.8" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build.Utilities.Core" Version="15.6.82" />
-    <Usage Id="Microsoft.Build.Utilities.Core" Version="15.7.0-preview-000143" />
-    <Usage Id="Microsoft.Cci" Version="4.0.0-rc3-24214-00" />
+    <Usage Id="Microsoft.Build.Utilities.Core" Version="15.7.0-preview-000143" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Cci" Version="4.0.0-rc3-24214-00" IsDirectDependency="true" />
     <Usage Id="Microsoft.CodeAnalysis.Analyzers" Version="1.1.0" />
     <Usage Id="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
     <Usage Id="Microsoft.CodeAnalysis.Common" Version="1.3.0" />
@@ -82,41 +82,41 @@
     <Usage Id="Microsoft.Data.Services.Client" Version="5.6.4" />
     <Usage Id="Microsoft.Diagnostics.Tracing.EventSource.Redist" Version="1.1.16-beta" />
     <Usage Id="Microsoft.DiaSymReader.Native" Version="1.4.1" />
-    <Usage Id="Microsoft.DiaSymReader.Native" Version="1.7.0" />
-    <Usage Id="Microsoft.Docker.Sdk" Version="1.1.0" />
-    <Usage Id="Microsoft.DotNet.Archive" Version="0.2.0-beta-63027-01" />
-    <Usage Id="Microsoft.DotNet.Build.Tasks.Feed" Version="2.1.0-rc1-03130-05" />
-    <Usage Id="Microsoft.DotNet.BuildTools" Version="2.1.0-rc1-03131-06" />
+    <Usage Id="Microsoft.DiaSymReader.Native" Version="1.7.0" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Docker.Sdk" Version="1.1.0" IsDirectDependency="true" />
+    <Usage Id="Microsoft.DotNet.Archive" Version="0.2.0-beta-63027-01" IsDirectDependency="true" />
+    <Usage Id="Microsoft.DotNet.Build.Tasks.Feed" Version="2.1.0-rc1-03130-05" IsDirectDependency="true" />
+    <Usage Id="Microsoft.DotNet.BuildTools" Version="2.1.0-rc1-03131-06" IsDirectDependency="true" />
     <Usage Id="Microsoft.DotNet.BuildTools.CoreCLR" Version="1.0.4-prerelease" />
-    <Usage Id="Microsoft.DotNet.Cli.CommandLine" Version="0.1.1-alpha-167" />
-    <Usage Id="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
+    <Usage Id="Microsoft.DotNet.Cli.CommandLine" Version="0.1.1-alpha-167" IsDirectDependency="true" />
+    <Usage Id="Microsoft.DotNet.Cli.Utils" Version="1.0.1" IsDirectDependency="true" />
     <Usage Id="Microsoft.DotNet.PlatformAbstractions" Version="1.0.3" />
-    <Usage Id="Microsoft.DotNet.PlatformAbstractions" Version="2.0.0" />
+    <Usage Id="Microsoft.DotNet.PlatformAbstractions" Version="2.0.0" IsDirectDependency="true" />
     <Usage Id="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0-preview2-26306-03" />
     <Usage Id="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4-20181009-2100240" />
-    <Usage Id="Microsoft.DotNet.VersionTools" Version="2.1.0-rc1-03130-05" />
+    <Usage Id="Microsoft.DotNet.VersionTools" Version="2.1.0-rc1-03130-05" IsDirectDependency="true" />
     <Usage Id="Microsoft.DotNet.Web.ItemTemplates" Version="2.1.6" />
     <Usage Id="Microsoft.DotNet.Web.ProjectTemplates.2.1" Version="2.1.6" />
     <Usage Id="Microsoft.DotNet.Web.Spa.ProjectTemplates" Version="2.1.6" />
-    <Usage Id="Microsoft.Extensions.CommandLineUtils" Version="1.1.0" />
+    <Usage Id="Microsoft.Extensions.CommandLineUtils" Version="1.1.0" IsDirectDependency="true" />
     <Usage Id="Microsoft.Extensions.DependencyModel" Version="1.0.3" />
-    <Usage Id="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
-    <Usage Id="Microsoft.Extensions.DependencyModel" Version="2.1.0-preview2-26306-03" />
-    <Usage Id="Microsoft.Internal.Dia" Version="14.0.0" />
-    <Usage Id="Microsoft.Internal.Intellitrace" Version="15.5.0-preview-20171207-01" />
-    <Usage Id="Microsoft.Internal.TestPlatform.Extensions" Version="15.6.0-preview-1270639" />
-    <Usage Id="Microsoft.Net.Compilers" Version="2.8.0-beta4-62824-10" />
-    <Usage Id="Microsoft.Net.Compilers.netcore" Version="2.6.0-beta3-62316-02" />
-    <Usage Id="Microsoft.Net.Compilers.Targets.NetCore" Version="0.1.5-dev" />
-    <Usage Id="Microsoft.NETCore.App" Version="1.0.3" />
-    <Usage Id="Microsoft.NETCore.App" Version="1.0.5" />
-    <Usage Id="Microsoft.NETCore.App" Version="1.1.1" />
-    <Usage Id="Microsoft.NETCore.App" Version="1.1.2" />
-    <Usage Id="Microsoft.NETCore.App" Version="2.0.0" />
-    <Usage Id="Microsoft.NETCore.App" Version="2.1.0-preview1-26116-04" />
-    <Usage Id="Microsoft.NETCore.App" Version="2.1.0" />
-    <Usage Id="Microsoft.NETCore.App" Version="2.1.5" />
-    <Usage Id="Microsoft.NETCore.Compilers" Version="2.8.0-beta2-62719-08" />
+    <Usage Id="Microsoft.Extensions.DependencyModel" Version="2.0.0" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Extensions.DependencyModel" Version="2.1.0-preview2-26306-03" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Internal.Dia" Version="14.0.0" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Internal.Intellitrace" Version="15.5.0-preview-20171207-01" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Internal.TestPlatform.Extensions" Version="15.6.0-preview-1270639" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Net.Compilers" Version="2.8.0-beta4-62824-10" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Net.Compilers.netcore" Version="2.6.0-beta3-62316-02" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Net.Compilers.Targets.NetCore" Version="0.1.5-dev" IsDirectDependency="true" />
+    <Usage Id="Microsoft.NETCore.App" Version="1.0.3" IsDirectDependency="true" IsAutoReferenced="true" />
+    <Usage Id="Microsoft.NETCore.App" Version="1.0.5" IsDirectDependency="true" IsAutoReferenced="true" />
+    <Usage Id="Microsoft.NETCore.App" Version="1.1.1" IsDirectDependency="true" />
+    <Usage Id="Microsoft.NETCore.App" Version="1.1.2" IsDirectDependency="true" IsAutoReferenced="true" />
+    <Usage Id="Microsoft.NETCore.App" Version="2.0.0" IsDirectDependency="true" IsAutoReferenced="true" />
+    <Usage Id="Microsoft.NETCore.App" Version="2.1.0-preview1-26116-04" IsDirectDependency="true" />
+    <Usage Id="Microsoft.NETCore.App" Version="2.1.0" IsDirectDependency="true" IsAutoReferenced="true" />
+    <Usage Id="Microsoft.NETCore.App" Version="2.1.5" IsDirectDependency="true" />
+    <Usage Id="Microsoft.NETCore.Compilers" Version="2.8.0-beta2-62719-08" IsDirectDependency="true" />
     <Usage Id="Microsoft.NETCore.Compilers" Version="2.8.0-beta4-62824-10" />
     <Usage Id="Microsoft.NETCore.DotNetAppHost" Version="2.0.0" />
     <Usage Id="Microsoft.NETCore.DotNetAppHost" Version="2.1.0-preview1-26116-04" />
@@ -124,7 +124,7 @@
     <Usage Id="Microsoft.NETCore.DotNetAppHost" Version="2.1.5" />
     <Usage Id="Microsoft.NETCore.DotNetHost" Version="1.0.1" />
     <Usage Id="Microsoft.NETCore.DotNetHost" Version="1.1.0" />
-    <Usage Id="Microsoft.NETCore.DotNetHost" Version="2.1.5" />
+    <Usage Id="Microsoft.NETCore.DotNetHost" Version="2.1.5" IsDirectDependency="true" />
     <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="1.0.3" />
     <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="1.0.5" />
     <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="1.1.0" />
@@ -132,69 +132,69 @@
     <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="2.0.0" />
     <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="2.1.0-preview1-26116-04" />
     <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="2.1.0" />
-    <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="2.1.5" />
+    <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="2.1.5" IsDirectDependency="true" />
     <Usage Id="Microsoft.NETCore.DotNetHostResolver" Version="1.0.1" />
     <Usage Id="Microsoft.NETCore.DotNetHostResolver" Version="1.1.0" />
     <Usage Id="Microsoft.NETCore.DotNetHostResolver" Version="2.0.0" />
     <Usage Id="Microsoft.NETCore.DotNetHostResolver" Version="2.1.0-preview1-26116-04" />
     <Usage Id="Microsoft.NETCore.DotNetHostResolver" Version="2.1.0" />
     <Usage Id="Microsoft.NETCore.DotNetHostResolver" Version="2.1.5" />
-    <Usage Id="Microsoft.NETCore.ILAsm" Version="2.1.6-servicing-27017-03" />
-    <Usage Id="Microsoft.NETCore.ILDAsm" Version="2.1.6-servicing-27017-03" />
+    <Usage Id="Microsoft.NETCore.ILAsm" Version="2.1.6-servicing-27017-03" IsDirectDependency="true" />
+    <Usage Id="Microsoft.NETCore.ILDAsm" Version="2.1.6-servicing-27017-03" IsDirectDependency="true" />
     <Usage Id="Microsoft.NETCore.Jit" Version="1.0.5" />
     <Usage Id="Microsoft.NETCore.Jit" Version="1.0.7" />
     <Usage Id="Microsoft.NETCore.Jit" Version="1.1.1" />
     <Usage Id="Microsoft.NETCore.Jit" Version="1.1.2" />
     <Usage Id="Microsoft.NETCore.Jit" Version="2.1.6-servicing-27017-03" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="1.0.1" />
-    <Usage Id="Microsoft.NETCore.Platforms" Version="1.0.2-beta-24224-02" />
+    <Usage Id="Microsoft.NETCore.Platforms" Version="1.0.2-beta-24224-02" IsDirectDependency="true" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="1.0.2" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="1.1.0" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="2.0.0" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="2.1.0-preview1-26116-01" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="2.1.0" />
-    <Usage Id="Microsoft.NETCore.Platforms" Version="2.1.1-servicing-26902-02" />
-    <Usage Id="Microsoft.NETCore.Platforms" Version="2.1.1" />
+    <Usage Id="Microsoft.NETCore.Platforms" Version="2.1.1-servicing-26902-02" IsDirectDependency="true" />
+    <Usage Id="Microsoft.NETCore.Platforms" Version="2.1.1" IsDirectDependency="true" />
     <Usage Id="Microsoft.NETCore.Runtime.CoreCLR" Version="1.0.5" />
     <Usage Id="Microsoft.NETCore.Runtime.CoreCLR" Version="1.0.7" />
     <Usage Id="Microsoft.NETCore.Runtime.CoreCLR" Version="1.1.1" />
     <Usage Id="Microsoft.NETCore.Runtime.CoreCLR" Version="1.1.2" />
-    <Usage Id="Microsoft.NETCore.Runtime.CoreCLR" Version="2.1.6-servicing-27017-03" />
+    <Usage Id="Microsoft.NETCore.Runtime.CoreCLR" Version="2.1.6-servicing-27017-03" IsDirectDependency="true" />
     <Usage Id="Microsoft.NETCore.Targets" Version="1.0.1" />
     <Usage Id="Microsoft.NETCore.Targets" Version="1.0.3" />
     <Usage Id="Microsoft.NETCore.Targets" Version="1.1.0" />
-    <Usage Id="Microsoft.NETCore.Windows.ApiSets" Version="1.0.1" />
-    <Usage Id="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-alpha-003" />
+    <Usage Id="Microsoft.NETCore.Windows.ApiSets" Version="1.0.1" IsDirectDependency="true" />
+    <Usage Id="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-alpha-003" IsDirectDependency="true" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net40" Version="1.0.0-alpha-003" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net46" Version="1.0.0-alpha-003" />
-    <Usage Id="Microsoft.Portable.Targets" Version="0.1.1-dev" />
-    <Usage Id="Microsoft.TargetingPack.NETFramework.v4.6" Version="1.0.1" />
-    <Usage Id="Microsoft.TargetingPack.NETFramework.v4.6.1" Version="1.0.1" />
-    <Usage Id="Microsoft.TemplateEngine.Cli.Localization" Version="1.0.2-beta3" />
+    <Usage Id="Microsoft.Portable.Targets" Version="0.1.1-dev" IsDirectDependency="true" />
+    <Usage Id="Microsoft.TargetingPack.NETFramework.v4.6" Version="1.0.1" IsDirectDependency="true" />
+    <Usage Id="Microsoft.TargetingPack.NETFramework.v4.6.1" Version="1.0.1" IsDirectDependency="true" />
+    <Usage Id="Microsoft.TemplateEngine.Cli.Localization" Version="1.0.2-beta3" IsDirectDependency="true" />
     <Usage Id="Microsoft.VisualBasic" Version="10.0.1" />
     <Usage Id="Microsoft.VisualBasic" Version="10.1.0" />
-    <Usage Id="Microsoft.VisualStudio.QualityTools" Version="15.6.0-preview-1270639" />
-    <Usage Id="Microsoft.VisualStudio.QualityTools.DataCollectors" Version="15.6.0-preview-1270639" />
+    <Usage Id="Microsoft.VisualStudio.QualityTools" Version="15.6.0-preview-1270639" IsDirectDependency="true" />
+    <Usage Id="Microsoft.VisualStudio.QualityTools.DataCollectors" Version="15.6.0-preview-1270639" IsDirectDependency="true" />
     <Usage Id="Microsoft.VisualStudio.RemoteControl" Version="14.0.262-masterA5CACE98" />
-    <Usage Id="Microsoft.VisualStudio.Sdk.BuildTasks.14.0" Version="14.0.12-pre" />
-    <Usage Id="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.15" />
-    <Usage Id="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" />
-    <Usage Id="Microsoft.VisualStudio.Telemetry" Version="15.6.815-master284DF69C" />
+    <Usage Id="Microsoft.VisualStudio.Sdk.BuildTasks.14.0" Version="14.0.12-pre" IsDirectDependency="true" />
+    <Usage Id="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.15" IsDirectDependency="true" />
+    <Usage Id="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" IsDirectDependency="true" />
+    <Usage Id="Microsoft.VisualStudio.Telemetry" Version="15.6.815-master284DF69C" IsDirectDependency="true" />
     <Usage Id="Microsoft.VisualStudio.Utilities.Internal" Version="14.0.74-masterCEEA65A3" />
-    <Usage Id="Microsoft.VSSDK.BuildTools" Version="15.0.26201" />
+    <Usage Id="Microsoft.VSSDK.BuildTools" Version="15.0.26201" IsDirectDependency="true" />
     <Usage Id="Microsoft.Win32.Primitives" Version="4.0.1" />
     <Usage Id="Microsoft.Win32.Primitives" Version="4.3.0" />
     <Usage Id="Microsoft.Win32.Registry" Version="4.0.0" />
     <Usage Id="Microsoft.Win32.Registry" Version="4.3.0" />
-    <Usage Id="NETStandard.Library" Version="1.6.0" />
-    <Usage Id="NETStandard.Library" Version="1.6.1" />
+    <Usage Id="NETStandard.Library" Version="1.6.0" IsDirectDependency="true" />
+    <Usage Id="NETStandard.Library" Version="1.6.1" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="NETStandard.Library" Version="2.0.0" />
     <Usage Id="NETStandard.Library" Version="2.0.1" />
-    <Usage Id="NETStandard.Library.NETFramework" Version="2.0.1-servicing-26011-01" />
+    <Usage Id="NETStandard.Library.NETFramework" Version="2.0.1-servicing-26011-01" IsDirectDependency="true" />
     <Usage Id="Newtonsoft.Json" Version="6.0.4" />
-    <Usage Id="Newtonsoft.Json" Version="8.0.3" />
-    <Usage Id="Newtonsoft.Json" Version="10.0.3" />
-    <Usage Id="NuGet.CommandLine" Version="3.4.3" />
+    <Usage Id="Newtonsoft.Json" Version="8.0.3" IsDirectDependency="true" />
+    <Usage Id="Newtonsoft.Json" Version="10.0.3" IsDirectDependency="true" />
+    <Usage Id="NuGet.CommandLine" Version="3.4.3" IsDirectDependency="true" />
     <Usage Id="NuGet.Common" Version="4.0.0-rtm-2283" />
     <Usage Id="NuGet.Common" Version="4.3.0-preview1-2500" />
     <Usage Id="NuGet.Common" Version="4.3.0-preview2-4095" />
@@ -212,8 +212,8 @@
     <Usage Id="NuGet.Packaging" Version="4.3.0-preview2-4095" />
     <Usage Id="NuGet.Packaging.Core" Version="4.3.0-preview1-2500" />
     <Usage Id="NuGet.Packaging.Core" Version="4.3.0-preview2-4095" />
-    <Usage Id="NuGet.ProjectModel" Version="4.3.0-preview1-2500" />
-    <Usage Id="NuGet.ProjectModel" Version="4.3.0-preview2-4095" />
+    <Usage Id="NuGet.ProjectModel" Version="4.3.0-preview1-2500" IsDirectDependency="true" />
+    <Usage Id="NuGet.ProjectModel" Version="4.3.0-preview2-4095" IsDirectDependency="true" />
     <Usage Id="NuGet.Protocol" Version="4.3.0-preview1-2500" />
     <Usage Id="NuGet.Protocol" Version="4.3.0-preview2-4095" />
     <Usage Id="NuGet.Versioning" Version="4.0.0-rtm-2283" />
@@ -222,7 +222,7 @@
     <Usage Id="NuGet.Versioning" Version="4.7.0-preview1-4992" />
     <Usage Id="NUnit3.DotNetNew.Template" Version="1.5.3" />
     <Usage Id="optimization.linux-x64.PGO.CoreCLR" Version="2.1.0-release-20180815-0105" />
-    <Usage Id="optimization.PGO.CoreCLR" Version="2.1.0-release-20180815-0105" />
+    <Usage Id="optimization.PGO.CoreCLR" Version="2.1.0-release-20180815-0105" IsDirectDependency="true" />
     <Usage Id="optimization.windows_nt-x64.PGO.CoreCLR" Version="2.1.0-release-20180815-0105" />
     <Usage Id="optimization.windows_nt-x86.PGO.CoreCLR" Version="2.1.0-release-20180815-0105" />
     <Usage Id="RoslynTools.RepoToolset" Version="1.0.0-beta2-62805-03" />
@@ -284,7 +284,7 @@
     <Usage Id="runtime.linux-x64.Microsoft.NETCore.Runtime.CoreCLR" Version="2.1.6-servicing-27017-03" Rid="linux-x64" />
     <Usage Id="runtime.native.System" Version="4.0.0" />
     <Usage Id="runtime.native.System" Version="4.3.0" />
-    <Usage Id="runtime.native.System.Data.SqlClient.sni" Version="4.4.0" />
+    <Usage Id="runtime.native.System.Data.SqlClient.sni" Version="4.4.0" IsDirectDependency="true" />
     <Usage Id="runtime.native.System.IO.Compression" Version="4.1.0" />
     <Usage Id="runtime.native.System.IO.Compression" Version="4.3.0" />
     <Usage Id="runtime.native.System.Net.Http" Version="4.0.1" />
@@ -375,7 +375,7 @@
     <Usage Id="runtime.win7-x86.runtime.native.System.IO.Compression" Version="4.3.0" Rid="win7-x86" />
     <Usage Id="runtime.win7.System.Private.Uri" Version="4.0.1" Rid="win7" />
     <Usage Id="runtime.win7.System.Private.Uri" Version="4.3.0" Rid="win7" />
-    <Usage Id="StyleCop.Analyzers" Version="1.0.1" />
+    <Usage Id="StyleCop.Analyzers" Version="1.0.1" IsDirectDependency="true" />
     <Usage Id="System.AppContext" Version="4.1.0" />
     <Usage Id="System.AppContext" Version="4.3.0" />
     <Usage Id="System.Buffers" Version="4.0.0" />
@@ -392,7 +392,7 @@
     <Usage Id="System.Collections.Immutable" Version="1.5.0" />
     <Usage Id="System.Collections.NonGeneric" Version="4.0.1" />
     <Usage Id="System.Collections.NonGeneric" Version="4.3.0" />
-    <Usage Id="System.Collections.Specialized" Version="4.0.1" />
+    <Usage Id="System.Collections.Specialized" Version="4.0.1" IsDirectDependency="true" />
     <Usage Id="System.Collections.Specialized" Version="4.3.0" />
     <Usage Id="System.ComponentModel" Version="4.0.1" />
     <Usage Id="System.ComponentModel" Version="4.3.0" />
@@ -403,7 +403,7 @@
     <Usage Id="System.ComponentModel.Primitives" Version="4.3.0" />
     <Usage Id="System.ComponentModel.TypeConverter" Version="4.1.0" />
     <Usage Id="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <Usage Id="System.Composition" Version="1.1.0" />
+    <Usage Id="System.Composition" Version="1.1.0" IsDirectDependency="true" />
     <Usage Id="System.Composition.AttributedModel" Version="1.1.0" />
     <Usage Id="System.Composition.Convention" Version="1.1.0" />
     <Usage Id="System.Composition.Hosting" Version="1.1.0" />
@@ -417,19 +417,19 @@
     <Usage Id="System.Diagnostics.DiagnosticSource" Version="4.0.0" />
     <Usage Id="System.Diagnostics.DiagnosticSource" Version="4.3.0" />
     <Usage Id="System.Diagnostics.DiagnosticSource" Version="4.3.1" />
-    <Usage Id="System.Diagnostics.DiagnosticSource" Version="4.4.0" />
+    <Usage Id="System.Diagnostics.DiagnosticSource" Version="4.4.0" IsDirectDependency="true" />
     <Usage Id="System.Diagnostics.FileVersionInfo" Version="4.0.0" />
-    <Usage Id="System.Diagnostics.FileVersionInfo" Version="4.3.0" />
-    <Usage Id="System.Diagnostics.Process" Version="4.1.0" />
+    <Usage Id="System.Diagnostics.FileVersionInfo" Version="4.3.0" IsDirectDependency="true" />
+    <Usage Id="System.Diagnostics.Process" Version="4.1.0" IsDirectDependency="true" />
     <Usage Id="System.Diagnostics.Process" Version="4.3.0" />
     <Usage Id="System.Diagnostics.StackTrace" Version="4.0.1" />
     <Usage Id="System.Diagnostics.StackTrace" Version="4.3.0" />
     <Usage Id="System.Diagnostics.TextWriterTraceListener" Version="4.0.0" />
-    <Usage Id="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />
+    <Usage Id="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" IsDirectDependency="true" />
     <Usage Id="System.Diagnostics.Tools" Version="4.0.1" />
     <Usage Id="System.Diagnostics.Tools" Version="4.3.0" />
     <Usage Id="System.Diagnostics.TraceSource" Version="4.0.0" />
-    <Usage Id="System.Diagnostics.TraceSource" Version="4.3.0" />
+    <Usage Id="System.Diagnostics.TraceSource" Version="4.3.0" IsDirectDependency="true" />
     <Usage Id="System.Diagnostics.Tracing" Version="4.1.0" />
     <Usage Id="System.Diagnostics.Tracing" Version="4.3.0" />
     <Usage Id="System.Dynamic.Runtime" Version="4.0.11" />
@@ -456,7 +456,7 @@
     <Usage Id="System.IO.MemoryMappedFiles" Version="4.3.0" />
     <Usage Id="System.IO.Pipes" Version="4.0.0" />
     <Usage Id="System.IO.Pipes" Version="4.3.0" />
-    <Usage Id="System.IO.Pipes.AccessControl" Version="4.3.0" />
+    <Usage Id="System.IO.Pipes.AccessControl" Version="4.3.0" IsDirectDependency="true" />
     <Usage Id="System.IO.UnmanagedMemoryStream" Version="4.0.1" />
     <Usage Id="System.IO.UnmanagedMemoryStream" Version="4.3.0" />
     <Usage Id="System.Linq" Version="4.1.0" />
@@ -478,7 +478,7 @@
     <Usage Id="System.Net.NameResolution" Version="4.3.0" />
     <Usage Id="System.Net.Primitives" Version="4.0.11" />
     <Usage Id="System.Net.Primitives" Version="4.3.0" />
-    <Usage Id="System.Net.Requests" Version="4.0.11" />
+    <Usage Id="System.Net.Requests" Version="4.0.11" IsDirectDependency="true" />
     <Usage Id="System.Net.Requests" Version="4.3.0" />
     <Usage Id="System.Net.Security" Version="4.0.0" />
     <Usage Id="System.Net.Security" Version="4.0.1" />
@@ -493,7 +493,7 @@
     <Usage Id="System.ObjectModel" Version="4.0.12" />
     <Usage Id="System.ObjectModel" Version="4.3.0" />
     <Usage Id="System.Private.DataContractSerialization" Version="4.1.1" />
-    <Usage Id="System.Private.DataContractSerialization" Version="4.3.0" />
+    <Usage Id="System.Private.DataContractSerialization" Version="4.3.0" IsDirectDependency="true" />
     <Usage Id="System.Private.Uri" Version="4.0.1" />
     <Usage Id="System.Private.Uri" Version="4.3.0" />
     <Usage Id="System.Reflection" Version="4.1.0" />
@@ -511,11 +511,11 @@
     <Usage Id="System.Reflection.Metadata" Version="1.3.0" />
     <Usage Id="System.Reflection.Metadata" Version="1.4.1" />
     <Usage Id="System.Reflection.Metadata" Version="1.4.2" />
-    <Usage Id="System.Reflection.Metadata" Version="1.5.0" />
+    <Usage Id="System.Reflection.Metadata" Version="1.5.0" IsDirectDependency="true" />
     <Usage Id="System.Reflection.Metadata" Version="1.6.0" />
     <Usage Id="System.Reflection.Primitives" Version="4.0.1" />
     <Usage Id="System.Reflection.Primitives" Version="4.3.0" />
-    <Usage Id="System.Reflection.TypeExtensions" Version="4.1.0" />
+    <Usage Id="System.Reflection.TypeExtensions" Version="4.1.0" IsDirectDependency="true" />
     <Usage Id="System.Reflection.TypeExtensions" Version="4.3.0" />
     <Usage Id="System.Resources.Reader" Version="4.0.0" />
     <Usage Id="System.Resources.Reader" Version="4.3.0" />
@@ -541,7 +541,7 @@
     <Usage Id="System.Runtime.Serialization.Primitives" Version="4.1.1" />
     <Usage Id="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <Usage Id="System.Runtime.Serialization.Xml" Version="4.1.1" />
-    <Usage Id="System.Security.AccessControl" Version="4.3.0" />
+    <Usage Id="System.Security.AccessControl" Version="4.3.0" IsDirectDependency="true" />
     <Usage Id="System.Security.Claims" Version="4.0.1" />
     <Usage Id="System.Security.Claims" Version="4.3.0" />
     <Usage Id="System.Security.Cryptography.Algorithms" Version="4.2.0" />
@@ -593,7 +593,7 @@
     <Usage Id="System.Threading.Timer" Version="4.0.1" />
     <Usage Id="System.Threading.Timer" Version="4.3.0" />
     <Usage Id="System.ValueTuple" Version="4.3.0" />
-    <Usage Id="System.ValueTuple" Version="4.4.0" />
+    <Usage Id="System.ValueTuple" Version="4.4.0" IsDirectDependency="true" />
     <Usage Id="System.Xml.ReaderWriter" Version="4.0.11" />
     <Usage Id="System.Xml.ReaderWriter" Version="4.3.0" />
     <Usage Id="System.Xml.XDocument" Version="4.0.11" />
@@ -607,10 +607,10 @@
     <Usage Id="System.Xml.XPath.XDocument" Version="4.0.1" />
     <Usage Id="System.Xml.XPath.XDocument" Version="4.3.0" />
     <Usage Id="System.Xml.XPath.XmlDocument" Version="4.0.1" />
-    <Usage Id="vswhere" Version="2.0.2" />
-    <Usage Id="WindowsAzure.Storage" Version="7.2.1" />
-    <Usage Id="XliffTasks" Version="0.2.0-beta-000081" />
-    <Usage Id="XliffTasks" Version="0.2.0-beta-62730-03" />
-    <Usage Id="XliffTasks" Version="0.2.0-beta-63004-01" />
+    <Usage Id="vswhere" Version="2.0.2" IsDirectDependency="true" />
+    <Usage Id="WindowsAzure.Storage" Version="7.2.1" IsDirectDependency="true" />
+    <Usage Id="XliffTasks" Version="0.2.0-beta-000081" IsDirectDependency="true" />
+    <Usage Id="XliffTasks" Version="0.2.0-beta-62730-03" IsDirectDependency="true" />
+    <Usage Id="XliffTasks" Version="0.2.0-beta-63004-01" IsDirectDependency="true" />
   </Usages>
 </UsageData>


### PR DESCRIPTION
Baseline generation now includes `IsDirectDependency`, but our baseline for 2.1.6 doesn't have that attribute. This means a diff between 2.1.6 and some future 2.1.7 would show a bunch of noisy `IsDirectDependency` additions.

To allow a noiseless diff, update the baselines so they include the new attribute. This PR doesn't add or remove any packages, so it still has the same package id/versions as the 2.1.6 baseline.

Once 2.1.7 comes out, instead of diffing from 2.1.6 to 2.1.7, diff from this PR's commit to 2.1.7 to see only the package adds/removes.