### PR TITLE
Remove arcade dependency on newtonsoft so arcades gets the version it…

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -93,7 +93,7 @@
       <Sha>b487ff10aafb8b58eaa2b78a236b1e97999d7a22</Sha>
     </Dependency>
     <!-- external dependencies, not handled by Maestro/Arcade -->
-    <Dependency Name="Newtonsoft.Json" Version="9.0.1">
+    <Dependency Name="Newtonsoft.Json" Version="12.0.1">
       <Uri>https://github.com/adaggarwal/Newtonsoft.Json</Uri>
       <Sha>252b0a02a539d144a246267010b91870c86744e8</Sha>
       <RepoName>newtonsoft-json</RepoName>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -94,8 +94,8 @@
     </Dependency>
     <!-- external dependencies, not handled by Maestro/Arcade -->
     <Dependency Name="Newtonsoft.Json" Version="9.0.1">
-      <Uri>https://github.com/dseefeld/Newtonsoft.Json</Uri>
-      <Sha>e43dae94c26f0c30e9095327a3a9eac87193923d</Sha>
+      <Uri>https://github.com/adaggarwal/Newtonsoft.Json</Uri>
+      <Sha>252b0a02a539d144a246267010b91870c86744e8</Sha>
       <RepoName>newtonsoft-json</RepoName>
     </Dependency>
     <!-- dependencies that will go away soon -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -93,9 +93,9 @@
       <Sha>b487ff10aafb8b58eaa2b78a236b1e97999d7a22</Sha>
     </Dependency>
     <!-- external dependencies, not handled by Maestro/Arcade -->
-    <Dependency Name="Newtonsoft.Json" Version="12.0.1">
+    <Dependency Name="Newtonsoft.Json" Version="12.0.2">
       <Uri>https://github.com/adaggarwal/Newtonsoft.Json</Uri>
-      <Sha>252b0a02a539d144a246267010b91870c86744e8</Sha>
+      <Sha>cac0690ad133c5e166ce5642dc71175791404fad</Sha>
       <RepoName>newtonsoft-json</RepoName>
     </Dependency>
     <!-- dependencies that will go away soon -->

--- a/repos/arcade.proj
+++ b/repos/arcade.proj
@@ -52,10 +52,6 @@
     <EnvironmentVariables Include="DotNetUseShippingVersions=false" />
   </ItemGroup>
 
-  <ItemGroup>
-    <RepositoryReference Include="newtonsoft-json" />
-  </ItemGroup>
-
   <PropertyGroup>
     <ArcadeBootstrapVersion Condition="'$(OfflineBuild)' == 'true'">1.0.0-dev</ArcadeBootstrapVersion>
     <ArcadeBootstrapVersion Condition="'$(OfflineBuild)' != 'true'">1.0.0-beta.19306.12</ArcadeBootstrapVersion>

--- a/repos/newtonsoft-json.proj
+++ b/repos/newtonsoft-json.proj
@@ -6,19 +6,22 @@
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
-
+  
+  <!--The Library Frameworks was added to environment variables so as to override the frameworks in newtonsoft csproj-->
+  <!--The semicolons were added with encoding so as to avoid conflicts in MSBuild shell-->
   <ItemGroup>
-    <EnvironmentVariables Include="LibraryFrameworks=netstandard1.0%3bnetstandard1.3%3bnetstandard2.0" />
+    <EnvironmentVariables Include="LibraryFrameworks=netstandard1.0%3Bnetstandard1.3%3Bnetstandard2.0" />
+    <RepositoryReference Include="arcade" />
   </ItemGroup>   
- 
+
   <PropertyGroup>
     <NuGetConfigFile>$(ProjectDirectory)/Src/NuGet.Config</NuGetConfigFile>
     <NewtonsoftJsonKeyFilePath>$(KeysDir)Newtonsoft.Json.snk</NewtonsoftJsonKeyFilePath>
     <NewtonsoftJsonDirectory>$(ProjectDirectory)/Src/Newtonsoft.Json/</NewtonsoftJsonDirectory>
     <NewtonsoftJsonProjectPath>$(NewtonsoftJsonDirectory)Newtonsoft.Json.csproj</NewtonsoftJsonProjectPath>
     <DotnetToolCommandArguments>"/p:DotnetOnly=true" "/p:Configuration=$(Configuration)" "/p:AssemblyOriginatorKeyFile=$(NewtonsoftJsonKeyFilePath)" "/p:SignAssembly=true" "/p:PublicSign=true" "/p:TreatWarningsAsErrors=false" "/p:AdditionalConstants=SIGNED"</DotnetToolCommandArguments>
