### PR TITLE
Add task to generate burndown data from the prebuilt report

### DIFF
--- a/.vsts.pipelines/builds/matrix.yml
+++ b/.vsts.pipelines/builds/matrix.yml
@@ -14,9 +14,8 @@ jobs:
     job: centos71
     imageName: microsoft/dotnet-buildtools-prereqs:centos-7-b46d863-20180719033416
     reportPrebuiltLeaks: true
-    generatePrebuiltBurndown: true
     matrix:
-      Production: {}
+      Production: { generatePrebuiltBurndown: true }
       Online: { type: Online }
       Offline: { type: Offline }
       Offline Portable: { type: Offline Portable }

--- a/.vsts.pipelines/builds/matrix.yml
+++ b/.vsts.pipelines/builds/matrix.yml
@@ -14,6 +14,7 @@ jobs:
     job: centos71
     imageName: microsoft/dotnet-buildtools-prereqs:centos-7-b46d863-20180719033416
     reportPrebuiltLeaks: true
+    generatePrebuiltBurndown: true
     matrix:
       Production: {}
       Online: { type: Online }

--- a/.vsts.pipelines/jobs/ci-linux.yml
+++ b/.vsts.pipelines/jobs/ci-linux.yml
@@ -35,6 +35,7 @@ jobs:
     rootDirectory: $(Build.SourcesDirectory)/..
     stagingDirectory: $(rootDirectory)/sb/staging
     tarballName: tarball_$(Build.BuildId)
+    SOURCE_BUILD_SKIP_SUBMODULE_CHECK: true
     # Default type, can be overridden by matrix legs.
     type: Production
 

--- a/.vsts.pipelines/jobs/ci-linux.yml
+++ b/.vsts.pipelines/jobs/ci-linux.yml
@@ -6,6 +6,7 @@ parameters:
     name: Hosted Ubuntu 1604
   imageName: null
   reportPrebuiltLeaks: false
+  generatePrebuiltBurndown: false
 
 jobs:
 - job: ${{ parameters.job }}
@@ -30,6 +31,7 @@ jobs:
     dropDirectory: $(stagingDirectory)/drop
     imageName: ${{ parameters.imageName }}
     reportPrebuiltLeaks: ${{ parameters.reportPrebuiltLeaks }}
+    generatePrebuiltBurndown: ${{ parameters.generatePrebuiltBurndown }}
     rootDirectory: $(Build.SourcesDirectory)/..
     stagingDirectory: $(rootDirectory)/sb/staging
     tarballName: tarball_$(Build.BuildId)
@@ -69,6 +71,16 @@ jobs:
         /p:ProdConBlobFeedUrlPrefix=$(prodConBlobFeedUrlPrefix)
     displayName: Build source-build
     timeoutInMinutes: 120
+
+  # Generate prebuilt burndown data
+  - script: |
+      set -x
+      df -h
+      $(docker.run) $(docker.src.map) $(docker.src.work) $(imageName) ./build.sh \
+        /t:WriteUsageBurndownData
+    displayName: Generate prebuilt burndown data
+    condition: and(succeeded(), eq(variables['generatePrebuiltBurndown'], true))
+    continueOnError: true
 
   # Run smoke tests. This is needed even in tarball legs to create the smoke-test-prereqs archive.
   - script: |

--- a/.vsts.pipelines/jobs/ci-linux.yml
+++ b/.vsts.pipelines/jobs/ci-linux.yml
@@ -77,7 +77,7 @@ jobs:
   - script: |
       set -x
       df -h
-      $(docker.run) $(docker.src.map) $(docker.src.work) $(imageName) ./build.sh \
+      $(docker.run) $(docker.src.map) $(docker.src.work) -e SOURCE_BUILD_SKIP_SUBMODULE_CHECK $(imageName) ./build.sh \
         /t:GeneratePrebuiltBurndownData
     displayName: Generate prebuilt burndown data
     condition: and(succeeded(), eq(variables['generatePrebuiltBurndown'], true))

--- a/.vsts.pipelines/jobs/ci-linux.yml
+++ b/.vsts.pipelines/jobs/ci-linux.yml
@@ -77,7 +77,7 @@ jobs:
       set -x
       df -h
       $(docker.run) $(docker.src.map) $(docker.src.work) $(imageName) ./build.sh \
-        /t:WriteUsageBurndownData
+        /t:GeneratePrebuiltBurndownData
     displayName: Generate prebuilt burndown data
     condition: and(succeeded(), eq(variables['generatePrebuiltBurndown'], true))
     continueOnError: true

--- a/build.proj
+++ b/build.proj
@@ -133,9 +133,12 @@
   </Target>
 
   <Target Name="GeneratePrebuiltBurndownData">
