### PR TITLE
Do not build .NET Fx binaries in source build

### DIFF
--- a/patches/aspnet-extensions/0001-Exclude-more-projects-from-source-build.patch
+++ b/patches/aspnet-extensions/0001-Exclude-more-projects-from-source-build.patch
@@ -1,16 +1,16 @@
-From a3db5879f727221bcb39a5b6332e226d7333d4d6 Mon Sep 17 00:00:00 2001
+From 7a7e3241182846d235c617ef2dec87a3425d9914 Mon Sep 17 00:00:00 2001
 From: Chris Rummel <crummel@microsoft.com>
 Date: Wed, 26 Jun 2019 10:40:36 -0500
-Subject: [PATCH 3/4] Exclude more projects from source-build.
+Subject: [PATCH 1/3] Exclude more projects from source-build.
 
 ---
- .../Async/src/Microsoft.DotNet.Analyzers.Async.csproj         | 1 +
- .../Async/test/Microsoft.DotNet.Analyzers.Async.Tests.csproj  | 1 +
- src/Logging/Logging.Analyzers/Directory.Build.props           | 4 ++++
+ src/Analyzers/Async/src/Microsoft.DotNet.Analyzers.Async.csproj       | 1 +
+ .../Async/test/Microsoft.DotNet.Analyzers.Async.Tests.csproj          | 1 +
+ src/Logging/Logging.Analyzers/Directory.Build.props                   | 4 ++++
  3 files changed, 6 insertions(+)
 
 diff --git a/src/Analyzers/Async/src/Microsoft.DotNet.Analyzers.Async.csproj b/src/Analyzers/Async/src/Microsoft.DotNet.Analyzers.Async.csproj
-index f438fdc49..8e404bfcb 100644
+index 07a994a..3275b4d 100644
 --- a/src/Analyzers/Async/src/Microsoft.DotNet.Analyzers.Async.csproj
 +++ b/src/Analyzers/Async/src/Microsoft.DotNet.Analyzers.Async.csproj
 @@ -17,6 +17,7 @@
@@ -22,7 +22,7 @@ index f438fdc49..8e404bfcb 100644
  
    <ItemGroup>
 diff --git a/src/Analyzers/Async/test/Microsoft.DotNet.Analyzers.Async.Tests.csproj b/src/Analyzers/Async/test/Microsoft.DotNet.Analyzers.Async.Tests.csproj
-index 8603e7c47..ebb78f4ea 100644
+index 8603e7c..ebb78f4 100644
 --- a/src/Analyzers/Async/test/Microsoft.DotNet.Analyzers.Async.Tests.csproj
 +++ b/src/Analyzers/Async/test/Microsoft.DotNet.Analyzers.Async.Tests.csproj
 @@ -5,6 +5,7 @@
@@ -34,7 +34,7 @@ index 8603e7c47..ebb78f4ea 100644
  
    <ItemGroup>
 diff --git a/src/Logging/Logging.Analyzers/Directory.Build.props b/src/Logging/Logging.Analyzers/Directory.Build.props
-index eef045ad3..627533dd9 100644
+index eef045a..627533d 100644
 --- a/src/Logging/Logging.Analyzers/Directory.Build.props
 +++ b/src/Logging/Logging.Analyzers/Directory.Build.props
 @@ -1,6 +1,10 @@
@@ -49,5 +49,5 @@ index eef045ad3..627533dd9 100644
      <Reference Include="Microsoft.CodeAnalysis.Common" PrivateAssets="All" />
      <Reference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="All" />
 -- 
-2.21.0
+1.8.3.1
 

--- a/patches/aspnet-extensions/0002-Exclude-two-non-shipping-projects-from-source-build.patch
+++ b/patches/aspnet-extensions/0002-Exclude-two-non-shipping-projects-from-source-build.patch
@@ -1,14 +1,14 @@
-From b226c8335e8afa03e3c19526be6987eb69971b24 Mon Sep 17 00:00:00 2001
+From fcc77631788c7d293cacd3298381abc93f5aa842 Mon Sep 17 00:00:00 2001
 From: Chris Rummel <crummel@microsoft.com>
 Date: Thu, 20 Jun 2019 01:19:36 -0500
-Subject: [PATCH 4/4] Exclude two non-shipping projects from source-build.
+Subject: [PATCH 2/3] Exclude two non-shipping projects from source-build.
 
 ---
- .../ref/Microsoft.Internal.Extensions.Refs.csproj                | 1 +
+ .../ref/Microsoft.Internal.Extensions.Refs.csproj                        | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/src/TargetingPack/Microsoft.Internal.Extensions.Refs/ref/Microsoft.Internal.Extensions.Refs.csproj b/src/TargetingPack/Microsoft.Internal.Extensions.Refs/ref/Microsoft.Internal.Extensions.Refs.csproj
-index 0198da33a..d358b96e7 100644
+index 746de0f..f67a8fd 100644
 --- a/src/TargetingPack/Microsoft.Internal.Extensions.Refs/ref/Microsoft.Internal.Extensions.Refs.csproj
 +++ b/src/TargetingPack/Microsoft.Internal.Extensions.Refs/ref/Microsoft.Internal.Extensions.Refs.csproj
 @@ -4,6 +4,7 @@
