### PR TITLE
Enable building on arm64

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -2,6 +2,9 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="$(Configuration) == ''">Release</Configuration>
+
+    <BuildArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</BuildArchitecture>
+    <Platform Condition="'$(Platform)' == '' AND '$(BuildArchitecture)' == 'arm64'">$(BuildArchitecture)</Platform>
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
 
     <!-- true if we have bootstrapped buildtools (usually on an unsupported platform -->
@@ -201,7 +204,7 @@
     <ExtraPackageVersionPropsPackageInfo Include="MicrosoftNETCoreAppRuntimePackageVersion" Version="%24(MicrosoftNETCoreDotNetAppHostPackageVersion)" />
     <ExtraPackageVersionPropsPackageInfo Include="MicrosoftNETCoreAppRuntimeVersion" Version="%24(MicrosoftNETCoreDotNetAppHostPackageVersion)" />
     <ExtraPackageVersionPropsPackageInfo Include="MicrosoftNETCoreAppHostPackageVersion" Version="%24(MicrosoftNETCoreDotNetAppHostPackageVersion)" />
-    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftAspNetCoreAppRuntimePackageVersion" Version="%24(MicrosoftAspNetCoreAppRuntimeLinuxX64PackageVersion)" />
+    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftAspNetCoreAppRuntimePackageVersion" Version="%24(MicrosoftAspNetCoreAppRuntimeLinux$(Platform)PackageVersion)" />
     <!-- core-sdk uses this property for ASP.NET blob directory -->
     <ExtraPackageVersionPropsPackageInfo Include="VSRedistCommonAspNetCoreTargetingPackx6430PackageVersion" Version="$(aspnetcoreOutputPackageVersion)" />
     <!-- OSX needs the OSX version instead of Linux.  We don't have a lot of flexibility in how we output these properties so we're relying on the previous one being blank if the Linux version of the package is missing.  -->

--- a/patches/aspnetcore/0001-Don-t-call-dotnet-without-path.patch
+++ b/patches/aspnetcore/0001-Don-t-call-dotnet-without-path.patch
@@ -1,14 +1,14 @@
-From b7a4992bfa45d3b1c00e095b0b1e7d860b347b50 Mon Sep 17 00:00:00 2001
+From c9ceade354813f98ca291757e7d1657d0959ee4e Mon Sep 17 00:00:00 2001
 From: Chris Rummel <crummel@microsoft.com>
 Date: Wed, 23 Oct 2019 20:04:55 -0500
-Subject: [PATCH 01/10] Don't call dotnet without path
+Subject: [PATCH 01/13] Don't call dotnet without path
 
 ---
  eng/common/tools.sh | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/eng/common/tools.sh b/eng/common/tools.sh
-index 757d5b9..5a4cfeb 100755
+index 757d5b9ea4..5a4cfeb1f0 100755
 --- a/eng/common/tools.sh
 +++ b/eng/common/tools.sh
 @@ -340,9 +340,9 @@ function MSBuild {
@@ -25,5 +25,5 @@ index 757d5b9..5a4cfeb 100755
      local toolset_dir="${_InitializeToolset%/*}"
      local logger_path="$toolset_dir/$_InitializeBuildToolFramework/Microsoft.DotNet.Arcade.Sdk.dll"
 -- 
-1.8.3.1
+2.18.0
 

--- a/patches/aspnetcore/0002-Use-non-portable-NETCoreAppRuntime-for-crossgen.patch
+++ b/patches/aspnetcore/0002-Use-non-portable-NETCoreAppRuntime-for-crossgen.patch
@@ -1,7 +1,7 @@
-From bec8be99172078645255a96cc012a1d2a95da8df Mon Sep 17 00:00:00 2001
+From 528f9457371651668d1923b27cdd5b761f8f2441 Mon Sep 17 00:00:00 2001
 From: dseefeld <dseefeld@microsoft.com>
 Date: Tue, 29 Oct 2019 18:19:03 +0000
-Subject: [PATCH 02/10] Use non-portable NETCoreAppRuntime for crossgen
+Subject: [PATCH 02/13] Use non-portable NETCoreAppRuntime for crossgen
 
 ---
  eng/Dependencies.props                                    | 1 +
@@ -9,7 +9,7 @@ Subject: [PATCH 02/10] Use non-portable NETCoreAppRuntime for crossgen
  2 files changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/eng/Dependencies.props b/eng/Dependencies.props
-index 2e11857..b49aee2 100644
+index 2e11857b1b..b49aee2a5c 100644
 --- a/eng/Dependencies.props
 +++ b/eng/Dependencies.props
 @@ -110,6 +110,7 @@ and are generated based on the last package release.
@@ -21,7 +21,7 @@ index 2e11857..b49aee2 100644
  
    <ItemGroup Label=".NET team dependencies (Non-source-build)" Condition="'$(DotNetBuildFromSource)' != 'true'">
 diff --git a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
-index 4c4298a..edad46b 100644
+index 4c4298a92d..edad46be14 100644
 --- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
 +++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
 @@ -100,7 +100,9 @@ This package is an internal implementation of the .NET Core SDK and is not meant
@@ -45,5 +45,5 @@ index 4c4298a..edad46b 100644
      <ProjectReference Condition="'$(BuildIisNativeProjects)' == 'true' AND '$(BuildNative)' != 'false' AND '$(VCTargetsPath)' != ''" Include="$(RepoRoot)src\Servers\IIS\AspNetCoreModuleV2\InProcessRequestHandler\InProcessRequestHandler.vcxproj">
        <SetPlatform>Platform=$(TargetArchitecture)</SetPlatform>
 -- 
-1.8.3.1
+2.18.0
 

--- a/patches/aspnetcore/0003-Conditionally-set-PackAsToolShimRID.patch
+++ b/patches/aspnetcore/0003-Conditionally-set-PackAsToolShimRID.patch
@@ -1,14 +1,14 @@
-From f7b62cf3e579babe120deb06be418541c717388c Mon Sep 17 00:00:00 2001
+From 87371172f24562810552567b15890eefc9d57249 Mon Sep 17 00:00:00 2001
 From: dseefeld <dseefeld@microsoft.com>
 Date: Thu, 31 Oct 2019 20:38:26 +0000
-Subject: [PATCH 03/10] Conditionally set PackAsToolShimRID
+Subject: [PATCH 03/13] Conditionally set PackAsToolShimRID
 
 ---
  Directory.Build.targets | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Directory.Build.targets b/Directory.Build.targets
-index db3cea5..518b5e6 100644
+index db3cea59f1..518b5e6246 100644
 --- a/Directory.Build.targets
 +++ b/Directory.Build.targets
 @@ -46,7 +46,7 @@
@@ -21,5 +21,5 @@ index db3cea5..518b5e6 100644
      <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86</PackAsToolShimRuntimeIdentifiers>
    </PropertyGroup>
 -- 
-1.8.3.1
+2.18.0
 

--- a/patches/aspnetcore/0004-Exclude-analyzer-for-source-build.patch
+++ b/patches/aspnetcore/0004-Exclude-analyzer-for-source-build.patch
@@ -1,14 +1,14 @@
-From ff7c8a971e21f847db4a9f762c6232a859aebbd1 Mon Sep 17 00:00:00 2001
+From bbd6cbebda9e08a49725b66d9130f76469479413 Mon Sep 17 00:00:00 2001
 From: adaggarwal <aditya.aggarwal@microsoft.com>
 Date: Thu, 14 Nov 2019 16:52:25 +0000
-Subject: [PATCH 04/10] Exclude analyzer for source-build
+Subject: [PATCH 04/13] Exclude analyzer for source-build
 
 ---
  Directory.Build.props | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Directory.Build.props b/Directory.Build.props
-index 2fe19bd..0bc8b25 100644
+index 2fe19bde83..0bc8b25ecc 100644
 --- a/Directory.Build.props
 +++ b/Directory.Build.props
 @@ -95,7 +95,7 @@
@@ -21,5 +21,5 @@ index 2fe19bd..0bc8b25 100644
    </ItemGroup>
  
 -- 
-1.8.3.1
+2.18.0
 

--- a/patches/aspnetcore/0005-Import-PackageVersions.props.patch
+++ b/patches/aspnetcore/0005-Import-PackageVersions.props.patch
@@ -1,17 +1,17 @@
-From 938dad01514f3a4d7bf8f5c8b976cee3d43cdae0 Mon Sep 17 00:00:00 2001
+From 2812263dd785904cf8edd68f258d78d82c3cea59 Mon Sep 17 00:00:00 2001
 From: adaggarwal <aditya.aggarwal@microsoft.com>
 Date: Thu, 14 Nov 2019 16:55:29 +0000
-Subject: [PATCH 05/10] Import PackageVersions.props
+Subject: [PATCH 05/13] Import PackageVersions.props
 
 ---
  eng/Versions.props | 3 +++
  1 file changed, 3 insertions(+)
 
 diff --git a/eng/Versions.props b/eng/Versions.props
-index fd988d1..71384d1 100644
+index a3e611aa4b..37797a5219 100644
 --- a/eng/Versions.props
 +++ b/eng/Versions.props
-@@ -264,6 +264,9 @@
+@@ -267,6 +267,9 @@
      <XunitExtensibilityExecutionPackageVersion>$(XunitVersion)</XunitExtensibilityExecutionPackageVersion>
      <MicrosoftDataSqlClientPackageVersion>1.0.19249.1</MicrosoftDataSqlClientPackageVersion>
    </PropertyGroup>
@@ -22,5 +22,5 @@ index fd988d1..71384d1 100644
    <PropertyGroup Label="Restore feeds">
      <!-- In an orchestrated build, this may be overridden to other Azure feeds. -->
 -- 
-1.8.3.1
+2.18.0
 

--- a/patches/aspnetcore/0006-Exclude-some-projects-from-source-build.patch
+++ b/patches/aspnetcore/0006-Exclude-some-projects-from-source-build.patch
@@ -1,14 +1,14 @@
-From 8de8ac124fdc61fef00c21aa9f4e03e1eeaa46f1 Mon Sep 17 00:00:00 2001
+From 494311a11525c9ca8ce44cff9d6de39802d1dbc6 Mon Sep 17 00:00:00 2001
 From: adaggarwal <aditya.aggarwal@microsoft.com>
 Date: Thu, 14 Nov 2019 16:57:39 +0000
-Subject: [PATCH 06/10] Exclude some projects from source-build
+Subject: [PATCH 06/13] Exclude some projects from source-build
 
 ---
  Directory.Build.props | 2 ++
  1 file changed, 2 insertions(+)
 
 diff --git a/Directory.Build.props b/Directory.Build.props
-index 0bc8b25..88411a3 100644
+index 0bc8b25ecc..88411a30b2 100644
 --- a/Directory.Build.props
 +++ b/Directory.Build.props
 @@ -18,9 +18,11 @@
@@ -24,5 +24,5 @@ index 0bc8b25..88411a3 100644
      <!--
        Following logic mimics core-setup approach as well as
 -- 
-1.8.3.1
+2.18.0
 

--- a/patches/aspnetcore/0007-Fix-version-number.patch
+++ b/patches/aspnetcore/0007-Fix-version-number.patch
@@ -1,10 +1,10 @@
-From 68980720c56f0a0b6d85189e77e11937e22a2119 Mon Sep 17 00:00:00 2001
+From e4b686cfdeeb4d921b3c6e5a63283eff8672856e Mon Sep 17 00:00:00 2001
 From: adaggarwal <aditya.aggarwal@microsoft.com>
 Date: Thu, 14 Nov 2019 17:27:30 +0000
-Subject: [PATCH 07/10] Fix version number
+Subject: [PATCH 07/13] Fix version number
 
 ---
- .../Web.JS/dist/Release/blazor.server.js           | Bin 214579 -> 214584 bytes
+ .../Web.JS/dist/Release/blazor.server.js      | Bin 214579 -> 214584 bytes
  1 file changed, 0 insertions(+), 0 deletions(-)
 
 diff --git a/src/Components/Web.JS/dist/Release/blazor.server.js b/src/Components/Web.JS/dist/Release/blazor.server.js
@@ -17,5 +17,5 @@ delta 24
 fcmdnd!@IeMx1oixg=q`3wi`!EYMD}Ptfn;pZdwQU
 
 -- 
-1.8.3.1
+2.18.0
 

--- a/patches/aspnetcore/0008-Remove-Yarn-dependency-not-used-in-source-build.patch
+++ b/patches/aspnetcore/0008-Remove-Yarn-dependency-not-used-in-source-build.patch
@@ -1,18 +1,18 @@
-From 78a5ac365ba2f82bec480ebba724cf5d60966a91 Mon Sep 17 00:00:00 2001
+From a0ae7e9b334c167943035dff556730d017baa760 Mon Sep 17 00:00:00 2001
 From: adaggarwal <aditya.aggarwal@microsoft.com>
 Date: Thu, 14 Nov 2019 17:34:41 +0000
-Subject: [PATCH 08/10] Remove Yarn dependency - not used in source-build
+Subject: [PATCH 08/13] Remove Yarn dependency - not used in source-build
 
 ---
- eng/targets/Npm.Common.targets                                         | 3 ---
- global.json                                                            | 1 -
- .../NodeServices/src/Microsoft.AspNetCore.NodeServices.csproj          | 3 ---
- src/Middleware/SpaServices/src/Microsoft.AspNetCore.SpaServices.csproj | 3 ---
- src/Shared/E2ETesting/E2ETesting.targets                               | 3 ---
+ eng/targets/Npm.Common.targets                                 | 3 ---
+ global.json                                                    | 1 -
+ .../NodeServices/src/Microsoft.AspNetCore.NodeServices.csproj  | 3 ---
+ .../SpaServices/src/Microsoft.AspNetCore.SpaServices.csproj    | 3 ---
+ src/Shared/E2ETesting/E2ETesting.targets                       | 3 ---
  5 files changed, 13 deletions(-)
 
 diff --git a/eng/targets/Npm.Common.targets b/eng/targets/Npm.Common.targets
-index 062a9d3..3f91b02 100644
+index 062a9d3a8f..3f91b02d42 100644
 --- a/eng/targets/Npm.Common.targets
 +++ b/eng/targets/Npm.Common.targets
 @@ -1,8 +1,5 @@
@@ -25,7 +25,7 @@ index 062a9d3..3f91b02 100644
      <NormalizedPackageId>$(PackageId.Replace('@','').Replace('/','-'))</NormalizedPackageId>
      <PackageFileName>$(NormalizedPackageId)-$(PackageVersion).tgz</PackageFileName>
 diff --git a/global.json b/global.json
-index 17454ad..2f5a03b 100644
+index 17454ad1bf..2f5a03b4b6 100644
 --- a/global.json
 +++ b/global.json
 @@ -24,7 +24,6 @@
@@ -37,7 +37,7 @@ index 17454ad..2f5a03b 100644
      "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19517.3"
    }
 diff --git a/src/Middleware/NodeServices/src/Microsoft.AspNetCore.NodeServices.csproj b/src/Middleware/NodeServices/src/Microsoft.AspNetCore.NodeServices.csproj