-    <WriteUsageBurndownData RootDirectory = "$(ProjectDir)"
-                            PrebuiltBaselineFile = "$(BaselineDataFile)"
-                            OutputFilePath = "$(PrebuiltBurndownDataFile)" /> 
+    <WriteUsageBurndownData RootDirectory="$(ProjectDir)"
+                            PrebuiltBaselineFile="$(OnlineBaselineDataFile)"
+                            OutputFilePath="$(OnlinePrebuiltBurndownDataFile)" />
+    <WriteUsageBurndownData RootDirectory="$(ProjectDir)"
+                            PrebuiltBaselineFile="$(OfflineBaselineDataFile)"
+                            OutputFilePath="$(OfflinePrebuiltBurndownDataFile)" />
   </Target>
 
   <Target Name="RunSmokeTest" DependsOnTargets="GetProdConBlobFeedUrl">

--- a/build.proj
+++ b/build.proj
@@ -4,6 +4,7 @@
 
   <UsingTask AssemblyFile="$(LeakDetectionTasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.dll" TaskName="CheckForPoison" />
   <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="CopyReferenceOnlyPackages" />
+  <UsingTask AssemblyFile="$(TasksBinDir)Microsoft.DotNet.SourceBuild.Tasks.dll" TaskName="WriteUsageBurndownData" />
 
   <Target Name="Build" DependsOnTargets="PrepareOutput;InitBuild">
     <Message Text="Build Environment: $(Platform) $(Configuration) $(TargetOS) $(TargetRid)" />
@@ -129,6 +130,12 @@
                     HashCatalogFilePath="$(PoisonReportDataFile)"
                     MarkerFileName="$(PoisonMarkerFile)"
                     PoisonReportOutputFilePath="$(PoisonUsageReportFile)" />
+  </Target>
+
+  <Target Name="GeneratePrebuiltBurndownData">
+    <WriteUsageBurndownData RootDirectory = "$(ProjectDir)"
+                            PrebuiltBaselineFile = "$(BaselineDataFile)"
+                            OutputFilePath = "$(PrebuiltBurndownDataFile)" /> 
   </Target>
 
   <Target Name="RunSmokeTest" DependsOnTargets="GetProdConBlobFeedUrl">

--- a/dir.props
+++ b/dir.props
@@ -83,7 +83,8 @@
     <ProdConManifestFile>$(PackageReportDir)prodcon-build.xml</ProdConManifestFile>
     <PoisonedReportFile>$(PackageReportDir)poisoned.txt</PoisonedReportFile>
     <ConflictingPackageReportDir>$(BaseOutputPath)conflict-report/</ConflictingPackageReportDir>
-    <PrebuiltBurndownDataFile>$(PackageReportDir)PrebuiltBurndownData.csv</PrebuiltBurndownDataFile>
+    <OfflinePrebuiltBurndownDataFile>$(PackageReportDir)PrebuiltBurndownData-offline.csv</OfflinePrebuiltBurndownDataFile>
+    <OnlinePrebuiltBurndownDataFile>$(PackageReportDir)PrebuiltBurndownData-online.csv</OnlinePrebuiltBurndownDataFile>
     <ReferencePackagesBaseDir>$(IntermediatePath)reference-packages/</ReferencePackagesBaseDir>
     <!--
       Change ReferencePackagesBaseDir conditionally in offline build.
@@ -96,8 +97,10 @@
     <ReferencePackagesDir>$(ReferencePackagesBaseDir)packages/</ReferencePackagesDir>
     <ReferencePackagesToDeleteDir>$(ReferencePackagesBaseDir)packages-to-delete/</ReferencePackagesToDeleteDir>
     <BaselineDataFile>$(ToolsLocalDir)prebuilt-baseline-</BaselineDataFile>
-    <BaselineDataFile Condition="'$(OfflineBuild)' == 'true'">$(BaselineDataFile)offline.xml</BaselineDataFile>
-    <BaselineDataFile Condition="'$(OfflineBuild)' != 'true'">$(BaselineDataFile)online.xml</BaselineDataFile>
+    <OfflineBaselineDataFile>$(BaselineDataFile)offline.xml</OfflineBaselineDataFile>
+    <OnlineBaselineDataFile>$(BaselineDataFile)online.xml</OnlineBaselineDataFile>
+    <BaselineDataFile Condition="'$(OfflineBuild)' == 'true'">$(OfflineBaselineDataFile)</BaselineDataFile>
+    <BaselineDataFile Condition="'$(OfflineBuild)' != 'true'">$(OnlineBaselineDataFile)</BaselineDataFile>
   </PropertyGroup>
 
   <!-- Import Build tools common props file where repo-independent properties are found -->

--- a/dir.props
+++ b/dir.props
@@ -47,7 +47,7 @@
     <IldasmPath>$(ToolsDir)ilasm/ildasm</IldasmPath>
     <ToolsLocalDir>$(ProjectDir)tools-local/</ToolsLocalDir>
     <TaskDirectory>$(ToolsLocalDir)tasks/</TaskDirectory>
