### PR TITLE
Add check for files with no extensions.  

### DIFF
--- a/tools-local/prebuilt-baseline-offline.xml
+++ b/tools-local/prebuilt-baseline-offline.xml
@@ -34,6 +34,8 @@
     <PackageIdentity Id="Microsoft.DotNet.BuildTools" Version="2.1.0-rc1-03131-06" />
     <PackageIdentity Id="RoslynTools.RepoToolset" Version="1.0.0-beta2-62805-03" />
     <PackageIdentity Id="runtime.linux-x64.Microsoft.NETCore.App" Version="2.1.5" />
+    <PackageIdentity Id="runtime.linux-x64.Microsoft.NETCore.ILAsm" Version="2.1.6-servicing-27017-03" />
+    <PackageIdentity Id="runtime.linux-x64.Microsoft.NETCore.ILDAsm" Version="2.1.6-servicing-27017-03" />
     <PackageIdentity Id="runtime.linux-x64.Microsoft.NETCore.Jit" Version="2.1.6-servicing-27017-03" />
     <PackageIdentity Id="runtime.linux-x64.Microsoft.NETCore.Runtime.CoreCLR" Version="2.1.6-servicing-27017-03" />
   </NeverRestoredTarballPrebuilts>
@@ -213,6 +215,9 @@
     <Usage Id="runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.1" Rid="fedora.24-x64" />
     <Usage Id="runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.2" Rid="fedora.24-x64" />
     <Usage Id="runtime.linux-x64.Microsoft.NETCore.App" Version="2.0.0" Rid="linux-x64" />
+    <Usage Id="runtime.linux-x64.Microsoft.NETCore.DotNetAppHost" Version="2.0.0" Rid="linux-x64" />
+    <Usage Id="runtime.linux-x64.Microsoft.NETCore.DotNetAppHost" Version="2.1.5" Rid="linux-x64" />
+    <Usage Id="runtime.linux-x64.Microsoft.NETCore.DotNetHost" Version="2.1.5" Rid="linux-x64" />
     <Usage Id="runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy" Version="2.0.0" Rid="linux-x64" />
     <Usage Id="runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy" Version="2.1.5" Rid="linux-x64" />
     <Usage Id="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" Version="2.0.0" Rid="linux-x64" />
@@ -225,6 +230,7 @@
     <Usage Id="runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.1" Rid="opensuse.42.1-x64" />
     <Usage Id="runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.2" Rid="opensuse.42.1-x64" />
     <Usage Id="runtime.osx-x64.Microsoft.NETCore.App" Version="2.0.0" Rid="osx-x64" />
+    <Usage Id="runtime.osx-x64.Microsoft.NETCore.DotNetAppHost" Version="2.0.0" Rid="osx-x64" />
     <Usage Id="runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy" Version="2.0.0" Rid="osx-x64" />
     <Usage Id="runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver" Version="2.0.0" Rid="osx-x64" />
     <Usage Id="runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple" Version="4.3.0" Rid="osx.10.10-x64" />

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/CopyReferenceOnlyPackages.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/CopyReferenceOnlyPackages.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
     /// </summary>
     public class CopyReferenceOnlyPackages : Task
     {
-        private static readonly string[] extensionsToExclude = { ".exe", ".dylib", ".so", ".profdata", ".pgd" };
+        private static readonly string[] extensionsToExclude = { ".exe", ".dylib", ".so", ".profdata", ".pgd", ".a" };
         private static readonly string[] pathsToExclude = { "testdata" };
         private static readonly string refPath = string.Concat(Path.DirectorySeparatorChar, "ref", Path.DirectorySeparatorChar);
 
@@ -53,14 +53,6 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
         [Required]
         public string DestinationDir { get; set; }
 
-        /// <summary>
-        /// Enumerate all files in a directory and its sub-directories.
-        /// </summary>
-        private static IEnumerable<string> EnumerateAllFiles(string path, string searchPattern)
-        {
-            return Directory.EnumerateFiles(path, searchPattern, SearchOption.AllDirectories);
-        }
-
         public override bool Execute()
         {
             DateTime startTime = DateTime.Now;
@@ -69,14 +61,17 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
                 .Where(nupkgFilePath =>
                 {
                     // Get all files in the nupkg path and normalize directory separators
-                    var nupkgFiles = EnumerateAllFiles(Path.GetDirectoryName(nupkgFilePath), "*.*").ToArray();
+                    var nupkgFiles = EnumerateAllFiles(Path.GetDirectoryName(nupkgFilePath), "*").ToArray();
 
                     // Do not include directories that contain exes, shared object files, OSX dynamic libraries
-                    // or profiling data
+                    // or profiling data.  Also remove binaries with no extension.
                     if (nupkgFiles
                         .Any(
                             file => extensionsToExclude.Contains(Path.GetExtension(file)) 
-                            || pathsToExclude.Any(path => file.Contains(path))))
+                            || pathsToExclude.Any(path => file.Contains(path))
+                            || (Path.GetExtension(file) == "" && IsBinaryFile(file))
+                            )
+                        )
                     {
                         return false;
                     }
@@ -93,7 +88,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
             Directory.CreateDirectory(IdentifiedPackagesDir);
             foreach (var dir in referenceOnlyPackageDirectories)
             {
-                foreach (var file in EnumerateAllFiles(dir, "*.*"))
+                foreach (var file in EnumerateAllFiles(dir, "*"))
                 {
                     if (file.EndsWith(".nupkg")) 
                     {
@@ -113,7 +108,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
                         if (destination.EndsWith(".nuspec"))
                         {
                             var fileText = File.ReadAllText(destination);
-                            File.WriteAllText(destination, fileText.Replace("</package>", "<files><file src=\".\\**\\*.*\"/></files>\n</package>"));
+                            File.WriteAllText(destination, fileText.Replace("</package>", "<files><file src=\".\\**\\*\"/></files>\n</package>"));
                         }
                     }
                 }
@@ -126,6 +121,37 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
                     $"Found {referenceOnlyPackageDirectories.Count()} packages.  Took {DateTime.Now - startTime} ");
 
             return !Log.HasLoggedErrors;
+        }
+
+        /// <summary>
+        /// Enumerate all files in a directory and its sub-directories.
+        /// </summary>
+        private static IEnumerable<string> EnumerateAllFiles(string path, string searchPattern)
+        {
+            return Directory.EnumerateFiles(path, searchPattern, SearchOption.AllDirectories);
+        }
+
+
+        /// <summary>
+        /// Quick binary file detection.  If file contains double null in the first 512 characters
+        /// chances are high that it is binary.  This is only used when files have no extensions.
+        /// </summary>
+        private static bool IsBinaryFile(string filePath)
+        {
+            int ch1 = ' ', ch2 = ' ';
+            int charCount = 512;
+            using (StreamReader stream = new StreamReader(new FileStream(filePath, FileMode.Open)))
+            {
+                while ((ch1 = stream.Read()) != -1 && charCount-- > 0)
+                {
+                    if (ch1 == '\0' && ch2 == '\0')
+                    {
+                        return true;
+                    }
+                    ch2 = ch1;
+                }
+            }
+            return false;
         }
 
     }


### PR DESCRIPTION
If files with no extensions are binaries, they're not eligible to be included in reference-only packages.  This adds backa handfull of prebuilts that shouldn't have been eliminated with the original referenceOnlyPackages PR.