-index e67862e..29c3b8c 100644
+index e67862ea45..29c3b8c137 100644
 --- a/src/Middleware/NodeServices/src/Microsoft.AspNetCore.NodeServices.csproj
 +++ b/src/Middleware/NodeServices/src/Microsoft.AspNetCore.NodeServices.csproj
 @@ -16,9 +16,6 @@
@@ -51,7 +51,7 @@ index e67862e..29c3b8c 100644
      <Message Text="Running yarn install on $(MSBuildProjectFile)" Importance="High" />
      <Yarn Command="install --mutex network" />
 diff --git a/src/Middleware/SpaServices/src/Microsoft.AspNetCore.SpaServices.csproj b/src/Middleware/SpaServices/src/Microsoft.AspNetCore.SpaServices.csproj
-index 3db479b..ad01493 100644
+index 3db479b01e..ad0149356f 100644
 --- a/src/Middleware/SpaServices/src/Microsoft.AspNetCore.SpaServices.csproj
 +++ b/src/Middleware/SpaServices/src/Microsoft.AspNetCore.SpaServices.csproj
 @@ -20,9 +20,6 @@
@@ -65,7 +65,7 @@ index 3db479b..ad01493 100644
      <Message Text="Running yarn install on $(MSBuildProjectFile)" Importance="High" />
      <Yarn Command="install --mutex network" />
 diff --git a/src/Shared/E2ETesting/E2ETesting.targets b/src/Shared/E2ETesting/E2ETesting.targets
-index 500d910..2ccf1a4 100644
+index 500d910a30..2ccf1a431c 100644
 --- a/src/Shared/E2ETesting/E2ETesting.targets
 +++ b/src/Shared/E2ETesting/E2ETesting.targets
 @@ -1,7 +1,4 @@
@@ -77,5 +77,5 @@ index 500d910..2ccf1a4 100644
    <ItemGroup>
      <None Update="e2eTestSettings*.json">
 -- 
-1.8.3.1
+2.18.0
 

--- a/patches/aspnetcore/0009-TargetFramework-changes.patch
+++ b/patches/aspnetcore/0009-TargetFramework-changes.patch
@@ -1,26 +1,26 @@
-From e2849b86f2fc893320ca53d2a777d6d5384cc324 Mon Sep 17 00:00:00 2001
+From ba06c858dd36a7d53d73a0fe16afec6c07244c81 Mon Sep 17 00:00:00 2001
 From: adaggarwal <aditya.aggarwal@microsoft.com>
 Date: Thu, 14 Nov 2019 21:04:08 +0000
-Subject: [PATCH 09/10] TargetFramework changes
+Subject: [PATCH 09/13] TargetFramework changes
 
 ---
