### PR TITLE
Return to building core runtime as non-portable and allow different portability in ASP.NET and core runtime

### DIFF
--- a/patches/core-sdk/0001-Exclude-test-project-from-source-build.patch
+++ b/patches/core-sdk/0001-Exclude-test-project-from-source-build.patch
@@ -1,7 +1,7 @@
-From 908d68c90383a54c6075f8594f0d418b2bf861a0 Mon Sep 17 00:00:00 2001
+From 09915a0de7e16eb529954cdc636f3a0a5908a563 Mon Sep 17 00:00:00 2001
 From: Chris Rummel <crummel@microsoft.com>
 Date: Thu, 20 Jun 2019 00:55:37 -0500
-Subject: [PATCH 2/2] Exclude test project from source-build
+Subject: [PATCH 1/2] Exclude test project from source-build
 
 ---
  test/EndToEnd/EndToEnd.Tests.csproj                            | 1 +
@@ -40,5 +40,5 @@ index a0d76c961..fa426d054 100644
 \ No newline at end of file
 +</Project>
 -- 
-2.21.0
+2.23.0
 

--- a/patches/core-sdk/0002-Allow-separate-core-setup-and-ASP.NET-RIDs.patch
+++ b/patches/core-sdk/0002-Allow-separate-core-setup-and-ASP.NET-RIDs.patch
@@ -1,0 +1,25 @@
+From 92e69728588a8a11116c54cf32fbc9291021fc17 Mon Sep 17 00:00:00 2001
+From: Chris Rummel <crummel@microsoft.com>
+Date: Fri, 6 Sep 2019 14:17:50 -0500
+Subject: [PATCH 2/2] Allow separate core-setup and ASP.NET RIDs
+
+---
+ src/redist/targets/GenerateLayout.targets | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/redist/targets/GenerateLayout.targets b/src/redist/targets/GenerateLayout.targets
+index 801b69ca0..2ce521253 100644
+--- a/src/redist/targets/GenerateLayout.targets
++++ b/src/redist/targets/GenerateLayout.targets
+@@ -48,7 +48,7 @@
+       <SharedFrameworkRid Condition=" '$(UsePortableLinuxSharedFramework)' == 'true' ">linux-$(Architecture)</SharedFrameworkRid>
+       <CombinedFrameworkHostCompressedFileName>dotnet-runtime-$(MicrosoftNETCoreAppPackageVersion)-$(SharedFrameworkRid)$(ArchiveExtension)</CombinedFrameworkHostCompressedFileName>
+ 
+-      <AspNetCoreSharedFxInstallerRid>$(SharedFrameworkRid)</AspNetCoreSharedFxInstallerRid>
++      <AspNetCoreSharedFxInstallerRid Condition="'$(AspNetCoreSharedFxInstallerRid)' == ''">$(SharedFrameworkRid)</AspNetCoreSharedFxInstallerRid>
+       <AspNetCoreSharedFxInstallerRid Condition="'$(SharedFrameworkRid)' == 'rhel.6-x64'">linux-x64</AspNetCoreSharedFxInstallerRid>
+       <AspNetCoreSharedFxArchiveRid>$(AspNetCoreSharedFxInstallerRid)</AspNetCoreSharedFxArchiveRid>
+       <AspNetCoreSharedFxInstallerRid Condition="'$(InstallerExtension)' == '.deb' OR '$(InstallerExtension)' == '.rpm'">x64</AspNetCoreSharedFxInstallerRid>
+-- 
+2.23.0
+

--- a/repos/core-sdk.proj
+++ b/repos/core-sdk.proj
@@ -3,8 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
+    <OSNameOverride>$(TargetRid.Substring(0, $(TargetRid.IndexOf("-"))))</OSNameOverride>
+
     <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">/p:Rid=$(TargetRid)</BuildCommandArgs>
-    <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">/p:CoreSetupRid=linux-x64</BuildCommandArgs>
+    <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">/p:OSName=$(OSNameOverride)</BuildCommandArgs>
     <!-- core-sdk always wants to build portable on OSX -->
     <BuildCommandArgs Condition="'$(TargetOS)' == 'OSX'">/p:CoreSetupRid=osx-x64</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) -c $(Configuration)</BuildCommandArgs>