-    <TasksBinDir>$(TaskDirectory)Microsoft.DotNet.SourceBuild.Tasks/bin/Debug/netstandard1.5/</TasksBinDir>
+    <TasksBinDir>$(TaskDirectory)Microsoft.DotNet.SourceBuild.Tasks/bin/Debug/netstandard2.0/</TasksBinDir>
     <LeakDetectionTasksBinDir>$(TaskDirectory)Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/</LeakDetectionTasksBinDir>
     <BaseIntermediatePath>$(BaseOutputPath)obj/</BaseIntermediatePath>
     <OutputPath>$(BaseOutputPath)$(Platform)/$(Configuration)/</OutputPath>
@@ -83,6 +83,7 @@
     <ProdConManifestFile>$(PackageReportDir)prodcon-build.xml</ProdConManifestFile>
     <PoisonedReportFile>$(PackageReportDir)poisoned.txt</PoisonedReportFile>
     <ConflictingPackageReportDir>$(BaseOutputPath)conflict-report/</ConflictingPackageReportDir>
+    <PrebuiltBurndownDataFile>$(PackageReportDir)PrebuiltBurndownData.csv</PrebuiltBurndownDataFile>
     <ReferencePackagesBaseDir>$(IntermediatePath)reference-packages/</ReferencePackagesBaseDir>
     <!--
       Change ReferencePackagesBaseDir conditionally in offline build.
@@ -94,6 +95,9 @@
     <ReferencePackagesSourceDir>$(ReferencePackagesBaseDir)source/</ReferencePackagesSourceDir>
     <ReferencePackagesDir>$(ReferencePackagesBaseDir)packages/</ReferencePackagesDir>
     <ReferencePackagesToDeleteDir>$(ReferencePackagesBaseDir)packages-to-delete/</ReferencePackagesToDeleteDir>
+    <BaselineDataFile>$(ToolsLocalDir)prebuilt-baseline-</BaselineDataFile>
+    <BaselineDataFile Condition="'$(OfflineBuild)' == 'true'">$(BaselineDataFile)offline.xml</BaselineDataFile>
+    <BaselineDataFile Condition="'$(OfflineBuild)' != 'true'">$(BaselineDataFile)online.xml</BaselineDataFile>
   </PropertyGroup>
 
   <!-- Import Build tools common props file where repo-independent properties are found -->

--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -467,10 +467,6 @@
 
   <Target Name="ReportPrebuiltUsage">
     <PropertyGroup>
-      <BaselineDataFile>$(ToolsLocalDir)prebuilt-baseline-</BaselineDataFile>
-      <BaselineDataFile Condition="'$(OfflineBuild)' == 'true'">$(BaselineDataFile)offline.xml</BaselineDataFile>
-      <BaselineDataFile Condition="'$(OfflineBuild)' != 'true'">$(BaselineDataFile)online.xml</BaselineDataFile>
-
       <FailOnPrebuiltBaselineError Condition="'$(FailOnPrebuiltBaselineError)' == ''">false</FailOnPrebuiltBaselineError>
     </PropertyGroup>
 

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.csproj
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CoreSetupPlatformAbstractionsPath>$(SubmoduleDirectory)core-setup/src/managed/Microsoft.DotNet.PlatformAbstractions/</CoreSetupPlatformAbstractionsPath>
     <OutputPath>$(MSBuildThisFileDirectory)bin/$(Configuration)</OutputPath>

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/Microsoft.DotNet.SourceBuild.Tasks.csproj
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/Microsoft.DotNet.SourceBuild.Tasks.csproj
@@ -27,9 +27,6 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core">
       <Version>15.6.82</Version>
     </PackageReference>