-    <BuildCommand>$(DotnetToolCommand) build $(NewtonsoftJsonProjectPath) $(DotnetToolCommandArguments)</BuildCommand>
-    <BuildPackagesCommand>$(DotnetToolCommand) pack $(NewtonsoftJsonProjectPath) $(DotnetToolCommandArguments)</BuildPackagesCommand>
+    <BuildCommand>$(DotnetToolCommand) build $(NewtonsoftJsonProjectPath) /bl:restore.binlog $(DotnetToolCommandArguments)</BuildCommand>
+    <BuildPackagesCommand>$(DotnetToolCommand) pack $(NewtonsoftJsonProjectPath) /bl:restore.binlog $(DotnetToolCommandArguments)</BuildPackagesCommand>
     <CleanCommand>$(DotnetToolCommand) clean $(NewtonsoftJsonProjectPath) $(DotnetToolCommandArguments)</CleanCommand>
     <PackagesOutput>$(NewtonsoftJsonDirectory)bin/$(Configuration)/</PackagesOutput>
     <RepoApiImplemented>false</RepoApiImplemented>

--- a/repos/newtonsoft-json.proj
+++ b/repos/newtonsoft-json.proj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PreferredHash>252b0a02a539d144a246267010b91870c86744e8</PreferredHash>
+    <PreferredHash>cac0690ad133c5e166ce5642dc71175791404fad</PreferredHash>
     <SourceDirectory>Newtonsoft.Json</SourceDirectory>
   </PropertyGroup>
 

--- a/repos/newtonsoft-json.proj
+++ b/repos/newtonsoft-json.proj
@@ -34,22 +34,5 @@
           IgnoreStandardErrorWarningFormat="true" />
   </Target>
 
-  <Target Name="ClearNonSourceBuildCachedPackages" AfterTargets="Build">
-    <Exec Command="sh -c 'rm -rf $(PackagesDir)/newtonsoft.json $(PackagesDir)/newtonsoft.json.bson'"
-          WorkingDirectory="$(ProjectDirectory)" />
-    <ItemGroup>
-      <PackageFiles Include="$(PackagesDir)/newtonsoft*" />
-    </ItemGroup>
-
-
-
-    <Message Importance="High" Text="Package files remaining: @(PackageFiles)" />
-  </Target>
-
-  <!--This is a workaround dependency and is not a real one. It was added so that arcade could use the newtonsoft its compatible with and other projects can use the newer newtonsoft version-->
-  <ItemGroup>
-    <RepositoryReference Include="arcade" />
-  </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
 </Project>

--- a/repos/newtonsoft-json.proj
+++ b/repos/newtonsoft-json.proj
@@ -1,17 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PreferredHash>e43dae94c26f0c30e9095327a3a9eac87193923d</PreferredHash>
+    <PreferredHash>252b0a02a539d144a246267010b91870c86744e8</PreferredHash>
     <SourceDirectory>Newtonsoft.Json</SourceDirectory>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
+  <ItemGroup>
+    <EnvironmentVariables Include="LibraryFrameworks=netstandard1.0%3bnetstandard1.3%3bnetstandard2.0" />
+  </ItemGroup>   
+ 
   <PropertyGroup>
     <NuGetConfigFile>$(ProjectDirectory)/Src/NuGet.Config</NuGetConfigFile>
     <NewtonsoftJsonKeyFilePath>$(KeysDir)Newtonsoft.Json.snk</NewtonsoftJsonKeyFilePath>
     <NewtonsoftJsonDirectory>$(ProjectDirectory)/Src/Newtonsoft.Json/</NewtonsoftJsonDirectory>
-    <NewtonsoftJsonProjectPath>$(NewtonsoftJsonDirectory)Newtonsoft.Json.Dotnet.csproj</NewtonsoftJsonProjectPath>
+    <NewtonsoftJsonProjectPath>$(NewtonsoftJsonDirectory)Newtonsoft.Json.csproj</NewtonsoftJsonProjectPath>
     <DotnetToolCommandArguments>"/p:DotnetOnly=true" "/p:Configuration=$(Configuration)" "/p:AssemblyOriginatorKeyFile=$(NewtonsoftJsonKeyFilePath)" "/p:SignAssembly=true" "/p:PublicSign=true" "/p:TreatWarningsAsErrors=false" "/p:AdditionalConstants=SIGNED"</DotnetToolCommandArguments>
     <BuildCommand>$(DotnetToolCommand) build $(NewtonsoftJsonProjectPath) $(DotnetToolCommandArguments)</BuildCommand>
     <BuildPackagesCommand>$(DotnetToolCommand) pack $(NewtonsoftJsonProjectPath) $(DotnetToolCommandArguments)</BuildPackagesCommand>
