### PR TITLE
Add PackageVersionProps to env variables

### DIFF
--- a/repos/aspnetcore.proj
+++ b/repos/aspnetcore.proj
@@ -51,6 +51,7 @@
 
   <ItemGroup>
     <EnvironmentVariables Include="RestoreSources=$(EnvironmentRestoreSources)" />
+    <EnvironmentVariables Include="DotNetPackageVersionPropsPath=$(PackageVersionPropsPath)" />
   </ItemGroup>
 
   <Target Name="SetOutputList" AfterTargets="Package" BeforeTargets="GatherBuiltPackages">


### PR DESCRIPTION
AspNetCore's build script (build.sh) builds eng/tools/RepoTasks before building the main project.  The build of this project doesn't use the passed in build params from source-build.  This change set DotNetPackageVersionPropsPath in env variables so the RepoTasks build can pick up the SourceBuilt version of Microsoft.Net.Compilers.Toolset.