### PR TITLE
Do not build for NET Fx in source build - aspnet-xdt repo

### DIFF
--- a/patches/aspnet-xdt/0002-Do-not-build-NET-Fx-binaries-in-source-build.patch
+++ b/patches/aspnet-xdt/0002-Do-not-build-NET-Fx-binaries-in-source-build.patch
@@ -1,0 +1,47 @@
+From 365b26b09317a0ffa1438c7a6ffc0a436c07b9fd Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Fri, 13 Sep 2019 16:56:21 +0000
+Subject: [PATCH 2/2] Do not build NET Fx binaries in source build
+
+---
+ eng/Versions.props                                               | 2 +-
+ src/Microsoft.Web.XmlTransform/Microsoft.Web.XmlTransform.csproj | 5 +++--
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/eng/Versions.props b/eng/Versions.props
+index 9117eba..b9883d5 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -3,7 +3,7 @@
+   <!-- Opt out of certain Arcade features -->
+   <PropertyGroup>
+     <UsingToolXliff>false</UsingToolXliff>
+-    <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
++    <UsingToolNetFrameworkReferenceAssemblies Condition="'$(DotNetBuildFromSource)' != 'true'">true</UsingToolNetFrameworkReferenceAssemblies>
+   </PropertyGroup>
+   <PropertyGroup>
+     <VersionPrefix>3.0.1</VersionPrefix>
+diff --git a/src/Microsoft.Web.XmlTransform/Microsoft.Web.XmlTransform.csproj b/src/Microsoft.Web.XmlTransform/Microsoft.Web.XmlTransform.csproj
+index cf5e7a3..72103a0 100644
+--- a/src/Microsoft.Web.XmlTransform/Microsoft.Web.XmlTransform.csproj
++++ b/src/Microsoft.Web.XmlTransform/Microsoft.Web.XmlTransform.csproj
+@@ -3,7 +3,8 @@
+   <Import Project="$(RepositoryEngineeringDir)\Package.props" />
+   
+   <PropertyGroup>
+-    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
++    <TargetFrameworks>netstandard2.0</TargetFrameworks>
++    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' != 'true'">$(TargetFrameworks);net40</TargetFrameworks>
+     <PlatformTarget>AnyCPU</PlatformTarget>
+     <IsPackable>true</IsPackable>
+     <IsShipping>false</IsShipping>
+@@ -24,4 +25,4 @@
+     </EmbeddedResource>
+   </ItemGroup>
+ 
+-</Project>
+\ No newline at end of file
++</Project>
+-- 
+1.8.3.1
+


### PR DESCRIPTION
Removing a single NET Fx binary in source build