### PR TITLE
[release/3.0] Update dependencies from dotnet/source-build-reference-packages

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,9 +5,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>8f3c22397990aeb20a88690b51dad4b33f21e7ff</Sha>
     </Dependency>
-    <Dependency Name="Private.SourceBuild.ReferencePackages" Version="1.0.0-beta.19369.1">
+    <Dependency Name="Private.SourceBuild.ReferencePackages" Version="1.0.0-beta.19381.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>cffb0d986fc6a64554f1b0f25777d9ff26af3b9e</Sha>
+      <Sha>fbb978db8c4a77c50e247a96a63bfa8915fa633c</Sha>
     </Dependency>
   </ToolsetDependencies>
   <ProductDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,6 +7,6 @@
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>
-    <PrivateSourceBuildReferencePackagesPackageVersion>1.0.0-beta.19369.1</PrivateSourceBuildReferencePackagesPackageVersion>
+    <PrivateSourceBuildReferencePackagesPackageVersion>1.0.0-beta.19381.1</PrivateSourceBuildReferencePackagesPackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This pull request updates the following dependencies

## From https://github.com/dotnet/source-build-reference-packages
- **Build**: 20190731.1
- **Date Produced**: 7/31/2019 1:59 PM
- **Commit**: fbb978db8c4a77c50e247a96a63bfa8915fa633c
- **Branch**: refs/heads/master
- **Updates**:
  - **Private.SourceBuild.ReferencePackages** -> 1.0.0-beta.19381.1
