### PR TITLE
[release/3.0] Update dependencies from dotnet/source-build-reference-packages

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,9 +5,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2b0830b8cc561f327e4e1b10b6e21a188b9ecee6</Sha>
     </Dependency>
-    <Dependency Name="Private.SourceBuild.ReferencePackages" Version="1.0.0-beta.19361.1">
+    <Dependency Name="Private.SourceBuild.ReferencePackages" Version="1.0.0-beta.19366.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>8ad672796d88c6c8b17f3a271e80f8790c83d928</Sha>
+      <Sha>f6a446ed771ccba783c0930a8e98a75b7fc93fb1</Sha>
     </Dependency>
   </ToolsetDependencies>
   <ProductDependencies>
@@ -85,7 +85,7 @@
       <Sha>99151dfa08364242d93c861568abaf044e134d8c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.FSharp.Compiler" Version="10.4.3-beta.19253.3" CoherentParentDependency="Microsoft.Dotnet.Toolset.Internal">
-      <Uri>https://github.com/microsoft/visualfsharp</Uri>
+      <Uri>https://github.com/dotnet/fsharp</Uri>
       <Sha>42526fe359672a05fd562dc16a91a43d0fe047a7</Sha>
       <RepoName>fsharp</RepoName>
     </Dependency>

--- a/patches/roslyn/0003-Conditionally-remove-net472-from-TargetFrameworks.patch
+++ b/patches/roslyn/0003-Conditionally-remove-net472-from-TargetFrameworks.patch
@@ -1,0 +1,24 @@
+From e9e3cdf532000c5e8d10e5df65f94e06ab8657e4 Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Mon, 15 Jul 2019 19:26:42 +0000
+Subject: [PATCH] Conditionally remove net472 from TargetFrameworks
+
+---
+ .../Microsoft.Net.Compilers.Toolset.Package.csproj                       | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj b/src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj
+index 1ae79d8..486b1af 100644
+--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj
++++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj
+@@ -2,6 +2,7 @@
+ <Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+     <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
++    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">netcoreapp2.1</TargetFrameworks>
+     <RoslynProjectType>Custom</RoslynProjectType>
+ 
+     <IsPackable>true</IsPackable>
+-- 
+1.8.3.1
+

--- a/repos/fsharp.proj
+++ b/repos/fsharp.proj
@@ -2,7 +2,6 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PreferredHash>42526fe359672a05fd562dc16a91a43d0fe047a7</PreferredHash>
-    <SourceDirectory>visualfsharp</SourceDirectory>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />

--- a/repos/roslyn.proj
+++ b/repos/roslyn.proj
@@ -28,7 +28,6 @@
   <ItemGroup>
     <PackProjects Include="$(ProjectDirectory)SourceBuild.sln" />
     <PackProjects Include="$(ProjectDirectory)src/NuGet/Microsoft.NETCore.Compilers/Microsoft.NETCore.Compilers.Package.csproj" />
-    <PackProjects Include="$(ProjectDirectory)src/NuGet/Microsoft.Net.Compilers/Microsoft.Net.Compilers.Package.csproj" />
     <PackProjects Include="$(ProjectDirectory)src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Manually updating this PR because DARC auto-update is failing.  The change to fsharp repo is an update to get auto-update working again.

This pull request updates the following dependencies

## From https://github.com/dotnet/source-build-reference-packages
- **Build**: 20190716.1
- **Date Produced**: 7/16/2019 1:54 PM
- **Commit**: f6a446ed771ccba783c0930a8e98a75b7fc93fb1
- **Branch**: refs/heads/master
- **Updates**:
  - **Private.SourceBuild.ReferencePackages** -> 1.0.0-beta.19366.1