### PR TITLE
Move packages instead of copy them to the blob feed to save space.

### DIFF
--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -336,7 +336,11 @@
 
   <Target Name="DeleteSourceCopyOfPackages"
           AfterTargets="CopyPackage;WriteVersions;ExtractToolPackage;EnsurePackagesCreated">
-    <Delete Files="@(_BuiltPackages)" />
+    <ItemGroup>
+      <SourcePackages Condition="'$(PackagesOutput)' != ''" Include="$(PackagesOutput)/*.nupkg" />
+      <SourcePackages Condition="'@(PackagesOutputList)' != ''" Include="%(PackagesOutputList.Identity)/*.nupkg" />
+    </ItemGroup>
+    <Delete Files="@(SourcePackages)" />
   </Target>
 
   <Target Name="Clean" Condition="'$(CleanCommand)' != ''" >

--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -265,7 +265,7 @@
           AfterTargets="Package"
           Condition="'$(OutputPlacementRepoApiImplemented)' != 'true' AND ('$(PackagesOutput)' != '' OR '@(PackagesOutputList)' != '')"
           DependsOnTargets="GatherBuiltPackages">
-    <Move SourceFiles="@(_BuiltPackages)"
+    <Copy SourceFiles="@(_BuiltPackages)"
           DestinationFolder="$(SourceBuiltPackagesPath)"
           Condition="'@(_BuiltPackages)'!=''" />
   </Target>
@@ -332,6 +332,11 @@
 
     <Message Importance="High" Text="New NuGet package(s) after building $(RepositoryName):" />
     <Message Importance="High" Text="  -> %(_JustSourceBuiltPackageInfos.PackageId) %(_JustSourceBuiltPackageInfos.PackageVersion)" />
+  </Target>
+
+  <Target Name="DeleteSourceCopyOfPackages"
+          AfterTargets="CopyPackage;WriteVersions;ExtractToolPackage;EnsurePackagesCreated">
+    <Delete Files="@(_BuiltPackages)" />
   </Target>
 
   <Target Name="Clean" Condition="'$(CleanCommand)' != ''" >

--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -265,7 +265,7 @@
           AfterTargets="Package"
           Condition="'$(OutputPlacementRepoApiImplemented)' != 'true' AND ('$(PackagesOutput)' != '' OR '@(PackagesOutputList)' != '')"
           DependsOnTargets="GatherBuiltPackages">
-    <Copy SourceFiles="@(_BuiltPackages)"
+    <Move SourceFiles="@(_BuiltPackages)"
           DestinationFolder="$(SourceBuiltPackagesPath)"
           Condition="'@(_BuiltPackages)'!=''" />
   </Target>


### PR DESCRIPTION
This should save about 18GB while creating the tarball in CI.