- .../ref/Microsoft.AspNetCore.Components.Authorization.csproj          | 4 ++--
- src/Components/Forms/ref/Microsoft.AspNetCore.Components.Forms.csproj | 4 ++--
- src/Components/Web/ref/Microsoft.AspNetCore.Components.Web.csproj     | 4 ++--
- .../DataProtection/ref/Microsoft.AspNetCore.DataProtection.csproj     | 4 ++--
- .../ref/Microsoft.AspNetCore.DataProtection.Extensions.csproj         | 4 ++--
- src/Http/Http.Features/ref/Microsoft.AspNetCore.Http.Features.csproj  | 4 ++--
- .../Extensions.Core/ref/Microsoft.Extensions.Identity.Core.csproj     | 4 ++--
- .../Extensions.Stores/ref/Microsoft.Extensions.Identity.Stores.csproj | 4 ++--
- .../Authorization/Core/ref/Microsoft.AspNetCore.Authorization.csproj  | 4 ++--
- .../ref/Microsoft.AspNetCore.Connections.Abstractions.csproj          | 4 ++--
- .../ref/Microsoft.AspNetCore.Http.Connections.Common.csproj           | 4 ++--
- .../ref/Microsoft.AspNetCore.SignalR.Protocols.Json.csproj            | 4 ++--
- .../SignalR.Common/ref/Microsoft.AspNetCore.SignalR.Common.csproj     | 4 ++--
+ .../ref/Microsoft.AspNetCore.Components.Authorization.csproj  | 4 ++--
+ .../Forms/ref/Microsoft.AspNetCore.Components.Forms.csproj    | 4 ++--
+ .../Web/ref/Microsoft.AspNetCore.Components.Web.csproj        | 4 ++--
+ .../ref/Microsoft.AspNetCore.DataProtection.csproj            | 4 ++--
+ .../ref/Microsoft.AspNetCore.DataProtection.Extensions.csproj | 4 ++--
+ .../ref/Microsoft.AspNetCore.Http.Features.csproj             | 4 ++--
+ .../ref/Microsoft.Extensions.Identity.Core.csproj             | 4 ++--
+ .../ref/Microsoft.Extensions.Identity.Stores.csproj           | 4 ++--
+ .../Core/ref/Microsoft.AspNetCore.Authorization.csproj        | 4 ++--
+ .../ref/Microsoft.AspNetCore.Connections.Abstractions.csproj  | 4 ++--
+ .../ref/Microsoft.AspNetCore.Http.Connections.Common.csproj   | 4 ++--
+ .../ref/Microsoft.AspNetCore.SignalR.Protocols.Json.csproj    | 4 ++--
+ .../ref/Microsoft.AspNetCore.SignalR.Common.csproj            | 4 ++--
  13 files changed, 26 insertions(+), 26 deletions(-)
 
 diff --git a/src/Components/Authorization/ref/Microsoft.AspNetCore.Components.Authorization.csproj b/src/Components/Authorization/ref/Microsoft.AspNetCore.Components.Authorization.csproj
-index 513c245..4f710d1 100644
+index 513c24575d..c22ea5fe96 100644
 --- a/src/Components/Authorization/ref/Microsoft.AspNetCore.Components.Authorization.csproj
 +++ b/src/Components/Authorization/ref/Microsoft.AspNetCore.Components.Authorization.csproj
 @@ -1,9 +1,9 @@
@@ -36,7 +36,7 @@ index 513c245..4f710d1 100644
      <Reference Include="Microsoft.AspNetCore.Authorization"  />
      <Reference Include="Microsoft.AspNetCore.Components"  />
 diff --git a/src/Components/Forms/ref/Microsoft.AspNetCore.Components.Forms.csproj b/src/Components/Forms/ref/Microsoft.AspNetCore.Components.Forms.csproj
-index cc3fcfd..dbe32b6 100644
+index cc3fcfda27..5f2f35e54c 100644
 --- a/src/Components/Forms/ref/Microsoft.AspNetCore.Components.Forms.csproj
 +++ b/src/Components/Forms/ref/Microsoft.AspNetCore.Components.Forms.csproj
 @@ -1,9 +1,9 @@
@@ -52,7 +52,7 @@ index cc3fcfd..dbe32b6 100644
      <Reference Include="Microsoft.AspNetCore.Components"  />
      <Reference Include="System.ComponentModel.Annotations"  />
 diff --git a/src/Components/Web/ref/Microsoft.AspNetCore.Components.Web.csproj b/src/Components/Web/ref/Microsoft.AspNetCore.Components.Web.csproj
-index cba2504..498130d 100644
+index cba25041e3..00e1e6b5b8 100644
 --- a/src/Components/Web/ref/Microsoft.AspNetCore.Components.Web.csproj
 +++ b/src/Components/Web/ref/Microsoft.AspNetCore.Components.Web.csproj
 @@ -1,9 +1,9 @@
@@ -68,7 +68,7 @@ index cba2504..498130d 100644
      <Reference Include="Microsoft.AspNetCore.Components"  />
      <Reference Include="Microsoft.AspNetCore.Components.Forms"  />
 diff --git a/src/DataProtection/DataProtection/ref/Microsoft.AspNetCore.DataProtection.csproj b/src/DataProtection/DataProtection/ref/Microsoft.AspNetCore.DataProtection.csproj
-index 9408c35..7fa31b0 100644
+index 9408c35dad..bc40c3586d 100644
 --- a/src/DataProtection/DataProtection/ref/Microsoft.AspNetCore.DataProtection.csproj
 +++ b/src/DataProtection/DataProtection/ref/Microsoft.AspNetCore.DataProtection.csproj
 @@ -1,9 +1,9 @@
@@ -84,7 +84,7 @@ index 9408c35..7fa31b0 100644
      <Reference Include="Microsoft.AspNetCore.Cryptography.Internal"  />
      <Reference Include="Microsoft.AspNetCore.DataProtection.Abstractions"  />
 diff --git a/src/DataProtection/Extensions/ref/Microsoft.AspNetCore.DataProtection.Extensions.csproj b/src/DataProtection/Extensions/ref/Microsoft.AspNetCore.DataProtection.Extensions.csproj
-index 8edb1af..beeaa4d 100644
+index 8edb1af38e..07fda33d8d 100644
 --- a/src/DataProtection/Extensions/ref/Microsoft.AspNetCore.DataProtection.Extensions.csproj
 +++ b/src/DataProtection/Extensions/ref/Microsoft.AspNetCore.DataProtection.Extensions.csproj
 @@ -1,9 +1,9 @@
@@ -100,7 +100,7 @@ index 8edb1af..beeaa4d 100644
      <Reference Include="Microsoft.AspNetCore.DataProtection"  />
      <Reference Include="Microsoft.Extensions.DependencyInjection"  />
 diff --git a/src/Http/Http.Features/ref/Microsoft.AspNetCore.Http.Features.csproj b/src/Http/Http.Features/ref/Microsoft.AspNetCore.Http.Features.csproj
-index ca82096..62aa355 100644
+index ca82096556..aa47f4b34d 100644
 --- a/src/Http/Http.Features/ref/Microsoft.AspNetCore.Http.Features.csproj
 +++ b/src/Http/Http.Features/ref/Microsoft.AspNetCore.Http.Features.csproj
 @@ -1,9 +1,9 @@
@@ -116,7 +116,7 @@ index ca82096..62aa355 100644
      <Reference Include="Microsoft.Extensions.Primitives"  />
      <Reference Include="System.IO.Pipelines"  />
 diff --git a/src/Identity/Extensions.Core/ref/Microsoft.Extensions.Identity.Core.csproj b/src/Identity/Extensions.Core/ref/Microsoft.Extensions.Identity.Core.csproj
-index ae16fce..e0a1740 100644
+index ae16fce673..4ffec37568 100644
 --- a/src/Identity/Extensions.Core/ref/Microsoft.Extensions.Identity.Core.csproj
 +++ b/src/Identity/Extensions.Core/ref/Microsoft.Extensions.Identity.Core.csproj
 @@ -1,9 +1,9 @@
@@ -132,7 +132,7 @@ index ae16fce..e0a1740 100644
      <Reference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation"  />
      <Reference Include="Microsoft.Extensions.Logging"  />
 diff --git a/src/Identity/Extensions.Stores/ref/Microsoft.Extensions.Identity.Stores.csproj b/src/Identity/Extensions.Stores/ref/Microsoft.Extensions.Identity.Stores.csproj
-index f490a31..d16cc35 100644
+index f490a31256..0618562899 100644
 --- a/src/Identity/Extensions.Stores/ref/Microsoft.Extensions.Identity.Stores.csproj
 +++ b/src/Identity/Extensions.Stores/ref/Microsoft.Extensions.Identity.Stores.csproj
 @@ -1,9 +1,9 @@
@@ -148,7 +148,7 @@ index f490a31..d16cc35 100644
      <Reference Include="Microsoft.Extensions.Logging"  />
      <Reference Include="Microsoft.Extensions.Identity.Core"  />
 diff --git a/src/Security/Authorization/Core/ref/Microsoft.AspNetCore.Authorization.csproj b/src/Security/Authorization/Core/ref/Microsoft.AspNetCore.Authorization.csproj
-index 1c742a8..4deb3ac 100644
+index 1c742a823a..d8e894652e 100644
 --- a/src/Security/Authorization/Core/ref/Microsoft.AspNetCore.Authorization.csproj
 +++ b/src/Security/Authorization/Core/ref/Microsoft.AspNetCore.Authorization.csproj
 @@ -1,9 +1,9 @@
@@ -164,7 +164,7 @@ index 1c742a8..4deb3ac 100644
      <Compile Include="Microsoft.AspNetCore.Authorization.Manual.cs" />
      <Reference Include="Microsoft.AspNetCore.Metadata"  />
 diff --git a/src/Servers/Connections.Abstractions/ref/Microsoft.AspNetCore.Connections.Abstractions.csproj b/src/Servers/Connections.Abstractions/ref/Microsoft.AspNetCore.Connections.Abstractions.csproj
-index 290b58c..521b59b 100644
+index 290b58c7fe..b3ea5b17d6 100644
 --- a/src/Servers/Connections.Abstractions/ref/Microsoft.AspNetCore.Connections.Abstractions.csproj
 +++ b/src/Servers/Connections.Abstractions/ref/Microsoft.AspNetCore.Connections.Abstractions.csproj
 @@ -1,9 +1,9 @@
