### PR TITLE
Do not build NET Fx binaries in source build - nuget-client

### DIFF
--- a/patches/nuget-client/0006-Do-not-build-NET-Fx-binaries-in-source-build.patch
+++ b/patches/nuget-client/0006-Do-not-build-NET-Fx-binaries-in-source-build.patch
@@ -1,0 +1,48 @@
+From d44112fb6a3728080ebb564b9ac5ac42fa3b72cb Mon Sep 17 00:00:00 2001
+From: Nikola Milosavljevic <nikolam@microsoft.com>
+Date: Tue, 17 Sep 2019 19:13:32 +0000
+Subject: [PATCH 6/6] Do not build NET Fx binaries in source build
+
+---
+ build/common.project.props                              | 4 +++-
+ src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj | 3 ++-
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/build/common.project.props b/build/common.project.props
+index 1b625cf..153df2d 100644
+--- a/build/common.project.props
++++ b/build/common.project.props
+@@ -15,7 +15,9 @@
+     <NETCoreTargetFramework>netcoreapp2.1</NETCoreTargetFramework>
+     <NetStandardVersion>netstandard2.0</NetStandardVersion>
+     <TargetFrameworksExe>$(NETFXTargetFramework);$(NETCoreTargetFramework)</TargetFrameworksExe>
++    <TargetFrameworksExe Condition="'$(DotNetBuildFromSource)' == 'true'">$(NETCoreTargetFramework)</TargetFrameworksExe>
+     <TargetFrameworksLibrary>$(NETFXTargetFramework);$(NetStandardVersion)</TargetFrameworksLibrary>
++    <TargetFrameworksLibrary Condition="'$(DotNetBuildFromSource)' == 'true'">$(NetStandardVersion)</TargetFrameworksLibrary> 
+     <RepositoryRootDirectory>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\</RepositoryRootDirectory>
+     <BuildCommonDirectory>$(RepositoryRootDirectory)build\</BuildCommonDirectory>
+     <SolutionFile>$(RepositoryRootDirectory)$(RepositoryName).sln</SolutionFile>
+@@ -282,4 +284,4 @@
+   </ItemGroup>
+ 
+   <Import Project="OptProfV2.props"/>
+-</Project>
+\ No newline at end of file
++</Project>
+diff --git a/src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj b/src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj
+index 3db2db2..340b774 100644
+--- a/src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj
++++ b/src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj
+@@ -4,7 +4,8 @@
+ 
+   <PropertyGroup>
+     <Description>The understanding of target frameworks for NuGet.Packaging.</Description>
+-    <TargetFrameworks>$(TargetFrameworksLibrary);net40</TargetFrameworks>
++    <TargetFrameworks>$(TargetFrameworksLibrary)</TargetFrameworks>
++    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' != 'true'">$(TargetFrameworks);net40</TargetFrameworks>
+     <TargetFramework />
+     <NoWarn>$(NoWarn);CS1591;CS1574;CS1573</NoWarn>
+     <LangVersion>5</LangVersion>
+-- 
+1.8.3.1
+


### PR DESCRIPTION
Stops building all NET Fx binaries in source-build.

VS Code tests passed without any issues.