@@ -20,5 +20,5 @@ index 0198da33a..d358b96e7 100644
  
      <!-- Subject to change: see https://github.com/dotnet/designs/pull/50 -->
 -- 
-2.21.0
+1.8.3.1
 

--- a/patches/aspnet-extensions/0003-Do-not-build-.NET-Fx-binaries-in-source-build.patch
+++ b/patches/aspnet-extensions/0003-Do-not-build-.NET-Fx-binaries-in-source-build.patch
@@ -1,0 +1,70 @@
+From 8bcc714a79d7d70cf82fa4a56a6bbd65cc1c92fe Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Mon, 9 Sep 2019 20:50:41 +0000
+Subject: [PATCH 3/3] Do not build .NET Fx binaries in source build
+
+---
+ eng/Versions.props                                                     | 2 +-
+ .../DI/src/Microsoft.Extensions.DependencyInjection.csproj             | 3 ++-
+ .../src/Microsoft.Extensions.DiagnosticAdapter.csproj                  | 3 ++-
+ .../Logging.EventLog/src/Microsoft.Extensions.Logging.EventLog.csproj  | 3 ++-
+ 4 files changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/eng/Versions.props b/eng/Versions.props
+index a7f92e3..da57762 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -28,7 +28,7 @@
+     <!-- Disable Arcade's Xliff tools -->
+     <UsingToolXliff>false</UsingToolXliff>
+     <!-- Using .NET framework assemblies from a package. -->
+-    <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
++    <UsingToolNetFrameworkReferenceAssemblies Condition="'$(DotNetBuildFromSource)' != 'true'">true</UsingToolNetFrameworkReferenceAssemblies>
+   </PropertyGroup>
+   <!--
+ 
+diff --git a/src/DependencyInjection/DI/src/Microsoft.Extensions.DependencyInjection.csproj b/src/DependencyInjection/DI/src/Microsoft.Extensions.DependencyInjection.csproj
+index 583c760..8d05c52 100644
+--- a/src/DependencyInjection/DI/src/Microsoft.Extensions.DependencyInjection.csproj
++++ b/src/DependencyInjection/DI/src/Microsoft.Extensions.DependencyInjection.csproj
+@@ -2,7 +2,8 @@
+ 
+   <PropertyGroup>
+     <Description>Default implementation of dependency injection for Microsoft.Extensions.DependencyInjection.</Description>
+-    <TargetFrameworks>netcoreapp3.0;net461;netstandard2.0</TargetFrameworks>
++    <TargetFrameworks>netcoreapp3.0;netstandard2.0</TargetFrameworks>
++    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' != 'true'">$(TargetFrameworks);net461</TargetFrameworks>
+     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+     <PackageTags>dependencyinjection;di</PackageTags>
+     <IsPackable>true</IsPackable>
+diff --git a/src/DiagnosticAdapter/src/Microsoft.Extensions.DiagnosticAdapter.csproj b/src/DiagnosticAdapter/src/Microsoft.Extensions.DiagnosticAdapter.csproj
+index 6655152..34c2610 100644
+--- a/src/DiagnosticAdapter/src/Microsoft.Extensions.DiagnosticAdapter.csproj
++++ b/src/DiagnosticAdapter/src/Microsoft.Extensions.DiagnosticAdapter.csproj
+@@ -2,7 +2,8 @@
+ 
+   <PropertyGroup>
+     <Description>Microsoft extension adapter feature to extend DiagnosticListener. Contains extension methods that extend System.Diagnostics.DiagnosticListener, and enables duck-typing based event handling by using dynamically generated proxy types.</Description>
+-    <TargetFrameworks>netstandard2.0;netcoreapp2.0;net461</TargetFrameworks>
++    <TargetFrameworks>netstandard2.0;netcoreapp2.0</TargetFrameworks>
++    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' != 'true'">$(TargetFrameworks);net461</TargetFrameworks>
+     <NoWarn>$(NoWarn);CS1591</NoWarn>
+     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+     <PackageTags>diagnosticadapter;diagnosticlistener;diagnostics</PackageTags>
+diff --git a/src/Logging/Logging.EventLog/src/Microsoft.Extensions.Logging.EventLog.csproj b/src/Logging/Logging.EventLog/src/Microsoft.Extensions.Logging.EventLog.csproj
+index d199db5..6a4c555 100644
+--- a/src/Logging/Logging.EventLog/src/Microsoft.Extensions.Logging.EventLog.csproj
++++ b/src/Logging/Logging.EventLog/src/Microsoft.Extensions.Logging.EventLog.csproj
+@@ -2,7 +2,8 @@
+ 
+   <PropertyGroup>
+     <Description>Windows Event Log logger provider implementation for Microsoft.Extensions.Logging.</Description>
+-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
++    <TargetFrameworks>netstandard2.0</TargetFrameworks>
++    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' != 'true'">$(TargetFrameworks);net461</TargetFrameworks>
+     <NoWarn>$(NoWarn);CS1591</NoWarn>
+     <PackageTags>$(PackageTags);eventlog;windowseventlog</PackageTags>
+     <IsPackable>true</IsPackable>
+-- 
+1.8.3.1
+


### PR DESCRIPTION
This cover all 3 binaries in aspnet-extensions repo.
