### PR TITLE
Use PVP for MicrosoftCodeAnalysisCSharp versions in arcade

### DIFF
--- a/patches/arcade/0004-Import-PackageVersions-props-if-exists.patch
+++ b/patches/arcade/0004-Import-PackageVersions-props-if-exists.patch
@@ -1,0 +1,37 @@
+From a5cd97b12dc8fb7677345a29d668ef2fe4aa6be6 Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Mon, 23 Sep 2019 19:06:35 +0000
+Subject: [PATCH] Import PackageVersions props if exists
+
+---
+ eng/Versions.props | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/eng/Versions.props b/eng/Versions.props
+index 249e6d2..bb68ec4 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -1,6 +1,10 @@
+ <?xml version="1.0" encoding="utf-8"?>
+ <Project>
+   <PropertyGroup>
++    <MicrosoftCodeAnalysisCSharpVersion>2.9.0</MicrosoftCodeAnalysisCSharpVersion>
++  </PropertyGroup>
++  <Import Project="$(DotNetPackageVersionPropsPath)" Condition="'$(DotNetPackageVersionPropsPath)' != ''" />
++  <PropertyGroup>
+     <!-- This repo version -->
+     <VersionPrefix>1.0.0</VersionPrefix>
+     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
+@@ -22,8 +26,8 @@
+     <MicrosoftBuildTasksCoreVersion>15.7.179</MicrosoftBuildTasksCoreVersion>
+     <MicrosoftBuildUtilitiesCoreVersion>15.7.179</MicrosoftBuildUtilitiesCoreVersion>
+     <MicrosoftCodeAnalysisAnalyzersVersion>2.6.3</MicrosoftCodeAnalysisAnalyzersVersion>
+-    <MicrosoftCodeAnalysisCSharpVersion>2.9.0</MicrosoftCodeAnalysisCSharpVersion>
+     <MsbuildTaskMicrosoftCodeAnalysisCSharpVersion>2.1.0</MsbuildTaskMicrosoftCodeAnalysisCSharpVersion>
++    <MsbuildTaskMicrosoftCodeAnalysisCSharpVersion Condition="'$(DotNetBuildFromSource)' == 'true'">$(MicrosoftCodeAnalysisCSharpVersion)</MsbuildTaskMicrosoftCodeAnalysisCSharpVersion>
+     <MicrosoftDotNetPlatformAbstractionsVersion>2.1.0</MicrosoftDotNetPlatformAbstractionsVersion>
+     <MicrosoftIdentityModelClientsActiveDirectoryVersion>3.19.8</MicrosoftIdentityModelClientsActiveDirectoryVersion>
+     <MicrosoftRestClientRuntimeVersion>2.3.13</MicrosoftRestClientRuntimeVersion>
+-- 
+1.8.3.1
+

--- a/patches/arcade/0005-Update-SystemNetHttpPackageVersion.patch
+++ b/patches/arcade/0005-Update-SystemNetHttpPackageVersion.patch
@@ -1,0 +1,25 @@
+From 9c5d482ce568d3164033856bc183f91fdfa733f8 Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Mon, 23 Sep 2019 16:32:11 +0000
+Subject: [PATCH] Update SystemNetHttpPackageVersion
+
+---
+ eng/Versions.props | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/eng/Versions.props b/eng/Versions.props
+index 249e6d2..e16e81a 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -14,7 +14,7 @@
+     <HandlebarsNetVersion>1.9.5</HandlebarsNetVersion>
+     <LibGit2SharpVersion>0.25.2</LibGit2SharpVersion>
+     <log4netVersion>2.0.8</log4netVersion>
+-    <SystemNetHttpVersion>4.3.3</SystemNetHttpVersion>
++    <SystemNetHttpVersion>4.3.4</SystemNetHttpVersion>
+     <MicrosoftAzureStorageBlobVersion>10.0.2</MicrosoftAzureStorageBlobVersion>
+     <MicrosoftAzureKeyVaultVersion>3.0.0</MicrosoftAzureKeyVaultVersion>
+     <MicrosoftBuildVersion>15.7.179</MicrosoftBuildVersion>
+-- 
+1.8.3.1
+

--- a/repos/arcade.proj
+++ b/repos/arcade.proj
@@ -21,7 +21,7 @@
 
     <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
 
-    <DependencyVersionInputRepoApiImplemented>false</DependencyVersionInputRepoApiImplemented>
+    <DependencyVersionInputRepoApiImplemented>true</DependencyVersionInputRepoApiImplemented>
     <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
 
     <OrchestratedManifestBuildName>N/A</OrchestratedManifestBuildName>


### PR DESCRIPTION
Use the PVP with previously source-built versions for MicrosoftCodeAnalysisCSharp versions only in arcade.  Update System.Net.Http version to reference package version.