--- a/repos/core-sdk.proj
+++ b/repos/core-sdk.proj
@@ -4,12 +4,12 @@
 
   <PropertyGroup>
     <OSNameOverride>$(TargetRid.Substring(0, $(TargetRid.IndexOf("-"))))</OSNameOverride>
-
-    <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">/p:Rid=$(TargetRid)</BuildCommandArgs>
-    <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">/p:AspNetCoreSharedFxInstallerRid=linux-x64</BuildCommandArgs>
-    <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">/p:OSName=$(OSNameOverride)</BuildCommandArgs>
+    <BuildCommandArgs/>
+    <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">$(BuildCommandArgs) /p:Rid=$(TargetRid)</BuildCommandArgs>
+    <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">$(BuildCommandArgs) /p:AspNetCoreSharedFxInstallerRid=linux-x64</BuildCommandArgs>
+    <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">$(BuildCommandArgs) /p:OSName=$(OSNameOverride)</BuildCommandArgs>
     <!-- core-sdk always wants to build portable on OSX -->
-    <BuildCommandArgs Condition="'$(TargetOS)' == 'OSX'">/p:CoreSetupRid=osx-x64</BuildCommandArgs>
+    <BuildCommandArgs Condition="'$(TargetOS)' == 'OSX'">$(BuildCommandArgs) /p:CoreSetupRid=osx-x64</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) -c $(Configuration)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) $(FlagParameterPrefix)nodereuse $(ArcadeFalseBoolBuildArg)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:DOTNET_INSTALL_DIR=$(DotNetCliToolDir)</BuildCommandArgs>

--- a/repos/core-sdk.proj
+++ b/repos/core-sdk.proj
@@ -6,6 +6,7 @@
     <OSNameOverride>$(TargetRid.Substring(0, $(TargetRid.IndexOf("-"))))</OSNameOverride>
 
     <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">/p:Rid=$(TargetRid)</BuildCommandArgs>
+    <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">/p:AspNetCoreSharedFxInstallerRid=linux-x64</BuildCommandArgs>
     <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">/p:OSName=$(OSNameOverride)</BuildCommandArgs>
     <!-- core-sdk always wants to build portable on OSX -->
     <BuildCommandArgs Condition="'$(TargetOS)' == 'OSX'">/p:CoreSetupRid=osx-x64</BuildCommandArgs>

--- a/repos/core-setup.proj
+++ b/repos/core-setup.proj
@@ -3,13 +3,21 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
-    <BuildArguments>--restore --build</BuildArguments>
-    <BuildArguments>$(BuildArguments) --configuration $(Configuration)</BuildArguments>
-    <BuildArguments>$(BuildArguments) --ci</BuildArguments>
+    <!-- core-sdk always wants a portable runtime on OSX -->
+    <OverrideTargetRid>$(TargetRid)</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'OSX'">osx-x64</OverrideTargetRid>
+    <OverridePortable>$(PortableBuild)</OverridePortable>
+    <OverridePortable Condition="'$(TargetOS)' == 'OSX'">true</OverridePortable>
+
+    <BuildArguments>$(FlagParameterPrefix)restore $(FlagParameterPrefix)build</BuildArguments>
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)configuration $(Configuration)</BuildArguments>
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)ci</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:PortableBuild=$(OverridePortable)</BuildArguments>
     <BuildArguments Condition="$(Platform.Contains('arm'))">$(BuildArguments) /p:TargetArchitecture=$(Platform) /p:DisableCrossgen=true /p:CrossBuild=true</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:BuildDebPackage=false</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:BuildAllPackages=true</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:RestoreAllBuildRids=false</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:OutputRid=$(OverrideTargetRid)</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:PreReleaseLabel="$(PreReleaseVersionLabel)"</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:DotNetOutputBlobFeedDir=$(SourceBuiltBlobFeedDir)</BuildArguments>
 

