### PR TITLE
 Add git commit count and hash in core-setup proj 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,18 @@
 [submodule "src/coreclr"]
 	path = src/coreclr
 	url = https://github.com/dotnet/coreclr
-	branch = release/2.0.0
+	branch = .
 [submodule "src/roslyn"]
 	path = src/roslyn
 	url = https://github.com/dotnet/roslyn
 [submodule "src/core-setup"]
 	path = src/core-setup
 	url = https://github.com/dotnet/core-setup
-	branch = release/2.0.0
+	branch = .
 [submodule "src/standard"]
 	path = src/standard
 	url = https://github.com/dotnet/standard
-	branch = release/2.0.0
+	branch = .
 [submodule "src/cli"]
 	path = src/cli
 	url = https://github.com/dotnet/cli
@@ -46,7 +46,7 @@
 [submodule "src/corefx"]
 	path = src/corefx
 	url = https://github.com/dotnet/corefx
-	branch = release/2.0.0
+	branch = .
 [submodule "src/fsharp"]
 	path = src/fsharp
 	url = https://github.com/Microsoft/VisualFSharp

--- a/repos/core-setup.proj
+++ b/repos/core-setup.proj
@@ -34,6 +34,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EnvironmentVariables Include="CommitCount=$(GitCommitCount)" />
+    <EnvironmentVariables Include="LatestCommit=$(GitCommitHash)" />
     <EnvironmentVariables Include="OfficialBuildId=$(OfficialBuildId)" />
   </ItemGroup>
 


### PR DESCRIPTION
* Add git commit count and hash in core-setup proj

Fixes #741

* Use reflexive `.` to set tracking branch same as in the current repo - [docs](https://git-scm.com/docs/gitmodules#Documentation/gitmodules.txt-submoduleltnamegtbranch)
  * This only affects when we update with remote (without `cd`ing into directories one at a time), i.e.
    `git submodule update --remote`