### PR TITLE
Only disassemble ref packages to create tarball

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -44,7 +44,7 @@
   -->
   <Target Name="CopyAndDisassembleReferenceOnlyPackages"
           AfterTargets="Build"
-          Condition="'$(OfflineBuild)' != 'true' and '$(OS)' != 'Windows_NT'">
+          Condition="'$(OfflineBuild)' != 'true' and '$(ArchiveDownloadedPackages)' == 'true' and '$(OS)' != 'Windows_NT'">
 
     <CopyReferenceOnlyPackages
         PackageCacheDir="$(PackagesDir)"


### PR DESCRIPTION
Disassembling the packages takes some time, is noisy, and isn't necessary in a production build that doesn't produce a tarball. This change only disassembles ref-only packages when creating a tarball.

I used this change while working on the 3.0 preview update to save some time. This PR pulls it out to add to all branches.