--- a/repos/coreclr.proj
+++ b/repos/coreclr.proj
@@ -12,6 +12,10 @@
     <BuildArguments Condition="'$(UseSystemLibraries)' == 'true' AND '$(OS)' != 'Windows_NT'">$(BuildArguments) cmakeargs -DCLR_CMAKE_USE_SYSTEM_LIBUNWIND=TRUE</BuildArguments>
     <BuildArguments Condition="$(Platform.Contains('arm'))">$(BuildArguments) skipnuget cross -skiprestore cmakeargs -DFEATURE_GDBJIT=TRUE</BuildArguments>
 
+    <!-- Portable builds only apply to Linux - Mac and Windows are both always portable.
+         Additionally, Linux builds are portable by default and only have a switch to turn it off -->
+    <BuildArguments Condition="'$(TargetOS)' == 'Linux' and '$(PortableBuild)' == 'false'">$(BuildArguments) -PortableBuild=false</BuildArguments>
+
     <BuildArguments>$(BuildArguments) /bl</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:ILLinkTrimAssembly=false</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:CheckCDefines=false</BuildArguments>

--- a/repos/corefx.proj
+++ b/repos/corefx.proj
@@ -56,7 +56,7 @@
     <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
     <UseSourceBuiltSdkOverride Include="@(ArcadeConfigurationOverride)" />
     <UseSourceBuiltSdkOverride Include="@(ArcadeCoreFxTestingOverride)" />
-    <UseSourceBuiltSdkOverride Condition="'$(TargetOS)' == 'Linux'" Include="@(ILSdkOverride)" />
+    <UseSourceBuiltSdkOverride Include="@(ILSdkOverride)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RunTests)' != 'true' AND '$(PrepForTests)' != 'true'">

--- a/repos/corefx.proj
+++ b/repos/corefx.proj
@@ -22,7 +22,7 @@
     <BuildArguments>$(BuildArguments) /p:PackageRid=$(OverrideTargetRid)</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:RuntimeOS=$(OverrideTargetRid.Substring(0, $(OverrideTargetRid.IndexOf("-"))))</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:PortableBuild=$(OverridePortableBuild)</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:ToolsDir=$(ToolsDir)</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:ILAsmToolPath=$(ToolPackageExtractDir)coreclr-tools/</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:EnableVSTestReferences=false</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:ILLinkTrimAssembly=false</BuildArguments>
     <BuildArguments Condition="'$(OfflineBuild)' != 'true'">$(BuildArguments) /p:DotNetSourceBuildIntermediatePath=$(GeneratedSourcePathOnline)</BuildArguments>

--- a/repos/corefx.proj
+++ b/repos/corefx.proj
@@ -5,6 +5,13 @@
   <PropertyGroup>
     <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
 
+    <!-- OSX core-setup build always uses the portable RID, so override it -->
+    <OverridePortableBuild>$(PortableBuild)</OverridePortableBuild>
+    <OverridePortableBuild Condition="'$(TargetOS)' == 'OSX' OR '$(TargetOS)' == 'Windows_NT'">true</OverridePortableBuild>
+    <OverrideTargetRid>$(TargetRid)</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'OSX'">osx-x64</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'Windows_NT'">win-x64</OverrideTargetRid>
+
     <BuildArguments>$(FlagParameterPrefix)configuration $(Configuration)</BuildArguments>
     <BuildArguments Condition="'$(RunTests)' != 'true' AND '$(PrepForTests)' != 'true'">$(BuildArguments) $(FlagParameterPrefix)restore $(FlagParameterPrefix)build $(FlagParameterPrefix)pack /p:SkipTests=true</BuildArguments>
     <BuildArguments Condition="'$(PrepForTests)' == 'true'">$(BuildArguments) $(FlagParameterPrefix)restore $(FlagParameterPrefix)build /p:IncludeTestUtils=true</BuildArguments>
@@ -12,6 +19,9 @@
     <BuildArguments Condition="'$(RunTests)' == 'true' AND '$(DotNetRunningInDocker)' == '1' AND '$(TargetOS)' == 'Linux'">$(BuildArguments) /p:TestRspFile=$(TestExclusionsDir)corefx/linux.docker.rsp</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:ArchGroup=$(Platform)</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:ConfigurationGroup=$(Configuration)</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:PackageRid=$(OverrideTargetRid)</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:RuntimeOS=$(OverrideTargetRid.Substring(0, $(OverrideTargetRid.IndexOf("-"))))</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:PortableBuild=$(OverridePortableBuild)</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:ToolsDir=$(ToolsDir)</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:EnableVSTestReferences=false</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:ILLinkTrimAssembly=false</BuildArguments>