-    <PackageReference Include="System.ValueTuple">
-      <Version>4.4.0</Version>
-    </PackageReference>
   </ItemGroup>
 
   <!--

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/Microsoft.DotNet.SourceBuild.Tasks.csproj
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/Microsoft.DotNet.SourceBuild.Tasks.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CoreSetupPlatformAbstractionsPath>$(SubmoduleDirectory)core-setup/src/managed/Microsoft.DotNet.PlatformAbstractions/</CoreSetupPlatformAbstractionsPath>
     <OutputPath>$(MSBuildThisFileDirectory)bin/$(Configuration)</OutputPath>

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/WriteUsageBurndownData.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/WriteUsageBurndownData.cs
@@ -1,0 +1,124 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Task = Microsoft.Build.Utilities.Task;
+
+namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
+{
+    public class WriteUsageBurndownData : Task
+    {
+        /// <summary>
+        /// Specifies the root directory for git.
+        /// </summary>
+        [Required]
+        public string RootDirectory { get; set; }
+
+        /// <summary>
+        /// Specifies the path to the prebuilt baseline file
+        /// to be used to generate the burndown.
+        /// </summary>
+        [Required]
+        public string PrebuiltBaselineFile { get; set; }
+
+        /// <summary>
+        /// Output data CSV file. 
+        /// </summary>
+        [Required]
+        public string OutputFilePath { get; set; }
+
+        class commit
+        {
+            public string sha { get; set; }
+            public string title { get; set; }
+            public DateTime commitDate { get; set; }
+            public int packageVersionCount { get; set; }
+            public int packageCount { get; set; }
+
+            public override string ToString()
+            {
+                return $"{sha}, {title}, {commitDate}, {packageVersionCount}, {packageCount}";
+            }
+        }
+
+        public override bool Execute()
+        {
+            string baselineRelativeFileName = PrebuiltBaselineFile.Replace(RootDirectory, "");
+            string gitLogCommand = $"log --first-parent --pretty=format:%H,%f,%ci -- {PrebuiltBaselineFile}";
+
+            DateTime startTime = DateTime.Now;
+            Log.LogMessage(MessageImportance.High, "Generating summary usage burndown data...");
+
+
+            var data = ExecuteGitCommand(RootDirectory, gitLogCommand).AsParallel().Select(commitLine =>
+            {
+                var splitLine = commitLine.Split(',');
+                var commit = new commit() { sha = splitLine[0], title = splitLine[1], commitDate = DateTime.Parse(splitLine[2]) };
+                var fileContents = GetFileContents(baselineRelativeFileName, commit.sha);
+                var usages = UsageData.Parse(XElement.Parse(fileContents)).Usages.NullAsEmpty().ToArray();
+                commit.packageVersionCount = usages.Count();
+                commit.packageCount = usages.GroupBy(i => i.PackageIdentity.Id).Select(grp => grp.First()).Count();
+                return commit;
+            })
+            .Select(c => c.ToString())
+            .Aggregate((a, b) => a + '\n' + b);
+    
+            Directory.CreateDirectory(Path.GetDirectoryName(OutputFilePath));
+
+            File.WriteAllText(OutputFilePath, data);
+
+            Log.LogMessage(
+                MessageImportance.High,
+                $"Generating summary usage burndown data at {OutputFilePath} done. Took {DateTime.Now - startTime}");
+
+            return !Log.HasLoggedErrors;
+        }
+
+        /// <summary>
+        /// Get the contents of a git file based on the commit sha.
+        /// </summary>
+        /// <param name="relativeFilePath">The relative path (from the git root) to the file.</param>
+        /// <param name="commitSha">The commit sha for the version of the file to get.</param>
+        /// <returns>The contents of the specified file.</returns>
+        public string GetFileContents(string relativeFilePath, string commitSha)
+        {
+            WebClient client = new WebClient();
+            var xmlString = client.DownloadString(String.Format("https://raw.githubusercontent.com/dotnet/source-build/{0}/{1}", commitSha, relativeFilePath.Replace('\\', '/')));
+            return xmlString;
+        }
+
+        /// <summary>
+        /// Executes a git command and returns the result.
+        /// </summary>
+        /// <param name="workingDirectory">The working directory for the git command.</param>
+        /// <param name="command">The git command to execute.</param>
+        /// <returns>An array of the output lines of the git command.</returns>
+        public string[] ExecuteGitCommand(string workingDirectory, string command)
+        {
+            Process _process = new Process();
+            _process.StartInfo.FileName = "git";
+            _process.StartInfo.Arguments = command;
+            _process.StartInfo.WorkingDirectory = workingDirectory;
+            _process.StartInfo.RedirectStandardOutput = true;
+            _process.StartInfo.UseShellExecute = false;
+            _process.Start();
+            _process.WaitForExit();
+            return _process.StandardOutput.ReadToEnd().Split('\n');
+        }
+    }
+}

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/WriteUsageBurndownData.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/UsageReport/WriteUsageBurndownData.cs
@@ -55,11 +55,11 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
             {
                 var splitLine = commitLine.Split(',');
                 var commit = new Commit()
-                    {
-                        Sha = splitLine[0],
-                        Title = splitLine[1],
-                        CommitDate = DateTime.Parse(splitLine[2])
-                    };
+                {
+                    Sha = splitLine[0],
+                    Title = splitLine[1],
+                    CommitDate = DateTime.Parse(splitLine[2])
+                };
                 string fileContents = GetFileContents(baselineRelativeFileName, commit.Sha);
                 Usage[] usages = UsageData.Parse(XElement.Parse(fileContents)).Usages.NullAsEmpty().ToArray();
                 commit.PackageVersionCount = usages.Count();


### PR DESCRIPTION
Generates burndown data from the prebuild report data checked in to git.  The burndown data counts the number of prebuilt packages and versions and number of prebuilt packages alone.