### PR TITLE
[release/3.0] Update dependencies from dotnet/source-build-reference-packages

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,9 +5,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2b0830b8cc561f327e4e1b10b6e21a188b9ecee6</Sha>
     </Dependency>
-    <Dependency Name="Private.SourceBuild.ReferencePackages" Version="1.0.0-beta.19367.1">
+    <Dependency Name="Private.SourceBuild.ReferencePackages" Version="1.0.0-beta.19369.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>3b5b0e599782e3ccdeed47e67dd2d384e09fba9d</Sha>
+      <Sha>cffb0d986fc6a64554f1b0f25777d9ff26af3b9e</Sha>
     </Dependency>
   </ToolsetDependencies>
   <ProductDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,6 +7,6 @@
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>
-    <PrivateSourceBuildReferencePackagesPackageVersion>1.0.0-beta.19367.1</PrivateSourceBuildReferencePackagesPackageVersion>
+    <PrivateSourceBuildReferencePackagesPackageVersion>1.0.0-beta.19369.1</PrivateSourceBuildReferencePackagesPackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This pull request updates the following dependencies

## From https://github.com/dotnet/source-build-reference-packages
- **Build**: 20190719.1
- **Date Produced**: 7/19/2019 4:44 PM
- **Commit**: cffb0d986fc6a64554f1b0f25777d9ff26af3b9e
- **Branch**: refs/heads/master
- **Updates**:
  - **Private.SourceBuild.ReferencePackages** -> 1.0.0-beta.19369.1