--- a/tools-local/prebuilt-baseline-offline.xml
+++ b/tools-local/prebuilt-baseline-offline.xml
@@ -162,6 +162,7 @@
     <Usage Id="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.19.8" IsDirectDependency="true" />
     <Usage Id="Microsoft.Net.Compilers.Toolset" Version="3.3.0-beta2-19365-05" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="Microsoft.NET.Sdk.WindowsDesktop" Version="3.0.0-preview8.19380.5" />
+    <Usage Id="Microsoft.NETCore.App.Runtime.linux-x64" Version="3.0.0-preview8-28405-07" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-alpha-004" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-alpha-5" IsDirectDependency="true" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net40" Version="1.0.0-alpha-5" />

--- a/tools-local/prebuilt-baseline-online.xml
+++ b/tools-local/prebuilt-baseline-online.xml
@@ -40,10 +40,10 @@
   <Usages>
     <!-- OSX-only prebuilts.  copy them to new baselines for now (may need version updates) -->
     <Usage Id="Microsoft.NET.Sdk.IL" Version="3.0.0-preview-27107-01" />
-    <Usage Id="runtime.osx-x64.Microsoft.NETCore.ILAsm" Version="3.0.0-preview-27101-06" Rid="osx-x64" />
-    <Usage Id="runtime.osx-x64.Microsoft.NETCore.ILDAsm" Version="3.0.0-preview-27101-06" Rid="osx-x64" />
-    <Usage Id="runtime.osx-x64.Microsoft.NETCore.Jit" Version="3.0.0-preview-27101-06" Rid="osx-x64" />
-    <Usage Id="runtime.osx-x64.Microsoft.NETCore.Runtime.CoreCLR" Version="3.0.0-preview-27101-06" Rid="osx-x64" />
+    <Usage Id="runtime.osx-x64.Microsoft.NETCore.ILAsm" Version="3.0.0-preview8.19379.2" Rid="osx-x64" />
+    <Usage Id="runtime.osx-x64.Microsoft.NETCore.ILDAsm" Version="3.0.0-preview8.19379.2" Rid="osx-x64" />
+    <Usage Id="runtime.osx-x64.Microsoft.NETCore.Jit" Version="3.0.0-preview8.19379.2" Rid="osx-x64" />
+    <Usage Id="runtime.osx-x64.Microsoft.NETCore.Runtime.CoreCLR" Version="3.0.0-preview8.19379.2" Rid="osx-x64" />
     <!-- end OSX-only prebuilts -->
 
     <Usage Id="CommandLineParser" Version="2.2.1" IsDirectDependency="true" />

--- a/tools-local/prebuilt-baseline-online.xml
+++ b/tools-local/prebuilt-baseline-online.xml
@@ -154,6 +154,7 @@
     <Usage Id="Microsoft.NETCore.App" Version="2.0.0" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="Microsoft.NETCore.App" Version="2.1.0" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="Microsoft.NETCore.App" Version="3.0.0-preview7-27912-14" IsDirectDependency="true" IsAutoReferenced="true" />
+    <Usage Id="Microsoft.NETCore.App.Runtime.linux-x64" Version="3.0.0-preview8-28405-07" />
     <Usage Id="Microsoft.NETCore.DotNetAppHost" Version="2.0.0" />
     <Usage Id="Microsoft.NETCore.DotNetAppHost" Version="2.1.0" />
     <Usage Id="Microsoft.NETCore.DotNetAppHost" Version="3.0.0-preview8-27915-11" />


### PR DESCRIPTION
- This patches core-sdk to allow different RIDs for the core runtime and ASP.NET runtime.
- We also go back to building CoreCLR and CoreFX as non-portable to support the non-portable core-setup.
So far I've only tested the default non-portable build on my Fedora 31 machine, but that builds and smoke-tests.  I'll work on testing additional configurations.