@@ -24,11 +28,28 @@
   </PropertyGroup>
 
   <Target Name="Restore" BeforeTargets="Build" DependsOnTargets="UpdateNuGetConfig">
-    <Exec Command="$(DotnetToolCommand) restore $(NewtonsoftJsonProjectPath) $(DotnetToolCommandArguments) /v:$(LogVerbosity) $(RedirectRepoOutputToLog)"
+    <Exec Command="$(DotnetToolCommand) restore $(NewtonsoftJsonProjectPath) $(DotnetToolCommandArguments) /v:$(LogVerbosity) /bl $(RedirectRepoOutputToLog)"
           WorkingDirectory="$(ProjectDirectory)"
           EnvironmentVariables="@(EnvironmentVariables)"
           IgnoreStandardErrorWarningFormat="true" />
   </Target>
+
+  <Target Name="ClearNonSourceBuildCachedPackages" AfterTargets="Build">
+    <Exec Command="sh -c 'rm -rf $(PackagesDir)/newtonsoft.json $(PackagesDir)/newtonsoft.json.bson'"
+          WorkingDirectory="$(ProjectDirectory)" />
+    <ItemGroup>
+      <PackageFiles Include="$(PackagesDir)/newtonsoft*" />
+    </ItemGroup>
+
+
+
+    <Message Importance="High" Text="Package files remaining: @(PackageFiles)" />
+  </Target>
+
+  <!--This is a workaround dependency and is not a real one. It was added so that arcade could use the newtonsoft its compatible with and other projects can use the newer newtonsoft version-->
+  <ItemGroup>
+    <RepositoryReference Include="arcade" />
+  </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
 </Project>

--- a/repos/newtonsoft-json.proj
+++ b/repos/newtonsoft-json.proj
@@ -10,7 +10,8 @@
   <!--The Library Frameworks was added to environment variables so as to override the frameworks in newtonsoft csproj-->
   <!--The semicolons were added with encoding so as to avoid conflicts in MSBuild shell-->
   <ItemGroup>
-    <EnvironmentVariables Include="LibraryFrameworks=netstandard1.0%3Bnetstandard1.3%3Bnetstandard2.0" />
+    <EnvironmentVariables Include="LibraryFrameworks=netstandard1.0%3Bnetstandard1.3%3Bnetstandard2.0" />a
+    <!--This is a fake repo reference to slightly tweak build ordering so that arcade builds before newtonsoft. Although this tweak is temporary. dtd 06/19/2019-->
     <RepositoryReference Include="arcade" />
   </ItemGroup>   
 

--- a/repos/newtonsoft-json.proj
+++ b/repos/newtonsoft-json.proj
@@ -10,7 +10,7 @@
   <!--The Library Frameworks was added to environment variables so as to override the frameworks in newtonsoft csproj-->
   <!--The semicolons were added with encoding so as to avoid conflicts in MSBuild shell-->
   <ItemGroup>
-    <EnvironmentVariables Include="LibraryFrameworks=netstandard1.0%3Bnetstandard1.3%3Bnetstandard2.0" />a
+    <EnvironmentVariables Include="LibraryFrameworks=netstandard1.0%3Bnetstandard1.3%3Bnetstandard2.0" />
     <!--This is a fake repo reference to slightly tweak build ordering so that arcade builds before newtonsoft. Although this tweak is temporary. dtd 06/19/2019-->
     <RepositoryReference Include="arcade" />
   </ItemGroup>   

--- a/repos/newtonsoft-json.proj
+++ b/repos/newtonsoft-json.proj
@@ -21,7 +21,7 @@
     <NewtonsoftJsonProjectPath>$(NewtonsoftJsonDirectory)Newtonsoft.Json.csproj</NewtonsoftJsonProjectPath>
     <DotnetToolCommandArguments>"/p:DotnetOnly=true" "/p:Configuration=$(Configuration)" "/p:AssemblyOriginatorKeyFile=$(NewtonsoftJsonKeyFilePath)" "/p:SignAssembly=true" "/p:PublicSign=true" "/p:TreatWarningsAsErrors=false" "/p:AdditionalConstants=SIGNED"</DotnetToolCommandArguments>
     <BuildCommand>$(DotnetToolCommand) build $(NewtonsoftJsonProjectPath) /bl:restore.binlog $(DotnetToolCommandArguments)</BuildCommand>