@@ -180,7 +180,7 @@ index 290b58c..521b59b 100644
      <Reference Include="Microsoft.AspNetCore.Http.Features"  />
      <Reference Include="Microsoft.Extensions.ActivatorUtilities.Sources"  />
 diff --git a/src/SignalR/common/Http.Connections.Common/ref/Microsoft.AspNetCore.Http.Connections.Common.csproj b/src/SignalR/common/Http.Connections.Common/ref/Microsoft.AspNetCore.Http.Connections.Common.csproj
-index 9955ca7..ab507ed 100644
+index 9955ca7202..5f8564703e 100644
 --- a/src/SignalR/common/Http.Connections.Common/ref/Microsoft.AspNetCore.Http.Connections.Common.csproj
 +++ b/src/SignalR/common/Http.Connections.Common/ref/Microsoft.AspNetCore.Http.Connections.Common.csproj
 @@ -1,9 +1,9 @@
@@ -196,7 +196,7 @@ index 9955ca7..ab507ed 100644
      <Reference Include="Microsoft.AspNetCore.Connections.Abstractions"  />
      <Reference Include="System.Text.Json"  />
 diff --git a/src/SignalR/common/Protocols.Json/ref/Microsoft.AspNetCore.SignalR.Protocols.Json.csproj b/src/SignalR/common/Protocols.Json/ref/Microsoft.AspNetCore.SignalR.Protocols.Json.csproj
-index 94da81a..088221f 100644
+index 94da81a8e3..5e83d7b1b3 100644
 --- a/src/SignalR/common/Protocols.Json/ref/Microsoft.AspNetCore.SignalR.Protocols.Json.csproj
 +++ b/src/SignalR/common/Protocols.Json/ref/Microsoft.AspNetCore.SignalR.Protocols.Json.csproj
 @@ -1,9 +1,9 @@
@@ -212,7 +212,7 @@ index 94da81a..088221f 100644
      <Reference Include="Microsoft.AspNetCore.SignalR.Common"  />
    </ItemGroup>
 diff --git a/src/SignalR/common/SignalR.Common/ref/Microsoft.AspNetCore.SignalR.Common.csproj b/src/SignalR/common/SignalR.Common/ref/Microsoft.AspNetCore.SignalR.Common.csproj
-index fdc6d74..0753031 100644
+index fdc6d747c7..1960a04139 100644
 --- a/src/SignalR/common/SignalR.Common/ref/Microsoft.AspNetCore.SignalR.Common.csproj
 +++ b/src/SignalR/common/SignalR.Common/ref/Microsoft.AspNetCore.SignalR.Common.csproj
 @@ -1,9 +1,9 @@
@@ -228,5 +228,5 @@ index fdc6d74..0753031 100644
      <Reference Include="Microsoft.AspNetCore.Connections.Abstractions"  />
      <Reference Include="Microsoft.Extensions.Options"  />
 -- 
-1.8.3.1
+2.18.0
 

--- a/patches/aspnetcore/0010-Revert-to-reference-versions-of-source-built-package.patch
+++ b/patches/aspnetcore/0010-Revert-to-reference-versions-of-source-built-package.patch
@@ -1,14 +1,14 @@
-From d81336af7e335715242423ae0e44b720251dbbd3 Mon Sep 17 00:00:00 2001
+From 09320c4b8d4a9f54699cd73e7ce22a198e410065 Mon Sep 17 00:00:00 2001
 From: adaggarwal <aditya.aggarwal@microsoft.com>
 Date: Thu, 14 Nov 2019 21:06:36 +0000
-Subject: [PATCH 10/10] Revert to reference versions of source-built packages
+Subject: [PATCH 10/13] Revert to reference versions of source-built packages
 
 ---
  eng/tools/RepoTasks/RepoTasks.csproj | 8 ++++----
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/eng/tools/RepoTasks/RepoTasks.csproj b/eng/tools/RepoTasks/RepoTasks.csproj
-index 68d4cd2..3cacb7d 100644
+index 68d4cd23fb..3cacb7d190 100644
 --- a/eng/tools/RepoTasks/RepoTasks.csproj
 +++ b/eng/tools/RepoTasks/RepoTasks.csproj
 @@ -12,14 +12,14 @@
@@ -31,5 +31,5 @@ index 68d4cd2..3cacb7d 100644
  
    <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
 -- 
-1.8.3.1
+2.18.0
 

--- a/patches/aspnetcore/0011-Add-FreeBSD.patch
+++ b/patches/aspnetcore/0011-Add-FreeBSD.patch
@@ -1,17 +1,17 @@
-From 457e4bcc40228d64bb98c4e35937d31b4cc76599 Mon Sep 17 00:00:00 2001
+From 1403934f085ecdeb67ae6aa54a059cca9fa92fcf Mon Sep 17 00:00:00 2001
 From: Tomas Weinfurt <tweinfurt@yahoo.com>
 Date: Wed, 13 Nov 2019 22:32:02 -0800
-Subject: [PATCH] Add FreeBSD
+Subject: [PATCH 11/13] Add FreeBSD
 
 ---
  Directory.Build.props | 2 ++
  1 file changed, 2 insertions(+)
 
 diff --git a/Directory.Build.props b/Directory.Build.props
-index 80e6bb14f0..76b1b4451b 100644
+index 88411a30b2..a6befbab24 100644
 --- a/Directory.Build.props
 +++ b/Directory.Build.props
-@@ -115,6 +115,7 @@
+@@ -105,6 +105,7 @@
    <PropertyGroup>
      <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('Windows'))">win</TargetOsName>
      <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('OSX'))">osx</TargetOsName>
@@ -19,7 +19,7 @@ index 80e6bb14f0..76b1b4451b 100644
      <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('Linux'))">linux</TargetOsName>
      <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
      <TargetRuntimeIdentifier>$(TargetOsName)-$(TargetArchitecture)</TargetRuntimeIdentifier>
-@@ -125,6 +126,7 @@
+@@ -115,6 +116,7 @@
        win-x86;
        win-arm;
        osx-x64;
@@ -28,5 +28,5 @@ index 80e6bb14f0..76b1b4451b 100644
        linux-musl-arm64;
        linux-x64;
 -- 
-2.23.0
+2.18.0
 

