### PR TITLE
Remove ApplyNgenOptimization settings

### DIFF
--- a/repos/roslyn.proj
+++ b/repos/roslyn.proj
@@ -25,8 +25,6 @@
     <BuildCommandArgs>$(BuildCommandArgs) /p:VersionSuffixDateStamp=$(VersionSuffixDateStamp)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:VersionSuffixBuildOfTheDay=$(VersionSuffixBuildOfTheDay)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:ContinuousIntegrationBuild=true</BuildCommandArgs>
-    <BuildCommandArgs>$(BuildCommandArgs) /p:ApplyPartialNgenOptimization=false</BuildCommandArgs>
-    <BuildCommandArgs>$(BuildCommandArgs) /p:EnablePartialNgenOptimization=false</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:PublishWindowsPdb=false</BuildCommandArgs>
 
     <!--


### PR DESCRIPTION
NGEN optimization is not enabled when building from source.

See
https://github.com/dotnet/arcade/blob/a1805103791e43031355e11c0d037bca803a9593/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props#L68

https://github.com/dotnet/arcade/blob/a1805103791e43031355e11c0d037bca803a9593/src/Microsoft.DotNet.Arcade.Sdk/tools/Imports.targets#L27

Roslyn is being fixed to use the right conditions: https://github.com/dotnet/roslyn/pull/37327