-    <BuildPackagesCommand>$(DotnetToolCommand) pack $(NewtonsoftJsonProjectPath) /bl:restore.binlog $(DotnetToolCommandArguments)</BuildPackagesCommand>
+    <BuildPackagesCommand>$(DotnetToolCommand) pack $(NewtonsoftJsonProjectPath) /bl:restorePackages.binlog $(DotnetToolCommandArguments)</BuildPackagesCommand>
     <CleanCommand>$(DotnetToolCommand) clean $(NewtonsoftJsonProjectPath) $(DotnetToolCommandArguments)</CleanCommand>
     <PackagesOutput>$(NewtonsoftJsonDirectory)bin/$(Configuration)/</PackagesOutput>
     <RepoApiImplemented>false</RepoApiImplemented>

--- a/repos/newtonsoft-json.proj
+++ b/repos/newtonsoft-json.proj
@@ -21,8 +21,8 @@
     <NewtonsoftJsonDirectory>$(ProjectDirectory)/Src/Newtonsoft.Json/</NewtonsoftJsonDirectory>
     <NewtonsoftJsonProjectPath>$(NewtonsoftJsonDirectory)Newtonsoft.Json.csproj</NewtonsoftJsonProjectPath>
     <DotnetToolCommandArguments>"/p:DotnetOnly=true" "/p:Configuration=$(Configuration)" "/p:AssemblyOriginatorKeyFile=$(NewtonsoftJsonKeyFilePath)" "/p:SignAssembly=true" "/p:PublicSign=true" "/p:TreatWarningsAsErrors=false" "/p:AdditionalConstants=SIGNED"</DotnetToolCommandArguments>
-    <BuildCommand>$(DotnetToolCommand) build $(NewtonsoftJsonProjectPath) /bl:restore.binlog $(DotnetToolCommandArguments)</BuildCommand>
-    <BuildPackagesCommand>$(DotnetToolCommand) pack $(NewtonsoftJsonProjectPath) /bl:restorePackages.binlog $(DotnetToolCommandArguments)</BuildPackagesCommand>
+    <BuildCommand>$(DotnetToolCommand) build $(NewtonsoftJsonProjectPath) /bl:build.binlog $(DotnetToolCommandArguments)</BuildCommand>
+    <BuildPackagesCommand>$(DotnetToolCommand) pack $(NewtonsoftJsonProjectPath) /bl:pack.binlog $(DotnetToolCommandArguments)</BuildPackagesCommand>
     <CleanCommand>$(DotnetToolCommand) clean $(NewtonsoftJsonProjectPath) $(DotnetToolCommandArguments)</CleanCommand>
     <PackagesOutput>$(NewtonsoftJsonDirectory)bin/$(Configuration)/</PackagesOutput>
     <RepoApiImplemented>false</RepoApiImplemented>
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <Target Name="Restore" BeforeTargets="Build" DependsOnTargets="UpdateNuGetConfig">
-    <Exec Command="$(DotnetToolCommand) restore $(NewtonsoftJsonProjectPath) $(DotnetToolCommandArguments) /v:$(LogVerbosity) /bl $(RedirectRepoOutputToLog)"
+    <Exec Command="$(DotnetToolCommand) restore $(NewtonsoftJsonProjectPath) $(DotnetToolCommandArguments) /v:$(LogVerbosity) /bl:restore.binlog $(RedirectRepoOutputToLog)"
           WorkingDirectory="$(ProjectDirectory)"
           EnvironmentVariables="@(EnvironmentVariables)"
           IgnoreStandardErrorWarningFormat="true" />

--- a/tools-local/prebuilt-baseline-offline.xml
+++ b/tools-local/prebuilt-baseline-offline.xml
@@ -69,7 +69,6 @@
     <PackageIdentity Id="Microsoft.VisualStudio.Services.Client" Version="16.138.0-preview" />
     <PackageIdentity Id="Microsoft.Win32.Registry" Version="4.4.0" />
     <PackageIdentity Id="Newtonsoft.Json" Version="11.0.2" />
-    <PackageIdentity Id="Newtonsoft.Json" Version="12.0.2" />
     <PackageIdentity Id="Newtonsoft.Json.Bson" Version="1.0.1" />
     <PackageIdentity Id="NuGet.Common" Version="4.8.0+017b293f18b8592897adf70b80d9488ff69b9b8c" />
     <PackageIdentity Id="NuGet.Frameworks" Version="4.8.0+017b293f18b8592897adf70b80d9488ff69b9b8c" />