--- a/patches/aspnetcore/0011-Support-global.json-on-arm64-as-well.patch
+++ b/patches/aspnetcore/0011-Support-global.json-on-arm64-as-well.patch
@@ -1,0 +1,33 @@
+From 84d274a8f3d416b0a5bd999e3d1c43ae1535e38f Mon Sep 17 00:00:00 2001
+From: Omair Majid <omajid@redhat.com>
+Date: Wed, 23 Oct 2019 15:43:57 -0400
+Subject: [PATCH] Support global.json on arm64 as well
+
+arcade uses the runtime section of global.json to decide which
+architecture + runtime combination needs to be installed.
+
+With https://github.com/dotnet/arcade/pull/4132 arcade can install
+foreign SDKs in separate locations correctly.
+
+This change, suggested by @dougbu, makes arcade always install the
+runtime for the local architecture (which means it should work on arm64
+and x64) as well as the x86 architecture (skipped on Linux).
+
+This gets us a working SDK/Runtime combo on arm64.
+---
+ global.json | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/global.json b/global.json
+index 602f4f44e17..40dec559cc9 100644
+--- a/global.json
++++ b/global.json
+@@ -5,7 +5,7 @@
+   "tools": {
+     "dotnet": "3.1.100-preview1-014400",
+     "runtimes": {
+-      "dotnet/x64": [
++      "dotnet": [
+         "$(MicrosoftNETCoreAppRuntimeVersion)"
+       ],
+       "dotnet/x86": [

--- a/patches/aspnetcore/0012-Support-building-for-arm64-on-arm64-nix.patch
+++ b/patches/aspnetcore/0012-Support-building-for-arm64-on-arm64-nix.patch
@@ -1,0 +1,85 @@
+From e2946a26c11be7f7f0c223721a5b14f58f2ea240 Mon Sep 17 00:00:00 2001
+From: Omair Majid <omajid@redhat.com>
+Date: Mon, 11 Nov 2019 13:37:40 -0500
+Subject: [PATCH] Support building for arm64 on arm64 (*nix)
+
+This commit allows ASP.NET Core to be built on arm64 machines directly,
+without relying on cross-compilation.
+
+There's a few changes in here:
+
+1. Ask msbuild to look into the BuildArchitecture
+
+   By default, our build systems assums the machine is x64. This
+   modifies the build configuration to check the architecture of the
+   currently running build machine, and set BuildArchitecture to that.
+
+2. Fix crossgen in Microsoft.AspNetCore.App.Runtime
+
+   We run crossgen for supported architectures (including x64 and
+   arm64). For that, we need a jit that we can point crossgen to.
+   Generally, we can rely on the build scripts to find the right
+   `libclrjit.so`. However, arm64 has multiple `libclirjit.so`, for
+   different use-cases. There's one for arm64 (for running on arm64) and
+   there's another one for cross-compiling for arm64 on x64. We need to
+   figure out and use the right one explicitly rather than assuming the
+   right one gets picked up.
+
+   See https://github.com/dotnet/core-setup/pull/8468 for similar
+   changes made in core-setup.
+
+This also needs https://github.com/aspnet/AspNetCore/pull/14790 to fully
+work on arm64.
+---
+ Directory.Build.props                                |  1 +
+ .../src/Microsoft.AspNetCore.App.Runtime.csproj      | 12 ++++++++----
+ 2 files changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/Directory.Build.props b/Directory.Build.props
+index b3dc903387f..1bd59d73121 100644
+--- a/Directory.Build.props
++++ b/Directory.Build.props
+@@ -108,6 +108,7 @@
+     <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('Windows'))">win</TargetOsName>
+     <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('OSX'))">osx</TargetOsName>
+     <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('Linux'))">linux</TargetOsName>
++    <BuildArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</BuildArchitecture>
+     <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
+     <TargetRuntimeIdentifier>$(TargetOsName)-$(TargetArchitecture)</TargetRuntimeIdentifier>
+ 
+diff --git a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+index 4c4298a92da..f843ded1241 100644
+--- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
++++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
+@@ -90,15 +90,17 @@ This package is an internal implementation of the .NET Core SDK and is not meant
+     <PathSeparator Condition="'$(PathSeparator)' == ''">:</PathSeparator>
+     <PathSeparator Condition=" '$(TargetOsName)' == 'win' ">%3B</PathSeparator>
+ 
++    <CrossCompileDirectory Condition=" '$(TargetRuntimeIdentifier)' == 'linux-arm' ">x64_arm</CrossCompileDirectory>
++    <CrossCompileDirectory Condition=" '$(TargetArchitecture)' == 'arm64' AND '$(BuildArchitecture)' != 'arm64' ">x64_arm64</CrossCompileDirectory>
++    <CrossCompileDirectory Condition=" '$(TargetRuntimeIdentifier)' == 'win-arm' ">x86_arm</CrossCompileDirectory>
++
+     <!-- Crossgen executable name -->
+     <CrossgenToolFileName>crossgen</CrossgenToolFileName>
+     <CrossgenToolFileName Condition=" '$(TargetOsName)' == 'win' ">$(CrossgenToolFileName).exe</CrossgenToolFileName>
+     <!-- Default crossgen executable relative path -->
+     <CrossgenToolPackagePath>$(CrossgenToolFileName)</CrossgenToolPackagePath>
+     <!-- Disambiguated RID-specific crossgen executable relative path -->
+-    <CrossgenToolPackagePath Condition=" '$(TargetRuntimeIdentifier)' == 'linux-arm' ">x64_arm\$(CrossgenToolPackagePath)</CrossgenToolPackagePath>
+-    <CrossgenToolPackagePath Condition=" '$(TargetRuntimeIdentifier)' == 'linux-arm64' OR '$(TargetRuntimeIdentifier)' == 'linux-musl-arm64' ">x64_arm64\$(CrossgenToolPackagePath)</CrossgenToolPackagePath>
+-    <CrossgenToolPackagePath Condition=" '$(TargetRuntimeIdentifier)' == 'win-arm' ">x86_arm\$(CrossgenToolPackagePath)</CrossgenToolPackagePath>
++    <CrossgenToolPackagePath Condition=" '$(CrossCompileDirectory)' != '' ">$(CrossCompileDirectory)\$(CrossgenToolPackagePath)</CrossgenToolPackagePath>
+ 
+     <MicrosoftNETCoreAppRuntimeIdentifier>$(RuntimeIdentifier)</MicrosoftNETCoreAppRuntimeIdentifier>
+     <MicrosoftNETCoreAppRuntimeIdentifier Condition="'$(TargetOsName)' != 'osx'">$(SourceBuildRuntimeIdentifier)</MicrosoftNETCoreAppRuntimeIdentifier>
+@@ -293,7 +295,9 @@ This package is an internal implementation of the .NET Core SDK and is not meant
+   -->
+   <PropertyGroup>
+     <CrossgenToolDir>$(IntermediateOutputPath)crossgen\</CrossgenToolDir>
+-    <CoreCLRJitPath>$(CrossgenToolDir)$(LibPrefix)clrjit$(LibExtension)</CoreCLRJitPath>
++    <!-- Pick the right coreclr jit based on whether we are cross-compiling or not -->
++    <CoreCLRJitPath Condition="'$(CrossCompileDirectory)' == ''">$(RuntimePackageRoot)runtimes\$(RuntimeIdentifier)\native\$(LibPrefix)clrjit$(LibExtension)</CoreCLRJitPath>
++    <CoreCLRJitPath Condition="'$(CrossCompileDirectory)' != ''">$(RuntimepackageRoot)runtimes\$(CrossCompileDirectory)\native\$(LibPrefix)clrjit$(LibExtension)</CoreCLRJitPath>
+   </PropertyGroup>
+ 
+   <ItemGroup>

--- a/patches/aspnetcore/0012-Support-global.json-on-arm64-as-well.patch
+++ b/patches/aspnetcore/0012-Support-global.json-on-arm64-as-well.patch
@@ -1,7 +1,7 @@
-From 84d274a8f3d416b0a5bd999e3d1c43ae1535e38f Mon Sep 17 00:00:00 2001
+From 99d98bdeedfb1894b4af46aa3f69b0a6962c47c4 Mon Sep 17 00:00:00 2001
 From: Omair Majid <omajid@redhat.com>
 Date: Wed, 23 Oct 2019 15:43:57 -0400
-Subject: [PATCH] Support global.json on arm64 as well
+Subject: [PATCH 12/13] Support global.json on arm64 as well
 
 arcade uses the runtime section of global.json to decide which
 architecture + runtime combination needs to be installed.
@@ -19,7 +19,7 @@ This gets us a working SDK/Runtime combo on arm64.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/global.json b/global.json
-index 602f4f44e17..40dec559cc9 100644
+index 2f5a03b4b6..0a09c9773c 100644
 --- a/global.json
 +++ b/global.json
 @@ -5,7 +5,7 @@
@@ -31,3 +31,6 @@ index 602f4f44e17..40dec559cc9 100644
          "$(MicrosoftNETCoreAppRuntimeVersion)"
        ],
        "dotnet/x86": [
+-- 
+2.18.0
+

--- a/patches/aspnetcore/0013-Support-building-for-arm64-on-arm64-nix.patch
+++ b/patches/aspnetcore/0013-Support-building-for-arm64-on-arm64-nix.patch
@@ -1,7 +1,7 @@
-From e2946a26c11be7f7f0c223721a5b14f58f2ea240 Mon Sep 17 00:00:00 2001
+From e2a30328cd69705abda36ba4cb8a695e1dc90d2a Mon Sep 17 00:00:00 2001
 From: Omair Majid <omajid@redhat.com>
 Date: Mon, 11 Nov 2019 13:37:40 -0500
-Subject: [PATCH] Support building for arm64 on arm64 (*nix)
+Subject: [PATCH 13/13] Support building for arm64 on arm64 (*nix)
 
 This commit allows ASP.NET Core to be built on arm64 machines directly,
 without relying on cross-compilation.
@@ -36,19 +36,19 @@ work on arm64.
  2 files changed, 9 insertions(+), 4 deletions(-)
 
 diff --git a/Directory.Build.props b/Directory.Build.props
-index b3dc903387f..1bd59d73121 100644
+index a6befbab24..30e1c7d683 100644
 --- a/Directory.Build.props
 +++ b/Directory.Build.props
-@@ -108,6 +108,7 @@
-     <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('Windows'))">win</TargetOsName>
+@@ -107,6 +107,7 @@
      <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('OSX'))">osx</TargetOsName>
+     <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('FreeBSD'))">freebsd</TargetOsName>
      <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('Linux'))">linux</TargetOsName>
 +    <BuildArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</BuildArchitecture>
      <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
      <TargetRuntimeIdentifier>$(TargetOsName)-$(TargetArchitecture)</TargetRuntimeIdentifier>
  
 diff --git a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
-index 4c4298a92da..f843ded1241 100644
+index edad46be14..b4e9189960 100644
 --- a/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
 +++ b/src/Framework/src/Microsoft.AspNetCore.App.Runtime.csproj
 @@ -90,15 +90,17 @@ This package is an internal implementation of the .NET Core SDK and is not meant
@@ -72,7 +72,7 @@ index 4c4298a92da..f843ded1241 100644
  
      <MicrosoftNETCoreAppRuntimeIdentifier>$(RuntimeIdentifier)</MicrosoftNETCoreAppRuntimeIdentifier>
      <MicrosoftNETCoreAppRuntimeIdentifier Condition="'$(TargetOsName)' != 'osx'">$(SourceBuildRuntimeIdentifier)</MicrosoftNETCoreAppRuntimeIdentifier>
-@@ -293,7 +295,9 @@ This package is an internal implementation of the .NET Core SDK and is not meant
+@@ -295,7 +297,9 @@ This package is an internal implementation of the .NET Core SDK and is not meant
    -->
    <PropertyGroup>
      <CrossgenToolDir>$(IntermediateOutputPath)crossgen\</CrossgenToolDir>
@@ -83,3 +83,6 @@ index 4c4298a92da..f843ded1241 100644
    </PropertyGroup>
  
    <ItemGroup>
+-- 
+2.18.0
+

