### PR TITLE
Don't add target rid to NetCoreRuntimePackRids

### DIFF
--- a/patches/core-sdk/0003-Don-t-add-target-rid-to-NetCoreRuntimePackRids.patch
+++ b/patches/core-sdk/0003-Don-t-add-target-rid-to-NetCoreRuntimePackRids.patch
@@ -1,0 +1,41 @@
+From 50a32f2e8708fd838a29ab3133e3f8e75d7bb942 Mon Sep 17 00:00:00 2001
+From: Tom Deseyn <tom.deseyn@gmail.com>
+Date: Tue, 17 Sep 2019 08:29:21 +0200
+Subject: [PATCH] Don't add target rid to NetCoreRuntimePackRids
+
+---
+ src/redist/targets/GenerateBundledVersions.targets | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/redist/targets/GenerateBundledVersions.targets b/src/redist/targets/GenerateBundledVersions.targets
+index b440f78e1..3f725a792 100644
+--- a/src/redist/targets/GenerateBundledVersions.targets
++++ b/src/redist/targets/GenerateBundledVersions.targets
+@@ -62,13 +62,14 @@
+     </MSBuild>
+ 
+     <GetRuntimePackRids MetapackagePath="$(NuGetPackageRoot)/microsoft.netcore.app.internal/$(MicrosoftNETCoreAppPackageVersion)">
+-      <Output TaskParameter="AvailableRuntimePackRuntimeIdentifiers" ItemName="NetCoreRuntimePackRids" />
++      <Output TaskParameter="AvailableRuntimePackRuntimeIdentifiers" ItemName="NetCoreAppHostPackRids" />
+     </GetRuntimePackRids>
+     <GetRuntimePackRids MetapackagePath="$(NuGetPackageRoot)/microsoft.windowsdesktop.app/$(MicrosoftWindowsDesktopPackageVersion)">
+       <Output TaskParameter="AvailableRuntimePackRuntimeIdentifiers" ItemName="WindowsDesktopRuntimePackRids" />
+     </GetRuntimePackRids>
+ 
+     <ItemGroup>
++      <NetCoreRuntimePackRids Include="linux-arm;linux-arm64;linux-musl-arm64;linux-musl-x64;linux-x64;osx-x64;rhel.6-x64;tizen.4.0.0-armel;tizen.5.0.0-armel;win-arm;win-arm64;win-x64;win-x86"/>
+       <AspNetCoreRuntimePackRids Include="
+         win-x64;
+         win-x86;
+@@ -187,7 +188,7 @@ Copyright (c) .NET Foundation. All rights reserved.
+                       TargetFramework="netcoreapp3.0"
+                       AppHostPackNamePattern="Microsoft.NETCore.App.Host.**RID**"
+                       AppHostPackVersion="$(_NETCoreAppPackageVersion)"
+-                      AppHostRuntimeIdentifiers="@(NetCoreRuntimePackRids, '%3B')"
++                      AppHostRuntimeIdentifiers="@(NetCoreAppHostPackRids, '%3B')"
+                       />
+     
+     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App"
+-- 
+2.21.0
+


### PR DESCRIPTION
Attempt to fix https://github.com/dotnet/source-build/issues/1202.

I haven't tested this because `./build.sh` on `release/3.0` is failing for me: https://github.com/dotnet/source-build/issues/1230.

CC @crummel @dagood @omajid @dsplaisted @nguerrera