### PR TITLE
Add parameters for the 1.0 and 1.1 builds shipping at the same time as the 2.1.9 release.

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -27,6 +27,14 @@
     <MicrosoftNETSdkRazorPackageVersion>2.2.0</MicrosoftNETSdkRazorPackageVersion>
   </PropertyGroup>
 
+  <!-- versions used for self-contained published apps by the final product.
+       These currently need to be manually updated each release, using the latest
+       shipped 1.0 and 1.1 version numbers.  -->
+  <PropertyGroup>
+    <LatestPatchVersionForNetCore1_0>1.0.15</LatestPatchVersionForNetCore1_0>
+    <LatestPatchVersionForNetCore1_1>1.1.12</LatestPatchVersionForNetCore1_1>
+  </PropertyGroup>
+
   <!-- Build stabilization properties as passed in by ProdCon. -->
   <PropertyGroup>
     <UseStableVersions Condition="'$(UseStableVersions)' == ''">true</UseStableVersions>

--- a/repos/cli.proj
+++ b/repos/cli.proj
@@ -34,6 +34,10 @@
     <BuildCommandArgs>$(BuildCommandArgs) /p:DefaultTargetLatestAspNetCoreRuntimePatch=true</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /v:$(LogVerbosity)</BuildCommandArgs>
 
+    <!-- These are the versions used for self-contained apps.  They are currently updated manually in dependencies.props for each release. -->
+    <BuildCommandArgs>$(BuildCommandArgs) /p:LatestPatchVersionForNetCore1_0=$(LatestPatchVersionForNetCore1_0)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:LatestPatchVersionForNetCore1_1=$(LatestPatchVersionForNetCore1_1)</BuildCommandArgs>
+
     <BuildCommandArgs Condition="'$(OS)' == 'Windows_NT'">$(BuildCommandArgs) '/p:CLITargets=\&quot;\&quot;\&quot;Prepare;Compile;Package\&quot;\&quot;\&quot;'</BuildCommandArgs>
     <BuildCommandArgs Condition="'$(OS)' != 'Windows_NT'">$(BuildCommandArgs) '/p:CLITargets=&quot;Prepare;Compile;Package&quot;'</BuildCommandArgs>
 


### PR DESCRIPTION
These will also be used for every future release.  Currently these are manually updated each release, but we want to eventually get the versions numbers published somewhere we can automatically update them.