### PR TITLE
Add "work-tree" parameter to git apply to unblock tarball builds within a git repo

### DIFF
--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -76,7 +76,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <PatchCommand>git apply --ignore-whitespace --whitespace=nowarn</PatchCommand>
+      <PatchCommand>git --work-tree=$(ProjectDirectory) apply --ignore-whitespace --whitespace=nowarn</PatchCommand>
     </PropertyGroup>
 
     <Exec Command="$(PatchCommand) %(PatchesToApply.Identity)"


### PR DESCRIPTION
This ensures patches apply even when building the tarball inside a git repo. Without `--work-tree`, the apply command finds the ancenstor `.git` and uses it as the root for relative paths, causing a patch skip.