### PR TITLE
[release/3.0] Update dependencies from dotnet/source-build-reference-packages

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,9 +5,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2b0830b8cc561f327e4e1b10b6e21a188b9ecee6</Sha>
     </Dependency>
-    <Dependency Name="Private.SourceBuild.ReferencePackages" Version="1.0.0-beta.19326.2">
+    <Dependency Name="Private.SourceBuild.ReferencePackages" Version="1.0.0-beta.19359.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>4ffd59a9136534cb44821870b890df8e27fa12ed</Sha>
+      <Sha>63b054527122bfc397305f256e768fd3e7179d90</Sha>
     </Dependency>
   </ToolsetDependencies>
   <ProductDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,6 +7,6 @@
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>
-    <PrivateSourceBuildReferencePackagesPackageVersion>1.0.0-beta.19326.2</PrivateSourceBuildReferencePackagesPackageVersion>
+    <PrivateSourceBuildReferencePackagesPackageVersion>1.0.0-beta.19359.1</PrivateSourceBuildReferencePackagesPackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Auto-update didn't happen for this build.  Opening manually for build 20190709.1 
https://dev.azure.com/dnceng/internal/_build/results?view=results&buildId=257275

