### PR TITLE
Revert "Workaround: CentralPackageVersions sdk as override"

### DIFF
--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -398,7 +398,7 @@
     <ItemGroup>
       <EnvironmentVariables Include="SOURCE_BUILT_SDK_ID_%(UseSourceBuiltSdkOverride.Group)=%(UseSourceBuiltSdkOverride.Identity)" />
       <EnvironmentVariables Include="SOURCE_BUILT_SDK_VERSION_%(UseSourceBuiltSdkOverride.Group)=%(UseSourceBuiltSdkOverride.Version)" />
-      <EnvironmentVariables Include="SOURCE_BUILT_SDK_DIR_%(UseSourceBuiltSdkOverride.Group)=$(ToolPackageExtractDir)%(UseSourceBuiltSdkOverride.Identity)/" />
+      <EnvironmentVariables Include="SOURCE_BUILT_SDK_DIR_%(UseSourceBuiltSdkOverride.Group)=$(ToolPackageExtractDir)%(UseSourceBuiltSdkOverride.Identity)/sdk/" />
     </ItemGroup>
   </Target>
 

--- a/repos/msbuild.proj
+++ b/repos/msbuild.proj
@@ -40,41 +40,5 @@
     <RepositoryReference Include="roslyn" />
   </ItemGroup>
 
-  <!--
-    Begin workaround: https://github.com/dotnet/source-build/issues/933
-
-    The CentralPackageVersions SDK isn't actually source-built. We get it as a text-only prebuilt,
-    but the NuGet resolver seems flaky so we're using our resolver instead. We only have access to
-    the nupkg ahead of time when building a tarball, so only enable this workaround then.
-  -->
-  <ItemGroup Condition="'$(OfflineBuild)' == 'true'">
-    <CentralPackageVersionsSdkOverride Include="Microsoft.Build.CentralPackageVersions" Group="CENTRAL_PACKAGE_VERSIONS" />
-    <UseSourceBuiltSdkOverride Include="@(CentralPackageVersionsSdkOverride)" />
-  </ItemGroup>
-
-  <Target Name="ExtractCentralPackageVersionsSdkPackage"
-          BeforeTargets="SetSourceBuiltSdkOverrides"
-          Condition="'$(OfflineBuild)' == 'true'">
-    <ItemGroup>
-      <_CentralVersionsToolPackage
-        Include="$(ReferencePackagesDir)%(CentralPackageVersionsSdkOverride.Identity)*.nupkg"
-        Id="%(CentralPackageVersionsSdkOverride.Identity)" />
-    </ItemGroup>
-
-    <PropertyGroup>
-      <CentralVersionsSdkDir>$(ToolPackageExtractDir)%(_CentralVersionsToolPackage.Id)/</CentralVersionsSdkDir>
-    </PropertyGroup>
-
-    <Message Importance="High" Text="Setting up SDK package for UseSourceBuiltSdkOverride: %(_CentralVersionsToolPackage.Filename)" />
-
-    <ZipFileExtractToDirectory
-      SourceArchive="@(_CentralVersionsToolPackage)"
-      DestinationDirectory="$(CentralVersionsSdkDir)"
-      OverwriteDestination="true" />
-  </Target>
-  <!--
-    End workaround: https://github.com/dotnet/source-build/issues/933
-  -->
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
 </Project>

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/SourceBuiltSdkResolver.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks/SourceBuiltSdkResolver.cs
@@ -6,7 +6,6 @@ using Microsoft.Build.Framework;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
 namespace Microsoft.DotNet.SourceBuild.Tasks
@@ -18,9 +17,9 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
     /// SOURCE_BUILD_SDK_ID_EXAMPLE=Your.Sdk.Example
     ///   ID of the SDK nuget package to override.
     /// 
-    /// SOURCE_BUILD_SDK_DIR_EXAMPLE=/git/repo/bin/extracted/Your.Sdk.Example/
-    ///   Directory where the sdk/Sdk.props and/or sdk/Sdk.targets files are located. This should be
-    ///   the directory where the override SDK package is extracted.
+    /// SOURCE_BUILD_SDK_DIR_EXAMPLE=/git/repo/bin/extracted/Your.Sdk.Example/sdk/
+    ///   Directory where the Sdk.props/Sdk.targets files are located. The override SDK package
+    ///   should be extracted to a directory: this is the "sdk" dir within that directory.
     /// 
     /// SOURCE_BUILD_SDK_VERSION_EXAMPLE=1.0.0-source-built
     ///   (Optional) Version of the SDK package to use. This is informational.
@@ -91,20 +90,11 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
                 {
                     LogMessage($"Overriding {sdkDescription} with '{match.Group}'");
 
-                    return factory.IndicateSuccess(match.SdkDir, match.Version);
+                    return factory.IndicateSuccess(match.Dir, match.Version);
                 }
             }
 
             return factory.IndicateFailure(unresolvableReasons.Select(r => $"[{Name}] {r}"));
-        }
-
-        /// <summary>
-        /// Takes a directory path (not ending in a separator) and determines if it is the "sdk"
-        /// directory inside a SDK package with a case-insensitive comparison.
-        /// </summary>
-        private static bool IsSdkDirectory(string path)
-        {
-            return Path.GetFileName(path).Equals("sdk", StringComparison.OrdinalIgnoreCase);
         }
 
         private class SourceBuiltSdkOverride
@@ -135,19 +125,12 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
                         version = "1.0.0-source-built";
                     }
 
-                    string sdkDir = null;
-                    if (!string.IsNullOrEmpty(dir))
-                    {
-                        sdkDir = Directory.EnumerateDirectories(dir).FirstOrDefault(IsSdkDirectory);
-                    }
-
                     return new SourceBuiltSdkOverride
                     {
                         Group = group,
                         Id = id,
                         Version = version,
-                        Dir = dir,
-                        SdkDir = sdkDir,
+                        Dir = dir
                     };
                 }
                 return null;
@@ -173,11 +156,6 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
             /// </summary>
             public string Dir { get; set; }
 
-            /// <summary>
-            /// Directory where the Sdk.props/Sdk.targets files are found, inside Dir.
-            /// </summary>
-            public string SdkDir { get; set; }
-
             public override string ToString() => $"'{Group}' for '{Id}/{Version}' at '{Dir}'";
 
             public IEnumerable<string> GetValidationErrors()
@@ -189,10 +167,6 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
                 if (string.IsNullOrEmpty(Dir))
                 {
                     yield return $"'{EnvDir}{Group}' not specified.";
-                }
-                else if (string.IsNullOrEmpty(SdkDir))
-                {
-                    yield return $"Didn't find any 'sdk' directory in SDK package dir '{Dir}'";
                 }
             }
         }


### PR DESCRIPTION
This reverts commit 0df70cc344d264ea792b60c1511bd7a4f700c426 per [my comment in #933](https://github.com/dotnet/source-build/issues/933#issuecomment-447919547):

> A few ways forward:
> 
> 1. Keep the workaround (using the source-built SDK resolver) that ensures this won't repro.
> 2. Remove the workaround because it doesn't seem to repro. However, if it does repro, we're in no better position to find out what happened. The problem becomes a source of flakiness.
>    * I'm relatively OK with this, we can add the workaround from 1 back in if it repros again.
