### PR TITLE
Add patch to remove runtime identifier specification in msbuild

### DIFF
--- a/patches/msbuild/0005-Remove-runtime-identifiers-to-break-runtime-prebuilt.patch
+++ b/patches/msbuild/0005-Remove-runtime-identifiers-to-break-runtime-prebuilt.patch
@@ -1,0 +1,45 @@
+From 8b4193dc8fb9cb2e614c7918d56317bb9764d50c Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Wed, 9 Oct 2019 14:55:27 +0000
+Subject: [PATCH] Remove runtime identifiers to break runtime prebuilt restore
+
+---
+ src/MSBuild/MSBuild.csproj                 | 5 -----
+ src/MSBuildTaskHost/MSBuildTaskHost.csproj | 5 -----
+ 2 files changed, 10 deletions(-)
+
+diff --git a/src/MSBuild/MSBuild.csproj b/src/MSBuild/MSBuild.csproj
+index 80e9e7d..7db4996 100644
+--- a/src/MSBuild/MSBuild.csproj
++++ b/src/MSBuild/MSBuild.csproj
+@@ -8,11 +8,6 @@
+     <TargetFrameworks>$(RuntimeOutputTargetFrameworks)</TargetFrameworks>
+     <PlatformTarget>$(RuntimeOutputPlatformTarget)</PlatformTarget>
+ 
+-    <!-- Set RuntimeIdentifiers so that NuGet will restore for both AnyCPU as well as x86 and x64.
+-         This is important for the MSBuild.VSSetup project, which "references" both the x86 and x64
+-         versions of this project -->
+-    <RuntimeIdentifiers>win7-x86;win7-x64</RuntimeIdentifiers>
+-
+     <EnableDefaultItems>false</EnableDefaultItems>
+     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+     <AssemblyName>MSBuild</AssemblyName>
+diff --git a/src/MSBuildTaskHost/MSBuildTaskHost.csproj b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+index 2e10ebd..9a89161 100644
+--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
++++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+@@ -10,11 +10,6 @@
+     <PlatformTarget Condition="'$(Platform)' == 'x64'">x64</PlatformTarget>
+     <PlatformTarget Condition="'$(Platform)' == 'AnyCPU'">x86</PlatformTarget>
+ 
+-    <!-- Set RuntimeIdentifiers so that NuGet will restore for both AnyCPU as well as x86 and x64.
+-         This is important for the MSBuild.VSSetup project, which "references" both the x86 and x64
+-         versions of this project -->
+-    <RuntimeIdentifiers>win7-x86;win7-x64</RuntimeIdentifiers>
+-    
+     <EnableDefaultItems>false</EnableDefaultItems>
+     <DefineConstants>$(DefineConstants);CLR2COMPATIBILITY</DefineConstants>
+     <!-- Need pointers for getting environment block -->
+-- 
+1.8.3.1
+


### PR DESCRIPTION
Runtime identifier is not needed in core build and therefore, not in source-build.  This specification is pulling in runtime.win-x*.nupkg prebuilts.