### PR TITLE
Do not build for .NET Fx in source build

### DIFF
--- a/patches/roslyn/0006-Do-not-build-for-.NET-Fx-in-source-build.patch
+++ b/patches/roslyn/0006-Do-not-build-for-.NET-Fx-in-source-build.patch
@@ -1,0 +1,40 @@
+From 57dcc9d8f5c1773adb997204b38535bc253abbff Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Wed, 11 Sep 2019 20:11:46 +0000
+Subject: [PATCH 6/6] Do not build for .NET Fx in source build
+
+---
+ eng/Versions.props         | 2 +-
+ eng/targets/Settings.props | 3 ++-
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/eng/Versions.props b/eng/Versions.props
+index d884d4e..7794f89 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -291,7 +291,7 @@
+     <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
+     <UsingToolNuGetRepack>true</UsingToolNuGetRepack>
+     <UsingToolVSSDK>true</UsingToolVSSDK>
+-    <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
++    <UsingToolNetFrameworkReferenceAssemblies Condition="'$(DotNetBuildFromSource)' != 'true'">true</UsingToolNetFrameworkReferenceAssemblies>
+     <UsingToolIbcOptimization>true</UsingToolIbcOptimization>
+     <UsingToolVisualStudioIbcTraining>true</UsingToolVisualStudioIbcTraining>
+     <UsingToolXliff>true</UsingToolXliff>
+diff --git a/eng/targets/Settings.props b/eng/targets/Settings.props
+index d074816..8d48d26 100644
+--- a/eng/targets/Settings.props
++++ b/eng/targets/Settings.props
+@@ -18,7 +18,8 @@
+     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+     <ToolsetPackagesDir>$(RepoRoot)build\ToolsetPackages\</ToolsetPackagesDir>
+ 
+-    <RoslynPortableTargetFrameworks>net472;netcoreapp2.1</RoslynPortableTargetFrameworks>
++    <RoslynPortableTargetFrameworks>netcoreapp2.1</RoslynPortableTargetFrameworks>
++    <RoslynPortableTargetFrameworks Condition="'$(DotNetBuildFromSource)' != 'true'">$(RoslynPortableTargetFrameworks);net472</RoslynPortableTargetFrameworks>
+     <RoslynPortableRuntimeIdentifiers>win;win-x64;linux-x64;osx-x64</RoslynPortableRuntimeIdentifiers>
+     <RoslynEnforceCodeStyle Condition="'$(ContinuousIntegrationBuild)' != 'true'">true</RoslynEnforceCodeStyle>
+     <UseSharedCompilation>true</UseSharedCompilation>
+-- 
+1.8.3.1
+


### PR DESCRIPTION
This change implicitly takes care of .NET Fx references in 5 Roslyn projects. 