### PR TITLE
Add parameters for the 1.0,  1.1, and 2.1 builds shipping at the same time as the 2.2.3 release.

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -27,6 +27,17 @@
     <MicrosoftNETSdkRazorPackageVersion>2.2.0</MicrosoftNETSdkRazorPackageVersion>
   </PropertyGroup>
 
+  <!-- versions used for self-contained published apps by the final product.
+       These currently need to be manually updated each release, using the latest
+       shipped 1.0, 1.1, and 2.1 version numbers.  -->
+  <PropertyGroup>
+    <MicrosoftNETCoreAppLatestVersion1_0>1.0.15</MicrosoftNETCoreAppLatestVersion1_0>
+    <MicrosoftNETCoreAppLatestVersion1_1>1.1.12</MicrosoftNETCoreAppLatestVersion1_1>
+    <MicrosoftNETCoreAppLatestVersion2_1>2.1.9</MicrosoftNETCoreAppLatestVersion2_1>
+    <MicrosoftAspNetCoreAppLatestVersion2_1>2.1.9</MicrosoftAspNetCoreAppLatestVersion2_1>
+    <MicrosoftAspNetCoreAllLatestVersion2_1>2.1.9</MicrosoftAspNetCoreAllLatestVersion2_1>
+  </PropertyGroup>
+
   <!-- Build stabilization properties as passed in by ProdCon. -->
   <PropertyGroup>
     <UseStableVersions Condition="'$(UseStableVersions)' == ''">true</UseStableVersions>

--- a/repos/cli.proj
+++ b/repos/cli.proj
@@ -34,6 +34,13 @@
     <BuildCommandArgs>$(BuildCommandArgs) /p:DefaultTargetLatestAspNetCoreRuntimePatch=true</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /v:$(LogVerbosity)</BuildCommandArgs>
 
+    <!-- These are the versions used for self-contained apps.  They are currently updated manually in dependencies.props for each release. -->
+    <BuildCommandArgs>$(BuildCommandArgs) /p:MicrosoftNETCoreAppLatestVersion1_0=$(MicrosoftNETCoreAppLatestVersion1_0)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:MicrosoftNETCoreAppLatestVersion1_1=$(MicrosoftNETCoreAppLatestVersion1_1)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:MicrosoftNETCoreAppLatestVersion2_1=$(MicrosoftNETCoreAppLatestVersion2_1)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:MicrosoftAspNetCoreAppLatestVersion2_1=$(MicrosoftAspNetCoreAppLatestVersion2_1)</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:MicrosoftAspNetCoreAllLatestVersion2_1=$(MicrosoftAspNetCoreAllLatestVersion2_1)</BuildCommandArgs>
+
     <BuildCommandArgs Condition="'$(OS)' == 'Windows_NT'">$(BuildCommandArgs) '/p:CLITargets=\&quot;\&quot;\&quot;Prepare;Compile;Package\&quot;\&quot;\&quot;'</BuildCommandArgs>
     <BuildCommandArgs Condition="'$(OS)' != 'Windows_NT'">$(BuildCommandArgs) '/p:CLITargets=&quot;Prepare;Compile;Package&quot;'</BuildCommandArgs>
 


### PR DESCRIPTION
This will also be used for all future releases.  Currently these must be manually updated with the correct versions each release, but we hope to automate these updates in the future.