### PR TITLE
Include the correct package version props file when building offline

### DIFF
--- a/repos/package-source-build.proj
+++ b/repos/package-source-build.proj
@@ -6,7 +6,10 @@
     <RepoApiImplemented>false</RepoApiImplemented>
     <ProjectDirectory>$(SubmoduleDirectory)$(RepositoryName)/</ProjectDirectory>
     <SkipEnsurePackagesCreated>true</SkipEnsurePackagesCreated>
-    <BuildCommand>$(ProjectDirectory)pack$(ShellExtension)</BuildCommand>
+    <BuildArgs>--binaryLog</BuildArgs>
+    <BuildArgs Condition="'$(OfflineBuild)' != 'true'">$(BuildArgs) /p:IncludedPackageVersionPropsFile="$(PackageVersionPropsPath)"</BuildArgs>
+    <BuildArgs Condition="'$(OfflineBuild)' == 'true'">$(BuildArgs) /p:IncludedPackageVersionPropsFile="$(GennedPackageVersionPropsPath)"</BuildArgs>
+    <BuildCommand>$(ProjectDirectory)pack$(ShellExtension) $(BuildArgs)</BuildCommand>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/package-source-build/package.proj
+++ b/src/package-source-build/package.proj
@@ -5,8 +5,7 @@
 
   <Target Name="Pack">
     <!-- Copy PVP to packages dir in order to package them together -->
-    <Copy Condition="'$(DotNetBuildOffline)' != 'true'" SourceFiles="$(PackageVersionPropsPath)" DestinationFolder="$(SourceBuiltPackagesPath)" />
-    <Copy Condition="'$(DotNetBuildOffline)' == 'true'" SourceFiles="$(GennedPackageVersionPropsPath)" DestinationFiles="$(SourceBuiltPackagesPath)PackageVersions.props" />
+    <Copy SourceFiles="$(IncludedPackageVersionPropsFile)" DestinationFiles="$(SourceBuiltPackagesPath)PackageVersions.props" />
     <PropertyGroup>
         <SourceBuiltTarballName>$(OutputPath)$(SourceBuiltArtifactsTarballName).$(VersionPrefix)-$(VersionSuffix).tar.gz</SourceBuiltTarballName>
     </PropertyGroup>


### PR DESCRIPTION
Pass in the package versions props file to include in the source-built artifacts tarball rather than trying to calculate it in the project.  