### PR TITLE
Remove il src from tarball for packages that are in source-built or refpkg archives

### DIFF
--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -285,22 +285,17 @@ popd
 for path in ${ilSrcPaths[@]}; do
     IFS='/'
     read -a splitLine <<< "$path"
-    echo " ${splitLine[1]}.${splitLine[2]}.nupkg "
     remove=false
     if [[ " ${allRefPkgs[@]} " =~ " ${splitLine[1]}.${splitLine[2]}.nupkg " ]]; then
-        echo "${splitLine[1]}.${splitLine[2]}.nupkg exists in ref pkgs"
         remove=true
     fi
     if [[ " ${allSourceBuiltPkgs[@]} " =~ " ${splitLine[1]}.${splitLine[2]}.nupkg " ]]; then
-        echo "${splitLine[1]}.${splitLine[2]}.nupkg exists in source-built pkgs"
         remove=true
     fi
     if [[ " ${allBuiltPkgs[@]} " =~ " ${splitLine[1]}.${splitLine[2]}.nupkg " ]]; then
-        echo "${splitLine[1]}.${splitLine[2]}.nupkg exists in source-built pkgs"
         remove=true
     fi
     if [[ "$remove" == "true" ]]; then
-        echo "removing $TARBALL_ROOT/packages/reference/staging/$path"
         rm -rf "$TARBALL_ROOT/packages/reference/staging/$path"
     fi
 done

--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -253,14 +253,59 @@ do
     fi
 done
 
+allRefPkgs=(`tar -tf $TARBALL_ROOT/packages/archive/Private.SourceBuild.ReferencePackages.*.tar.gz | tr '[:upper:]' '[:lower:]'`)
+allSourceBuiltPkgs=(`tar -tf $TARBALL_ROOT/packages/archive/Private.SourceBuilt.Artifacts.*.tar.gz | tr '[:upper:]' '[:lower:]'`)
+
 echo 'Removing reference-packages from tarball prebuilts...'
 
-for ref_package in $(tar -tf $TARBALL_ROOT/packages/archive/Private.SourceBuild.ReferencePackages.*.tar.gz | tr '[:upper:]' '[:lower:]')
+for ref_package in ${allRefPkgs[@]}
 do
-    if [ -e $TARBALL_ROOT/packages/prebuilt/$(basename $ref_package) ]; then
-        rm $TARBALL_ROOT/packages/prebuilt/$(basename $ref_package)
+    if [ -e $TARBALL_ROOT/packages/prebuilt/$ref_package ]; then
+        rm $TARBALL_ROOT/packages/prebuilt/$ref_package
     fi
 done
+
+echo 'Removing previously source-built packages from tarball prebuilts...'
+
+for ref_package in ${allSourceBuiltPkgs[@]}
+do
+    if [ -e $TARBALL_ROOT/packages/prebuilt/$ref_package ]; then
+        rm $TARBALL_ROOT/packages/prebuilt/$ref_package
+    fi
+done
+
+echo 'Removing source-built, previously source-built packages and reference packages from il pkg src...'
+OLDIFS=$IFS
+
+allBuiltPkgs=(`ls $SCRIPT_ROOT/bin/obj/x64/Release/blob-feed/packages/*.nupkg | xargs -n1 basename | tr '[:upper:]' '[:lower:]'`)
+pushd $TARBALL_ROOT/packages/reference/staging/
+ilSrcPaths=(`find . -maxdepth 2 -mindepth 2`)
+popd
+
+for path in ${ilSrcPaths[@]}; do
+    IFS='/'
+    read -a splitLine <<< "$path"
+    echo " ${splitLine[1]}.${splitLine[2]}.nupkg "
+    remove=false
+    if [[ " ${allRefPkgs[@]} " =~ " ${splitLine[1]}.${splitLine[2]}.nupkg " ]]; then
+        echo "${splitLine[1]}.${splitLine[2]}.nupkg exists in ref pkgs"
+        remove=true
+    fi
+    if [[ " ${allSourceBuiltPkgs[@]} " =~ " ${splitLine[1]}.${splitLine[2]}.nupkg " ]]; then
+        echo "${splitLine[1]}.${splitLine[2]}.nupkg exists in source-built pkgs"
+        remove=true
+    fi
+    if [[ " ${allBuiltPkgs[@]} " =~ " ${splitLine[1]}.${splitLine[2]}.nupkg " ]]; then
+        echo "${splitLine[1]}.${splitLine[2]}.nupkg exists in source-built pkgs"
+        remove=true
+    fi
+    if [[ "$remove" == "true" ]]; then
+        echo "removing $TARBALL_ROOT/packages/reference/staging/$path"
+        rm -rf "$TARBALL_ROOT/packages/reference/staging/$path"
+    fi
+done
+
+IFS=$OLDIFS
 
 echo 'Recording commits for the source-build repo and all submodules, to aid in reproducibility...'
 


### PR DESCRIPTION
Packages that are supplied to source-build via the source-built or reference package archives may show up in IL src when we decompile reference only packages.  These can be removed from the IL src since they are being resolved from the archives.