--- a/patches/core-sdk/0003-Enable-building-on-arm64-machines.patch
+++ b/patches/core-sdk/0003-Enable-building-on-arm64-machines.patch
@@ -1,0 +1,103 @@
+From 4b5c617203cfb9d2c1b12995e12d819fba6d7b6f Mon Sep 17 00:00:00 2001
+From: Omair Majid <omajid@redhat.com>
+Date: Tue, 8 Oct 2019 17:02:29 -0400
+Subject: [PATCH] Enable building on arm64 machines
+
+With this commit, I can build core-sdk on RHEL 8 on arm64 directly,
+without cross compilation.
+
+Bump the sourcelink version to pick up the ability to parse git info
+without depending on libgit2sharp. This allows sourcelink to work on
+arm64. The version is the same as the one recently added to core-setup:
+https://github.com/dotnet/core-setup/pull/7696
+
+Introduce a new 'BuildArchitecture' msbuild property that contains the host
+architecture (arm64, x64, etc). This is the architecture of the
+currently running machine, and may be different from the architecture we
+are targetting in the case of cross compilation.
+
+There's a gotcha with BuildArchitecture: under Visual Studio (an x86) process,
+we generally want a x64 architecture. So try and restrict it to arm64 only.
+
+Use BuildArchitecture to determine whether _crossDir and LibCLRJitRid need to
+be special-cased for arm64 or or not.
+---
+ Directory.Build.props                            | 6 ++++++
+ eng/Versions.props                               | 2 +-
+ src/redist/targets/Crossgen.targets              | 6 +++---
+ src/redist/targets/GenerateLayout.targets        | 4 ++--
+ src/redist/targets/GetRuntimeInformation.targets | 1 -
+ 5 files changed, 12 insertions(+), 7 deletions(-)
+
+diff --git a/Directory.Build.props b/Directory.Build.props
+index b65a72410..be3834859 100644
+--- a/Directory.Build.props
++++ b/Directory.Build.props
+@@ -7,6 +7,12 @@
+     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+   </PropertyGroup>
+ 
++  <PropertyGroup>
++    <BuildArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</BuildArchitecture>
++    <Architecture Condition="'$(BuildArchitecture)' == 'arm64'">$(BuildArchitecture)</Architecture>
++    <Architecture Condition="'$(Architecture)' == ''">x64</Architecture>
++  </PropertyGroup>
++
+   <PropertyGroup>
+     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+     <DebugType>embedded</DebugType>
+diff --git a/src/redist/targets/Crossgen.targets b/src/redist/targets/Crossgen.targets
+index 8d3091307..931dff2d9 100644
+--- a/src/redist/targets/Crossgen.targets
++++ b/src/redist/targets/Crossgen.targets
+@@ -5,14 +5,14 @@
+     
+     <PropertyGroup>
+       <RuntimeNETCoreAppPackageName>microsoft.netcore.app.runtime.$(SharedFrameworkRid)</RuntimeNETCoreAppPackageName>
+-      <_crossDir Condition="'$(Architecture)' == 'arm64'">/x64_arm64</_crossDir>
++      <_crossDir Condition="'$(Architecture)' == 'arm64' and '$(BuildArchitecture)' != 'arm64'">/x64_arm64</_crossDir>
+       <_crossDir Condition="'$(Architecture)' == 'arm' And '$(OSName)' == 'win'">/x86_arm</_crossDir>
+       <_crossDir Condition="'$(Architecture)' == 'arm' And '$(OSName)' == 'linux'">/x64_arm</_crossDir>
+       <CrossgenPath>$(NuGetPackageRoot)/$(RuntimeNETCoreAppPackageName)/$(MicrosoftNETCoreAppRuntimePackageVersion)/tools$(_crossDir)/crossgen$(ExeExtension)</CrossgenPath>
+-      <LibCLRJitRid Condition="!$(Architecture.StartsWith('arm'))">$(SharedFrameworkRid)</LibCLRJitRid>
+-      <LibCLRJitRid Condition="'$(Architecture)' == 'arm64'">x64_arm64</LibCLRJitRid>
++      <LibCLRJitRid Condition="'$(Architecture)' == 'arm64' and '$(BuildArchitecture)' == 'x64'">x64_arm64</LibCLRJitRid>
+       <LibCLRJitRid Condition="'$(Architecture)' == 'arm' And '$(OSName)' == 'win'">x86_arm</LibCLRJitRid>
+       <LibCLRJitRid Condition="'$(Architecture)' == 'arm' And '$(OSName)' == 'linux'">x64_arm</LibCLRJitRid>
++      <LibCLRJitRid Condition="'$(LibCLRJitRid)' == ''">$(SharedFrameworkRid)</LibCLRJitRid>
+       <LibCLRJitPath>$(NuGetPackageRoot)/$(RuntimeNETCoreAppPackageName)/$(MicrosoftNETCoreAppRuntimePackageVersion)/runtimes/$(LibCLRJitRid)/native/$(DynamicLibPrefix)clrjit$(DynamicLibExtension)</LibCLRJitPath>
+       <SharedFrameworkNameVersionPath>$(RedistLayoutPath)shared/$(SharedFrameworkName)/$(MicrosoftNETCoreAppRuntimePackageVersion)</SharedFrameworkNameVersionPath>
+       <DIASymReaderCrossgenFilter>*</DIASymReaderCrossgenFilter>
+diff --git a/src/redist/targets/GenerateLayout.targets b/src/redist/targets/GenerateLayout.targets
+index d2a0b6fd1..a0bcf6f35 100644
+--- a/src/redist/targets/GenerateLayout.targets
++++ b/src/redist/targets/GenerateLayout.targets
+@@ -25,11 +25,11 @@
+ 
+       <!-- Use the "x64" Rid when downloading Linux shared framework 'DEB' installer files. -->
+       <SharedFrameworkInstallerFileRid>$(CoreSetupRid)</SharedFrameworkInstallerFileRid>
+-      <SharedFrameworkInstallerFileRid Condition=" '$(IsDebianBaseDistro)' == 'true' OR '$(IsRPMBasedDistro)' == 'true' ">x64</SharedFrameworkInstallerFileRid>
++      <SharedFrameworkInstallerFileRid Condition=" '$(IsDebianBaseDistro)' == 'true' OR '$(IsRPMBasedDistro)' == 'true' ">$(Architecture)</SharedFrameworkInstallerFileRid>
+ 
+       <!-- Use the "x64" Rid when downloading Linux runtime dependencies Debian package. -->
+       <RuntimeDepsInstallerFileRid>$(CoreSetupRid)</RuntimeDepsInstallerFileRid>
+-      <RuntimeDepsInstallerFileRid Condition=" '$(IsDebianBaseDistro)' == 'true' ">x64</RuntimeDepsInstallerFileRid>
++      <RuntimeDepsInstallerFileRid Condition=" '$(IsDebianBaseDistro)' == 'true' ">$(Architecture)</RuntimeDepsInstallerFileRid>
+ 
+       <AlternateArchitecture Condition="'$(Architecture)' == 'x86'">x64</AlternateArchitecture>
+       <AlternateArchitecture Condition="'$(Architecture)' == 'x64'">x86</AlternateArchitecture>
+diff --git a/src/redist/targets/GetRuntimeInformation.targets b/src/redist/targets/GetRuntimeInformation.targets
+index 3b14d1203..f49c7262f 100644
+--- a/src/redist/targets/GetRuntimeInformation.targets
++++ b/src/redist/targets/GetRuntimeInformation.targets
+@@ -13,7 +13,6 @@
+       <OSName Condition=" '$(OSName)' == '' AND '$(IsLinux)' == 'True' ">linux</OSName>
+       <OSPlatform Condition=" '$(OSPlatform)' == '' AND '$(IsLinux)' == 'True' ">linux</OSPlatform>
+ 
+-      <Architecture Condition=" '$(Architecture)' == '' ">x64</Architecture>
+       <Rid Condition=" '$(Rid)' == '' ">$(OSName)-$(Architecture)</Rid>
+     </PropertyGroup>
+     
+-- 
+2.18.1
+

