### PR TITLE
Sync submodule URLs for dirty agent CI

### DIFF
--- a/.vsts.pipelines/jobs/ci-local.yml
+++ b/.vsts.pipelines/jobs/ci-local.yml
@@ -38,6 +38,10 @@ jobs:
   - checkout: self
     clean: true
 
+  # If the machine is dirty, submodule URLs may be from a different branch. Sync to prevent that.
+  - script: git submodule sync
+    displayName: Sync submodule urls
+
   # Make sure submodules from other branches are removed: pass extra f.
   - script: git clean -xdff
     displayName: Clean leftover submodules


### PR DESCRIPTION
Windows CI uses a pool that doesn't recycle agents, so `.git` sticks around. This causes flakiness when:

1. CI builds on `release/2.1`.
   1. Initializes newtonsoft-json with remote pointing at the main repo.
2. CI builds on `master`
   1. Uses the already set up newtonsoft-json submodule.
   1. Even though `master` should pull from Dan's fork, the submodule's remote isn't changed by AzDO clean logic.
   1. When CI tries to `git submodule update`, it can't find the commit that only exists on Dan's fork.

Seen in https://dnceng.visualstudio.com/public/_build/results?buildId=48988 (master PR).

The pool that does recycle agents doesn't have enough disk space to support us yet, looking forward to that. 🙁