@@ -227,6 +226,7 @@
     <Usage Id="Microsoft.VisualStudio.Threading.Analyzers" Version="15.8.209" IsDirectDependency="true" />
     <Usage Id="Microsoft.Web.Xdt" Version="3.0.0" IsDirectDependency="true" />
     <Usage Id="NETStandard.Library.NETFramework" Version="2.0.1-servicing-26011-01" IsDirectDependency="true" />
+    <Usage Id="Newtonsoft.Json" Version="9.0.1" />
     <Usage Id="Newtonsoft.Json" Version="10.0.3" IsDirectDependency="true" />
     <Usage Id="NuGet.Commands" Version="4.9.0-rtm.5658+849063018d8ee08625774a2dcd07ab84224dabb9" />
     <Usage Id="NuGet.Common" Version="4.3.0-preview2-4095" />
@@ -260,7 +260,6 @@
     <Usage Id="optimization.windows_nt-x64.PGO.CoreCLR" Version="99.99.99-master-20190505.1" />
     <Usage Id="optimization.windows_nt-x86.IBC.CoreCLR" Version="99.99.99-master-20190505.1" />
     <Usage Id="optimization.windows_nt-x86.PGO.CoreCLR" Version="99.99.99-master-20190505.1" />
-    <Usage Id="Newtonsoft.Json" Version="9.0.1" />
     <Usage Id="Roslyn.Diagnostics.Analyzers" Version="2.6.2-beta2" IsDirectDependency="true" />
     <Usage Id="RoslynTools.Lightup.System.Runtime.Loader" Version="4.3.0" />
     <Usage Id="runtime.any.System.Collections" Version="4.0.11" Rid="any" />

--- a/tools-local/prebuilt-baseline-offline.xml
+++ b/tools-local/prebuilt-baseline-offline.xml
@@ -260,6 +260,7 @@
     <Usage Id="optimization.windows_nt-x64.PGO.CoreCLR" Version="99.99.99-master-20190505.1" />
     <Usage Id="optimization.windows_nt-x86.IBC.CoreCLR" Version="99.99.99-master-20190505.1" />
     <Usage Id="optimization.windows_nt-x86.PGO.CoreCLR" Version="99.99.99-master-20190505.1" />
+    <Usage Id="Newtonsoft.Json" Version="9.0.1" />
     <Usage Id="Roslyn.Diagnostics.Analyzers" Version="2.6.2-beta2" IsDirectDependency="true" />
     <Usage Id="RoslynTools.Lightup.System.Runtime.Loader" Version="4.3.0" />
     <Usage Id="runtime.any.System.Collections" Version="4.0.11" Rid="any" />

--- a/tools-local/prebuilt-baseline-online.xml
+++ b/tools-local/prebuilt-baseline-online.xml
@@ -260,6 +260,7 @@
     <Usage Id="NETStandard.Library" Version="2.0.1" />
     <Usage Id="NETStandard.Library" Version="2.0.3" />
     <Usage Id="NETStandard.Library.NETFramework" Version="2.0.1-servicing-26011-01" IsDirectDependency="true" />
+    <Usage Id="Newtonsoft.Json" Version="9.0.1" />
     <Usage Id="Newtonsoft.Json" Version="10.0.3" IsDirectDependency="true" />
     <Usage Id="Newtonsoft.Json" Version="11.0.2" IsDirectDependency="true" />
     <Usage Id="Newtonsoft.Json" Version="12.0.2" IsDirectDependency="true" />

--- a/tools-local/prebuilt-baseline-online.xml
+++ b/tools-local/prebuilt-baseline-online.xml
@@ -263,7 +263,6 @@
     <Usage Id="Newtonsoft.Json" Version="9.0.1" />
     <Usage Id="Newtonsoft.Json" Version="10.0.3" IsDirectDependency="true" />
     <Usage Id="Newtonsoft.Json" Version="11.0.2" IsDirectDependency="true" />
-    <Usage Id="Newtonsoft.Json" Version="12.0.2" IsDirectDependency="true" />
     <Usage Id="Newtonsoft.Json.Bson" Version="1.0.1" />
     <Usage Id="NuGet.Commands" Version="4.9.0-rtm.5658+849063018d8ee08625774a2dcd07ab84224dabb9" />
     <Usage Id="NuGet.Common" Version="4.3.0-preview2-4095" />


### PR DESCRIPTION
Issue #594.

- Change newtonsoft Version Details to point to adaggarwal's newtonsoft fork
- Workaround to remove arcade's dependency on newtonsoft so it picks up the version that it wants
- Pass LibraryFrameworks via environment variable to bypass default portable frameworks that newtonsoft tries to build as they are not compatible with sb