--- a/patches/core-setup/0004-Enable-building-for-arm64-on-arm64.patch
+++ b/patches/core-setup/0004-Enable-building-for-arm64-on-arm64.patch
@@ -1,0 +1,81 @@
+From c02027bfee1c523006430183d37c1b61072d5ed8 Mon Sep 17 00:00:00 2001
+From: Omair Majid <omajid@redhat.com>
+Date: Fri, 4 Oct 2019 16:08:59 -0400
+Subject: [PATCH] Enable building for arm64 on arm64
+
+To enable building core-setup on arm64 machines (not cross compiled), we need
+to do a few things:
+
+- Set the right TargetArchitecture
+
+  When `TargetArchitecture` is not explicitly specified and when the currently
+  running architecture is Arm64, use arm64 as the `TargetArchitecture`. Don't
+  always use the currently running architecture as that doesn't play well with
+  an x86 Visual Studio trying to create x64 builds.
+
+- Use the right coreclr JIT
+
+  If we are cross-compiling, we need to use the x86_arm64 libclrjit.so. But if
+  we are building on an arm64 machine, we need to filter the list of found
+  libclrjit.so files to pick the normal-RID (eg, linux-arm64) libclrjit.so from
+  the two:
+
+  ./.packages/transport.runtime.linux-arm64.microsoft.netcore.jit/<version>/runtimes/linux-arm64/native/libclrjit.so
+  ./.packages/transport.runtime.linux-arm64.microsoft.netcore.jit/<version>/runtimes/x64_arm64/native/libclrjit.so
+---
+ Directory.Build.props                                | 4 +++-
+ src/pkg/packaging-tools/framework.dependency.targets | 7 +++----
+ 2 files changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/Directory.Build.props b/Directory.Build.props
+index a53af2f09f..a7e9169c91 100644
+--- a/Directory.Build.props
++++ b/Directory.Build.props
+@@ -94,6 +94,8 @@
+   </PropertyGroup>
+ 
+   <PropertyGroup>
++    <BuildArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</BuildArchitecture>
++    <TargetArchitecture  Condition="'$(TargetArchitecture)' == '' AND '$(BuildArchitecture)' == 'arm64'">$(BuildArchitecture)</TargetArchitecture>
+     <TargetArchitecture  Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
+     <Platform Condition="'$(Platform)'==''">$(TargetArchitecture)</Platform>
+   </PropertyGroup>
+@@ -398,4 +400,4 @@
+     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+   </PropertyGroup>
+ 
+-</Project>
+\ No newline at end of file
++</Project>
+diff --git a/src/pkg/packaging-tools/framework.dependency.targets b/src/pkg/packaging-tools/framework.dependency.targets
+index 3e7afc5483..14ac018b02 100644
+--- a/src/pkg/packaging-tools/framework.dependency.targets
++++ b/src/pkg/packaging-tools/framework.dependency.targets
+@@ -254,7 +254,7 @@
+     <PropertyGroup>
+       <_crossDir Condition="'$(TargetArchitecture)' == 'arm' AND '$(OS)' == 'Windows_NT'">/x86_arm</_crossDir>
+       <_crossDir Condition="'$(TargetArchitecture)' == 'arm' AND '$(OS)' != 'Windows_NT'">/x64_arm</_crossDir>
+-      <_crossDir Condition="'$(TargetArchitecture)' == 'arm64'">/x64_arm64</_crossDir>
++      <_crossDir Condition="'$(TargetArchitecture)' == 'arm64' AND '$(BuildArchitecture)' != 'arm64'">/x64_arm64</_crossDir>
+     </PropertyGroup>
+ 
+     <ItemGroup>
+@@ -272,7 +272,6 @@
+       <!-- Find crossgen tool assets in package cache to allow ExcludeAssets=All. -->
+       <_runtimeCLR Include="$(_runtimePackageDir)**/$(LibraryFilePrefix)coreclr$(LibraryFileExtension)" />
+       <_runtimeCoreLib Include="$(_runtimePackageDir)**/native/System.Private.CoreLib.dll" />
+-      <_runtimeJIT Include="$(_jitPackageDir)**/$(LibraryFilePrefix)clrjit$(LibraryFileExtension)" />
+       <_fxSystemRuntime Include="$(_corefxPackageDir)**/System.Runtime.dll" />
+       <_windowsWinMD Include="$(_winmdPackageDir)**/Windows.winmd" />
+       <_diaSymReaderAssembly Include="$(_diaSymReaderPackageDir)**\Microsoft.DiaSymReader.Native.*.dll" />
+@@ -287,8 +286,8 @@
+       <_coreLibDirectory>%(_runtimeCoreLib.RootDir)%(_runtimeCoreLib.Directory)</_coreLibDirectory>
+     </PropertyGroup>
+ 
+-    <PropertyGroup Condition="'@(_runtimeJIT)' != ''">
+-      <_jitPath>%(_runtimeJIT.FullPath)</_jitPath>
++    <PropertyGroup>
++      <_jitPath Condition="'$(_crossDir)' == ''">$(_jitPackageDir)runtimes/$(PackageRID)/native/$(LibraryFilePrefix)clrjit$(LibraryFileExtension)</_jitPath>
+       <_jitPath Condition="'$(_crossDir)' != ''">$(_jitPackageDir)runtimes$(_crossDir)/native/$(LibraryFilePrefix)clrjit$(LibraryFileExtension)</_jitPath>
+     </PropertyGroup>
+ 

--- a/patches/corefx/0004-Enable-build-on-hosted-arm64.patch
+++ b/patches/corefx/0004-Enable-build-on-hosted-arm64.patch
@@ -1,0 +1,46 @@
+From d36274c31cc30a946c023b7a5bb5c6fa1ff86625 Mon Sep 17 00:00:00 2001
+From: Omair Majid <omajid@redhat.com>
+Date: Tue, 20 Aug 2019 13:40:19 -0400
+Subject: [PATCH] Enable build on hosted arm64
+
+This is attempt #2. The first attempt was commit
+176da26d634fd760d7c8c99956f2e8d3f7d485e7.
+
+Initialize HostArch to the arch-style used in RIDs directly by
+converting things to lowercase.
+
+Use the HostArch for the tool runtime instead of assuming x64.
+---
+ Directory.Build.props | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/Directory.Build.props b/Directory.Build.props
+index fe1f406a02d7..dae20af84cc1 100644
+--- a/Directory.Build.props
++++ b/Directory.Build.props
+@@ -64,9 +64,9 @@
+     <TargetGroup Condition="'$(TargetGroup)' == ''">netcoreapp</TargetGroup>
+     <OSGroup Condition="'$(OSGroup)' == ''">$(DefaultOSGroup)</OSGroup>
+     <ConfigurationGroup Condition="'$(ConfigurationGroup)' == ''">Debug</ConfigurationGroup>
+-    <HostArch>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)</HostArch>
+-    <ArchGroup Condition="'$(ArchGroup)' == '' AND '$(HostArch)' == 'Arm'">arm</ArchGroup>
+-    <ArchGroup Condition="'$(ArchGroup)' == '' AND '$(HostArch)' == 'Arm64'">arm64</ArchGroup>
++    <HostArch>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant)</HostArch>
++    <ArchGroup Condition="'$(ArchGroup)' == '' AND '$(HostArch)' == 'arm'">arm</ArchGroup>
++    <ArchGroup Condition="'$(ArchGroup)' == '' AND '$(HostArch)' == 'arm64'">arm64</ArchGroup>
+     <ArchGroup Condition="'$(ArchGroup)' == ''">x64</ArchGroup>
+ 
+     <!-- Initialize BuildConfiguration from the individual properties if it wasn't already explicitly set -->
+@@ -135,9 +135,10 @@
+     <_runtimeOS Condition="'$(_runtimeOS)' == 'tizen.4.0.0'">linux</_runtimeOS>
+     <_runtimeOS Condition="'$(_runtimeOS)' == 'tizen.5.0.0'">linux</_runtimeOS>
+     <_runtimeOS Condition="'$(PortableBuild)' == 'true'">$(_portableOS)</_runtimeOS>
+-    <ToolRuntimeRID>$(_runtimeOS)-x64</ToolRuntimeRID>
++    <ToolRuntimeRID Condition="'$(BuildingInsideVisualStudio)' == 'true'">$(_runtimeOS)-x64</ToolRuntimeRID>
++    <ToolRuntimeRID Condition="'$(ToolRuntimeID)' == ''">$(_runtimeOS)-$(HostArch)</ToolRuntimeRID>
+     <!-- We build linux-musl-arm on a ubuntu container, so we can't use the toolset build for alpine runtime. We need to use portable linux RID for our toolset in order to be able to use it. -->
+-    <ToolRuntimeRID Condition="'$(_runtimeOS)' == 'linux-musl' AND $(ArchGroup.StartsWith('arm')) AND !$(HostArch.StartsWith('Arm'))">linux-x64</ToolRuntimeRID>
++    <ToolRuntimeRID Condition="'$(_runtimeOS)' == 'linux-musl' AND $(ArchGroup.StartsWith('arm')) AND !$(HostArch.StartsWith('arm'))">linux-x64</ToolRuntimeRID>
+ 
+     <!-- There are no WebAssembly tools, so treat them as Windows -->
+     <ToolRuntimeRID Condition="'$(RuntimeOS)' == 'WebAssembly'">win-x64</ToolRuntimeRID>

--- a/repos/aspnetcore.proj
+++ b/repos/aspnetcore.proj
@@ -14,6 +14,8 @@
     <BuildCommandArgs>$(BuildCommandArgs) --configuration $(Configuration)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) --ci</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) -bl</BuildCommandArgs>
+    <!-- The arch flag (defaults to x64) overrides any value of TargetArchitecture that we might set -->
+    <BuildCommandArgs>$(BuildCommandArgs) --arch $(Platform)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:BuildNodeJs=false</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:SourceBuildRuntimeIdentifier=$(OverrideTargetRid)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:UseAppHost=false</BuildCommandArgs>

--- a/repos/core-sdk.proj
+++ b/repos/core-sdk.proj
@@ -6,7 +6,7 @@
     <OSNameOverride>$(TargetRid.Substring(0, $(TargetRid.IndexOf("-"))))</OSNameOverride>
     <BuildCommandArgs/>
     <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">$(BuildCommandArgs) /p:Rid=$(TargetRid)</BuildCommandArgs>
-    <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">$(BuildCommandArgs) /p:AspNetCoreSharedFxInstallerRid=linux-x64</BuildCommandArgs>
+    <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">$(BuildCommandArgs) /p:AspNetCoreSharedFxInstallerRid=linux-$(Platform)</BuildCommandArgs>
     <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">$(BuildCommandArgs) /p:OSName=$(OSNameOverride)</BuildCommandArgs>
     <!-- core-sdk always wants to build portable on OSX and FreeBSD -->
     <BuildCommandArgs Condition="'$(TargetOS)' == 'FreeBSD'">$(BuildCommandArgs) /p:CoreSetupRid=freebsd-x64 /p:PortableBuild=true</BuildCommandArgs>

--- a/repos/core-setup.proj
+++ b/repos/core-setup.proj
@@ -14,7 +14,7 @@
     <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)configuration $(Configuration)</BuildArguments>
     <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)ci</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:PortableBuild=$(OverridePortable)</BuildArguments>
-    <BuildArguments Condition="$(Platform.Contains('arm'))">$(BuildArguments) /p:TargetArchitecture=$(Platform) /p:DisableCrossgen=true /p:CrossBuild=true</BuildArguments>
+    <BuildArguments Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64'">$(BuildArguments) /p:TargetArchitecture=$(Platform) /p:DisableCrossgen=true /p:CrossBuild=true</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:BuildDebPackage=false</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:BuildAllPackages=true</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:RestoreAllBuildRids=false</BuildArguments>
@@ -29,7 +29,7 @@
     <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)nodereuse $(ArcadeFalseBoolBuildArg)</BuildArguments>
 
     <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments)</BuildCommand>
-    <BuildCommand Condition="$(Platform.Contains('arm'))">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
+    <BuildCommand Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64'">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
 
     <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
     <ShippingPackagesOutput>$(ProjectDirectory)artifacts/packages/$(Configuration)/Shipping/</ShippingPackagesOutput>

--- a/repos/coreclr.proj
+++ b/repos/coreclr.proj
@@ -10,7 +10,7 @@
     <BuildArguments Condition="'$(SkipDisablePgo)' != 'true'">$(BuildArguments) -nopgooptimize</BuildArguments>
     <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) msbuildonunsupportedplatform</BuildArguments>
     <BuildArguments Condition="'$(UseSystemLibraries)' == 'true' AND '$(OS)' != 'Windows_NT'">$(BuildArguments) cmakeargs -DCLR_CMAKE_USE_SYSTEM_LIBUNWIND=TRUE</BuildArguments>
-    <BuildArguments Condition="$(Platform.Contains('arm'))">$(BuildArguments) skipnuget cross -skiprestore cmakeargs -DFEATURE_GDBJIT=TRUE</BuildArguments>
+    <BuildArguments Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64' ">$(BuildArguments) skipnuget cross -skiprestore cmakeargs -DFEATURE_GDBJIT=TRUE</BuildArguments>
     <BuildArguments Condition="'$(TargetOS)' == 'FreeBSD'">$(BuildArguments) -clang6.0 /p:PortableBuild=true</BuildArguments>
 
     <!-- Portable builds only apply to Linux - Mac and Windows are both always portable.
@@ -27,7 +27,7 @@
 
     <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments)</BuildCommand>
 
-    <BuildCommand Condition="$(Platform.Contains('arm'))">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
+    <BuildCommand Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64' ">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
 
     <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension)</CleanCommand>
 

--- a/repos/corefx.proj
+++ b/repos/corefx.proj
@@ -51,7 +51,7 @@
     <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)nodereuse $(ArcadeFalseBoolBuildArg) $(FlagParameterPrefix)ci</BuildArguments>
 
     <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments)</BuildCommand>
-    <BuildCommand Condition="$(Platform.Contains('arm'))">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
+    <BuildCommand Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64'">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
 
     <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
     <ShippingPackagesOutput>$(ProjectDirectory)artifacts/packages/$(Configuration)/Shipping/</ShippingPackagesOutput>

--- a/repos/known-good.proj
+++ b/repos/known-good.proj
@@ -19,7 +19,7 @@
         <RepositoryReference Include="corefx" />
       </ItemGroup>
     </When>
-    <When Condition="$(Platform.Contains('arm'))">
+    <When Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64'">
       <ItemGroup>
         <RepositoryReference Include="core-setup" />
       </ItemGroup>

--- a/tools-local/init-build.proj
+++ b/tools-local/init-build.proj
@@ -75,7 +75,7 @@
   </Target>
 
   <Target Name="GenerateRootFs" Condition="'$(OS)' != 'Windows_NT'">
-     <Exec Condition="$(Platform.Contains('arm')) AND '$(Platform)' != 'armel'" Command="$(ArmEnvironmentVariables) $(ProjectDir)cross/build-rootfs.sh" />
+     <Exec Condition="$(Platform.Contains('arm')) AND '$(Platform)' != 'armel' AND '$(BuildArchitecture)' != 'arm64'" Command="$(ArmEnvironmentVariables) $(ProjectDir)cross/build-rootfs.sh" />
      <Exec Condition="'$(Platform)' == 'armel'" Command="$(ArmEnvironmentVariables) $(ProjectDir)cross/armel/tizen-build-rootfs.sh" />
   </Target>
 
@@ -175,7 +175,7 @@
       <DarcCloneCommand>$(DotNetCliToolDir)dotnet $(DarcDll) $(DarcCloneArguments)</DarcCloneCommand>
     </PropertyGroup>
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Running Darc command: '$(DarcCloneCommand)' from working dir $(ProjectDir)" />
-    <Exec Command="$(DarcCloneCommand)" WorkingDirectory="$(ProjectDir)" EnvironmentVariables="LD_LIBRARY_PATH=$(DotNetCliToolDir)/tools/.store/microsoft.dotnet.darc/$(DarcVersion)/microsoft.dotnet.darc/$(DarcVersion)/tools/netcoreapp2.1/any/runtimes/rhel-x64/native/" />
+    <Exec Command="$(DarcCloneCommand)" WorkingDirectory="$(ProjectDir)"  />
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Done getting source code for repos in Version.Details.xml." />
   </Target>
 


### PR DESCRIPTION
With this change, I can build source-build on RHEL 8 on arm64:

```
$ ~/source-build/dotnet-sdk/dotnet --info                                                                                                                                                                      
.NET Core SDK (reflecting any global.json):                                                                                                                                                                                                   
 Version:   3.0.100                                                                                                                                                                                                                           
 Commit:    04339c3a26                                                                                                                                                                                                                        
                                                                                                                                                                                                                                              
Runtime Environment:                                                                                                                                                                                                                          
 OS Name:     rhel                                                                                                                                                                                                                            
 OS Version:  8                                                                                                                                                                                                                               
 OS Platform: Linux                                                                                                                                                                                                                           
 RID:         rhel.8-arm64                                                                                                                                                                                                                    
 Base Path:   /home/omajid/source-build/dotnet-sdk/sdk/3.0.100/                                                                                                                                                                               
                                                                                                                                                                                                                                              
Host (useful for support):                                                                                                                                                                                                                    
  Version: 3.0.0                                                                                                                                                                                                                              
  Commit:  62f8ee7211                                                                                                                                                                                                                         
                                                                                                                                                                                                                                              
.NET Core SDKs installed:                                                                                                                                                                                                                     
  3.0.100 [/home/omajid/source-build/dotnet-sdk/sdk]                                                                                                                                                                                          
                                                                                                                                                                                                                                              
.NET Core runtimes installed:                                                                                                                                                                                                                 
  Microsoft.AspNetCore.App 3.0.0 [/home/omajid/source-build/dotnet-sdk/shared/Microsoft.AspNetCore.App]                                                                                                                                       
  Microsoft.NETCore.App 3.0.0 [/home/omajid/source-build/dotnet-sdk/shared/Microsoft.NETCore.App]                                                                                                                                             
                                                                                                                                                                                                                                              
To install additional .NET Core runtimes or SDKs:                                                                                                                                                                                             
  https://aka.ms/dotnet-download                                                                                                                                                                                                              
$ ~/source-build/dotnet-sdk/dotnet new console                                                                                                                                                                 
The template "Console Application" was created successfully.                                                                                                                                                                                  
                                                                                                                                                                                                                                              
Processing post-creation actions...                                                                                                                                                                                                           
Running 'dotnet restore' on /home/omajid/source-build/hello/hello.csproj...                                                                                                                                                                   
  Restore completed in 122.02 ms for /home/omajid/source-build/hello/hello.csproj.                                                                                                                                                            
                                                                                                                                                                                                                                              
Restore succeeded.                                                                                                                                                                                                                            
                                                                                                                                                                                                                                              
$ ~/source-build/dotnet-sdk/dotnet run                                                                                                                                                                         
Hello World!
```

~~I also needed this change to `arcade-services`:~~ The following is redundant because the `arcade-services` submodule was removed:

```diff
diff --git a/tools-local/arcade-services/eng/Versions.props b/tools-local/arcade-services/eng/Versions.props
index c69a2ff..6350ff1 100644
--- a/tools-local/arcade-services/eng/Versions.props
+++ b/tools-local/arcade-services/eng/Versions.props
@@ -12,7 +12,7 @@
     <CommandLineParserVersion>2.2.1</CommandLineParserVersion>
     <CredentialManagementVersion>1.0.2</CredentialManagementVersion>
     <HandlebarsNetVersion>1.9.5</HandlebarsNetVersion>
-    <LibGit2SharpVersion>0.26.0</LibGit2SharpVersion>
+    <LibGit2SharpVersion>0.27.0-preview-0020</LibGit2SharpVersion>
     <log4netVersion>2.0.8</log4netVersion>
     <SystemNetHttpVersion>4.3.3</SystemNetHttpVersion>
     <MicrosoftAzureKeyVaultVersion>3.0.3</MicrosoftAzureKeyVaultVersion>
```


Some open questions:

- I am working on opening PRs to get these patches merged in the orginial repos. What should I do for the `release/3.0` and `release/3.1` branches? Should I try and get the fixes in the original repos too? Or is it okay to carry these patches for 3.0 and 3.1?

- There's a ton of hardcoded `x64` assumptions. Is there a longer term plan to fix them? Is this something I need to look into?

- There's a number of assumptions that cross compile and `arm` mean that the tools building this are x64 (only).

Any thoughts or comments?