### PR TITLE
Set property in Templating build to not use AppHost

### DIFF
--- a/repos/templating.proj
+++ b/repos/templating.proj
@@ -9,6 +9,7 @@
     <BuildCommandArgs>--restore --pack --configuration $(Configuration) $(OutputVersionArgs)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) $(FlagParameterPrefix)warnasError $(ArcadeFalseBoolBuildArg)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:PackSpecific=true</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) /p:UseAppHost=false</BuildCommandArgs>
 
     <LogVerbosityOptOut>true</LogVerbosityOptOut>
     <BuildCommandArgs>$(BuildCommandArgs) -v $(LogVerbosity)</BuildCommandArgs>

--- a/tools-local/prebuilt-baseline-offline.xml
+++ b/tools-local/prebuilt-baseline-offline.xml
@@ -40,21 +40,89 @@
   </ProjectDirectories>
   <NeverRestoredTarballPrebuilts>
     <PackageIdentity Id="CommandLineParser" Version="2.2.1" />
+    <PackageIdentity Id="dotnet-dev-certs" Version="3.0.0-rc2.19509.1" />
+    <PackageIdentity Id="dotnet-dev-certs" Version="3.0.0-rc2.19521.1" />
+    <PackageIdentity Id="dotnet-dev-certs" Version="3.0.0-rc2.19524.1" />
+    <PackageIdentity Id="dotnet-dev-certs" Version="3.0.0-rc2.19525.1" />
+    <PackageIdentity Id="dotnet-dev-certs" Version="3.0.0-rc2.19529.1" />
+    <PackageIdentity Id="dotnet-dev-certs" Version="3.0.0-rc2.19531.1" />
+    <PackageIdentity Id="dotnet-dev-certs" Version="3.0.0-rc2.19551.1" />
+    <PackageIdentity Id="dotnet-user-secrets" Version="3.0.0-rc2.19509.1" />
+    <PackageIdentity Id="dotnet-user-secrets" Version="3.0.0-rc2.19521.1" />
+    <PackageIdentity Id="dotnet-user-secrets" Version="3.0.0-rc2.19524.1" />
+    <PackageIdentity Id="dotnet-user-secrets" Version="3.0.0-rc2.19525.1" />
+    <PackageIdentity Id="dotnet-user-secrets" Version="3.0.0-rc2.19529.1" />
+    <PackageIdentity Id="dotnet-user-secrets" Version="3.0.0-rc2.19531.1" />
+    <PackageIdentity Id="dotnet-user-secrets" Version="3.0.0-rc2.19551.1" />
+    <PackageIdentity Id="dotnet-watch" Version="3.0.0-rc2.19509.1" />
+    <PackageIdentity Id="dotnet-watch" Version="3.0.0-rc2.19521.1" />
+    <PackageIdentity Id="dotnet-watch" Version="3.0.0-rc2.19524.1" />
+    <PackageIdentity Id="dotnet-watch" Version="3.0.0-rc2.19525.1" />
+    <PackageIdentity Id="dotnet-watch" Version="3.0.0-rc2.19529.1" />
+    <PackageIdentity Id="dotnet-watch" Version="3.0.0-rc2.19531.1" />
+    <PackageIdentity Id="dotnet-watch" Version="3.0.0-rc2.19551.1" />
+    <PackageIdentity Id="ILLink.Tasks" Version="0.1.5-preview-1461378" />
     <PackageIdentity Id="LibGit2Sharp" Version="0.26.0" />
     <PackageIdentity Id="LibGit2Sharp.NativeBinaries" Version="2.0.267" />
+    <PackageIdentity Id="Libuv" Version="1.9.1" />
     <PackageIdentity Id="Microsoft.AspNet.WebApi.Client" Version="5.2.6" />
+    <PackageIdentity Id="Microsoft.AspNetCore.Analyzers" Version="3.0.0-rc2.19509.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.Analyzers" Version="3.0.0-rc2.19521.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.Analyzers" Version="3.0.0-rc2.19524.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.Analyzers" Version="3.0.0-rc2.19525.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.Analyzers" Version="3.0.0-rc2.19529.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.Analyzers" Version="3.0.0-rc2.19531.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.Analyzers" Version="3.0.0-rc2.19551.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="3.0.0-rc2.19509.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="3.0.0-rc2.19521.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="3.0.0-rc2.19524.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="3.0.0-rc2.19525.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="3.0.0-rc2.19529.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="3.0.0-rc2.19531.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="3.0.0-rc2.19551.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.Mvc.Analyzers" Version="3.0.0-rc2.19509.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.Mvc.Analyzers" Version="3.0.0-rc2.19521.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.Mvc.Analyzers" Version="3.0.0-rc2.19524.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.Mvc.Analyzers" Version="3.0.0-rc2.19525.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.Mvc.Analyzers" Version="3.0.0-rc2.19529.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.Mvc.Analyzers" Version="3.0.0-rc2.19531.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.Mvc.Analyzers" Version="3.0.0-rc2.19551.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="3.0.0-rc2.19509.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="3.0.0-rc2.19521.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="3.0.0-rc2.19524.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="3.0.0-rc2.19525.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="3.0.0-rc2.19529.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="3.0.0-rc2.19531.1" />
+    <PackageIdentity Id="Microsoft.AspNetCore.Mvc.Api.Analyzers" Version="3.0.0-rc2.19551.1" />
     <PackageIdentity Id="Microsoft.Azure.KeyVault" Version="3.0.3" />
     <PackageIdentity Id="Microsoft.Azure.KeyVault.WebKey" Version="3.0.3" />
     <PackageIdentity Id="Microsoft.Azure.Services.AppAuthentication" Version="1.0.1" />
     <PackageIdentity Id="Microsoft.Bcl" Version="1.1.10" />
+    <PackageIdentity Id="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0-preview7.19362.9" />
     <PackageIdentity Id="Microsoft.Bcl.Build" Version="1.0.14" />
+    <PackageIdentity Id="Microsoft.Build" Version="16.0.461" />
+    <PackageIdentity Id="Microsoft.Build.Framework" Version="16.0.461" />
+    <PackageIdentity Id="Microsoft.Build.Localization" Version="16.3.0-preview-19509-01" />
+    <PackageIdentity Id="Microsoft.Build.Localization" Version="16.3.0-preview-19521-01" />
+    <PackageIdentity Id="Microsoft.Build.Localization" Version="16.3.0-preview-19524-01" />
+    <PackageIdentity Id="Microsoft.Build.Localization" Version="16.3.0-preview-19525-01" />
+    <PackageIdentity Id="Microsoft.Build.Localization" Version="16.3.0-preview-19529-01" />
+    <PackageIdentity Id="Microsoft.Build.Localization" Version="16.3.0-preview-19531-01" />
+    <PackageIdentity Id="Microsoft.Build.Localization" Version="16.3.0-preview-19551-01" />
+    <PackageIdentity Id="Microsoft.Build.Tasks.Core" Version="16.0.461" />
+    <PackageIdentity Id="Microsoft.Build.Utilities.Core" Version="16.0.461" />
+    <PackageIdentity Id="Microsoft.CodeAnalysis.Analyzers" Version="1.1.0" />
     <PackageIdentity Id="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
+    <PackageIdentity Id="Microsoft.CodeAnalysis.Common" Version="1.3.0" />
     <PackageIdentity Id="Microsoft.CodeAnalysis.Common" Version="2.9.0" />
+    <PackageIdentity Id="Microsoft.CodeAnalysis.CSharp" Version="1.3.0" />
     <PackageIdentity Id="Microsoft.CodeAnalysis.CSharp" Version="2.9.0" />
+    <PackageIdentity Id="Microsoft.CodeAnalysis.VisualBasic" Version="1.3.0" />
     <PackageIdentity Id="Microsoft.CSharp" Version="4.5.0" />
     <PackageIdentity Id="Microsoft.DiaSymReader.Pdb2Pdb" Version="1.1.0-beta1-62506-02" />
     <PackageIdentity Id="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19359.6" />
     <PackageIdentity Id="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.19501.4" />
+    <PackageIdentity Id="Microsoft.DotNet.GenAPI" Version="1.0.0-beta.19461.7" />
     <PackageIdentity Id="Microsoft.DotNet.GenAPI" Version="1.0.0-beta.19474.3" />
     <PackageIdentity Id="Microsoft.DotNet.SignTool" Version="1.0.0-beta.19359.6" />
     <PackageIdentity Id="Microsoft.DotNet.SwaggerGenerator.MSBuild" Version="5.0.0-beta.19501.4" />
@@ -72,25 +140,79 @@
     <PackageIdentity Id="Microsoft.Extensions.Primitives" Version="2.1.1" />
     <PackageIdentity Id="Microsoft.Extensions.Primitives" Version="2.2.0" />
     <PackageIdentity Id="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.14.2" />
+    <PackageIdentity Id="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.19.8" />
     <PackageIdentity Id="Microsoft.Net.Compilers.Toolset" Version="3.3.1-beta3-final" />
     <PackageIdentity Id="Microsoft.Net.Http" Version="2.2.29" />
+    <PackageIdentity Id="Microsoft.NETCore.App.Host.linux-x64" Version="3.0.0" />
+    <PackageIdentity Id="Microsoft.NETCore.App.Runtime.linux-x64" Version="3.0.0" />
+    <PackageIdentity Id="Microsoft.NETCore.App.Runtime.linux-x64" Version="3.0.1-servicing-19502-09" />
     <PackageIdentity Id="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0-preview.1" />
     <PackageIdentity Id="Microsoft.Rest.ClientRuntime" Version="2.3.13" />
     <PackageIdentity Id="Microsoft.Rest.ClientRuntime" Version="2.3.18" />
     <PackageIdentity Id="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.18" />
     <PackageIdentity Id="Microsoft.TeamFoundation.DistributedTask.Common.Contracts" Version="16.138.0-preview" />
     <PackageIdentity Id="Microsoft.TeamFoundationServer.Client" Version="16.138.0-preview" />
+    <PackageIdentity Id="Microsoft.TemplateEngine.Abstractions" Version="3.0.0-rc1.19509.1" />
+    <PackageIdentity Id="Microsoft.TemplateEngine.Cli" Version="3.0.0-rc1.19509.1" />
+    <PackageIdentity Id="Microsoft.TemplateEngine.Core" Version="3.0.0-rc1.19509.1" />
+    <PackageIdentity Id="Microsoft.TemplateEngine.Core.Contracts" Version="3.0.0-rc1.19509.1" />
+    <PackageIdentity Id="Microsoft.TemplateEngine.Edge" Version="3.0.0-rc1.19509.1" />
+    <PackageIdentity Id="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="3.0.0-rc1.19509.1" />
+    <PackageIdentity Id="Microsoft.TemplateEngine.Utils" Version="3.0.0-rc1.19509.1" />
+    <PackageIdentity Id="Microsoft.TemplateSearch.Common" Version="3.0.0-rc1.19509.1" />
+    <PackageIdentity Id="Microsoft.VisualBasic" Version="10.0.1" />
     <PackageIdentity Id="Microsoft.VisualStudio.Services.Client" Version="16.138.0-preview" />
     <PackageIdentity Id="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" />
+    <PackageIdentity Id="Microsoft.Web.Xdt" Version="3.0.1-preview.19509.1" />
+    <PackageIdentity Id="Microsoft.Web.Xdt" Version="3.0.1-preview.19521.1" />
+    <PackageIdentity Id="Microsoft.Web.Xdt" Version="3.0.1-preview.19524.1" />
+    <PackageIdentity Id="Microsoft.Web.Xdt" Version="3.0.1-preview.19525.1" />
+    <PackageIdentity Id="Microsoft.Web.Xdt" Version="3.0.1-preview.19529.1" />
+    <PackageIdentity Id="Microsoft.Web.Xdt" Version="3.0.1-preview.19531.1" />
+    <PackageIdentity Id="Microsoft.Web.Xdt" Version="3.0.1-preview.19551.1" />
     <PackageIdentity Id="Microsoft.Win32.Registry" Version="4.4.0" />
     <PackageIdentity Id="Newtonsoft.Json" Version="10.0.3" />
     <PackageIdentity Id="Newtonsoft.Json" Version="11.0.2" />
     <PackageIdentity Id="Newtonsoft.Json.Bson" Version="1.0.1" />
+    <PackageIdentity Id="NuGet.Build.Tasks" Version="5.1.0-rtm.5921+27af96bdb7ba8d6d7ea9ad53fc76cd1d1aa80703" />
+    <PackageIdentity Id="NuGet.Commands" Version="4.9.0-rtm.5658+849063018d8ee08625774a2dcd07ab84224dabb9" />
+    <PackageIdentity Id="NuGet.Commands" Version="5.1.0-rtm.5921+27af96bdb7ba8d6d7ea9ad53fc76cd1d1aa80703" />
     <PackageIdentity Id="NuGet.Common" Version="4.8.0+017b293f18b8592897adf70b80d9488ff69b9b8c" />
+    <PackageIdentity Id="NuGet.Common" Version="4.9.0-rtm.5658+849063018d8ee08625774a2dcd07ab84224dabb9" />
+    <PackageIdentity Id="NuGet.Common" Version="4.9.4+ed6e2dca9391d13b431f4eff58c5194f0ebcee13" />
+    <PackageIdentity Id="NuGet.Common" Version="5.1.0-rtm.5921+27af96bdb7ba8d6d7ea9ad53fc76cd1d1aa80703" />
+    <PackageIdentity Id="NuGet.Configuration" Version="4.9.0-rtm.5658+849063018d8ee08625774a2dcd07ab84224dabb9" />
+    <PackageIdentity Id="NuGet.Configuration" Version="4.9.4+ed6e2dca9391d13b431f4eff58c5194f0ebcee13" />
+    <PackageIdentity Id="NuGet.Configuration" Version="5.1.0-rtm.5921+27af96bdb7ba8d6d7ea9ad53fc76cd1d1aa80703" />
+    <PackageIdentity Id="NuGet.Credentials" Version="4.9.0-rtm.5658+849063018d8ee08625774a2dcd07ab84224dabb9" />
+    <PackageIdentity Id="NuGet.Credentials" Version="5.1.0-rtm.5921+27af96bdb7ba8d6d7ea9ad53fc76cd1d1aa80703" />
+    <PackageIdentity Id="NuGet.DependencyResolver.Core" Version="4.9.0-rtm.5658+849063018d8ee08625774a2dcd07ab84224dabb9" />
+    <PackageIdentity Id="NuGet.DependencyResolver.Core" Version="4.9.4+ed6e2dca9391d13b431f4eff58c5194f0ebcee13" />
+    <PackageIdentity Id="NuGet.DependencyResolver.Core" Version="5.1.0-rtm.5921+27af96bdb7ba8d6d7ea9ad53fc76cd1d1aa80703" />
     <PackageIdentity Id="NuGet.Frameworks" Version="4.8.0+017b293f18b8592897adf70b80d9488ff69b9b8c" />
+    <PackageIdentity Id="NuGet.Frameworks" Version="4.9.0-rtm.5658+849063018d8ee08625774a2dcd07ab84224dabb9" />
+    <PackageIdentity Id="NuGet.Frameworks" Version="4.9.4+ed6e2dca9391d13b431f4eff58c5194f0ebcee13" />
+    <PackageIdentity Id="NuGet.Frameworks" Version="5.1.0-rtm.5921+27af96bdb7ba8d6d7ea9ad53fc76cd1d1aa80703" />
+    <PackageIdentity Id="NuGet.LibraryModel" Version="4.9.0-rtm.5658+849063018d8ee08625774a2dcd07ab84224dabb9" />
+    <PackageIdentity Id="NuGet.LibraryModel" Version="4.9.4+ed6e2dca9391d13b431f4eff58c5194f0ebcee13" />
+    <PackageIdentity Id="NuGet.LibraryModel" Version="5.1.0-rtm.5921+27af96bdb7ba8d6d7ea9ad53fc76cd1d1aa80703" />
     <PackageIdentity Id="NuGet.Packaging" Version="4.8.0+017b293f18b8592897adf70b80d9488ff69b9b8c" />
+    <PackageIdentity Id="NuGet.Packaging" Version="4.9.0-rtm.5658+849063018d8ee08625774a2dcd07ab84224dabb9" />
+    <PackageIdentity Id="NuGet.Packaging" Version="4.9.4+ed6e2dca9391d13b431f4eff58c5194f0ebcee13" />
+    <PackageIdentity Id="NuGet.Packaging" Version="5.1.0-rtm.5921+27af96bdb7ba8d6d7ea9ad53fc76cd1d1aa80703" />
     <PackageIdentity Id="NuGet.Packaging.Core" Version="4.8.0+017b293f18b8592897adf70b80d9488ff69b9b8c" />
+    <PackageIdentity Id="NuGet.Packaging.Core" Version="4.9.0-rtm.5658+849063018d8ee08625774a2dcd07ab84224dabb9" />
+    <PackageIdentity Id="NuGet.Packaging.Core" Version="4.9.4+ed6e2dca9391d13b431f4eff58c5194f0ebcee13" />
+    <PackageIdentity Id="NuGet.ProjectModel" Version="4.9.0-rtm.5658+849063018d8ee08625774a2dcd07ab84224dabb9" />
+    <PackageIdentity Id="NuGet.ProjectModel" Version="4.9.4+ed6e2dca9391d13b431f4eff58c5194f0ebcee13" />
+    <PackageIdentity Id="NuGet.ProjectModel" Version="5.1.0-rtm.5921+27af96bdb7ba8d6d7ea9ad53fc76cd1d1aa80703" />
+    <PackageIdentity Id="NuGet.Protocol" Version="4.9.0-rtm.5658+849063018d8ee08625774a2dcd07ab84224dabb9" />
+    <PackageIdentity Id="NuGet.Protocol" Version="4.9.4+ed6e2dca9391d13b431f4eff58c5194f0ebcee13" />
+    <PackageIdentity Id="NuGet.Protocol" Version="5.1.0-rtm.5921+27af96bdb7ba8d6d7ea9ad53fc76cd1d1aa80703" />
     <PackageIdentity Id="NuGet.Versioning" Version="4.8.0+017b293f18b8592897adf70b80d9488ff69b9b8c" />
+    <PackageIdentity Id="NuGet.Versioning" Version="4.9.0-rtm.5658+849063018d8ee08625774a2dcd07ab84224dabb9" />
+    <PackageIdentity Id="NuGet.Versioning" Version="4.9.4+ed6e2dca9391d13b431f4eff58c5194f0ebcee13" />
+    <PackageIdentity Id="NuGet.Versioning" Version="5.1.0-rtm.5921+27af96bdb7ba8d6d7ea9ad53fc76cd1d1aa80703" />
     <PackageIdentity Id="Octokit" Version="0.32.0" />
     <PackageIdentity Id="runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.0" />
     <PackageIdentity Id="runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.2" />
@@ -118,9 +240,22 @@
     <PackageIdentity Id="runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.0" />
     <PackageIdentity Id="runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.2" />
     <PackageIdentity Id="runtime.win-arm64.runtime.native.System.Data.SqlClient.sni" Version="4.4.0" />
+    <PackageIdentity Id="runtime.win-x64.Microsoft.NETCore.App" Version="2.1.0" />
+    <PackageIdentity Id="runtime.win-x64.Microsoft.NETCore.DotNetAppHost" Version="2.1.0" />
+    <PackageIdentity Id="runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy" Version="2.1.0" />
+    <PackageIdentity Id="runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" Version="2.1.0" />
     <PackageIdentity Id="runtime.win-x64.runtime.native.System.Data.SqlClient.sni" Version="4.4.0" />
+    <PackageIdentity Id="runtime.win-x86.Microsoft.NETCore.App" Version="2.1.0" />
+    <PackageIdentity Id="runtime.win-x86.Microsoft.NETCore.App" Version="2.1.12" />
+    <PackageIdentity Id="runtime.win-x86.Microsoft.NETCore.DotNetAppHost" Version="2.1.0" />
+    <PackageIdentity Id="runtime.win-x86.Microsoft.NETCore.DotNetAppHost" Version="2.1.12" />
+    <PackageIdentity Id="runtime.win-x86.Microsoft.NETCore.DotNetHostPolicy" Version="2.1.0" />
+    <PackageIdentity Id="runtime.win-x86.Microsoft.NETCore.DotNetHostPolicy" Version="2.1.12" />
+    <PackageIdentity Id="runtime.win-x86.Microsoft.NETCore.DotNetHostResolver" Version="2.1.0" />
+    <PackageIdentity Id="runtime.win-x86.Microsoft.NETCore.DotNetHostResolver" Version="2.1.12" />
     <PackageIdentity Id="runtime.win-x86.runtime.native.System.Data.SqlClient.sni" Version="4.4.0" />
     <PackageIdentity Id="sn" Version="1.0.0" />
+    <PackageIdentity Id="System.ComponentModel.Annotations" Version="4.1.0" />
     <PackageIdentity Id="System.ComponentModel.Annotations" Version="4.4.1" />
     <PackageIdentity Id="System.Composition.AttributedModel" Version="1.0.31" />
     <PackageIdentity Id="System.Composition.Convention" Version="1.0.31" />
@@ -131,11 +266,23 @@
     <PackageIdentity Id="System.Console" Version="4.0.0-rc2-24027" />
     <PackageIdentity Id="System.Data.SqlClient" Version="4.4.2" />
     <PackageIdentity Id="System.Diagnostics.DiagnosticSource" Version="4.4.1" />
+    <PackageIdentity Id="System.Diagnostics.StackTrace" Version="4.0.1" />
     <PackageIdentity Id="System.IO" Version="4.1.0-rc2-24027" />
+    <PackageIdentity Id="System.IO.FileSystem.Watcher" Version="4.0.0" />
+    <PackageIdentity Id="System.IO.MemoryMappedFiles" Version="4.0.0" />
+    <PackageIdentity Id="System.IO.UnmanagedMemoryStream" Version="4.0.1" />
     <PackageIdentity Id="System.Linq" Version="4.1.0-rc2-24027" />
     <PackageIdentity Id="System.Linq.Expressions" Version="4.0.11-rc2-24027" />
+    <PackageIdentity Id="System.Linq.Expressions" Version="4.1.1" />
+    <PackageIdentity Id="System.Linq.Queryable" Version="4.0.1" />
+    <PackageIdentity Id="System.Net.Http" Version="4.1.2" />
+    <PackageIdentity Id="System.Net.NameResolution" Version="4.0.0" />
+    <PackageIdentity Id="System.Net.Security" Version="4.0.1" />
+    <PackageIdentity Id="System.Numerics.Vectors" Version="4.1.1" />
     <PackageIdentity Id="System.ObjectModel" Version="4.0.12-rc2-24027" />
+    <PackageIdentity Id="System.Private.DataContractSerialization" Version="4.3.0" />
     <PackageIdentity Id="System.Reflection" Version="4.1.0-rc2-24027" />
+    <PackageIdentity Id="System.Reflection.DispatchProxy" Version="4.0.1" />
     <PackageIdentity Id="System.Reflection.Emit" Version="4.0.1-rc2-24027" />
     <PackageIdentity Id="System.Reflection.Emit.ILGeneration" Version="4.0.1-rc2-24027" />
     <PackageIdentity Id="System.Reflection.Emit.Lightweight" Version="4.0.1-rc2-24027" />
@@ -143,56 +290,30 @@
     <PackageIdentity Id="System.Runtime" Version="4.1.0-rc2-24027" />
     <PackageIdentity Id="System.Runtime.CompilerServices.Unsafe" Version="4.5.0" />
     <PackageIdentity Id="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
+    <PackageIdentity Id="System.Runtime.CompilerServices.Unsafe" Version="4.6.0-preview7.19362.9" />
     <PackageIdentity Id="System.Runtime.Extensions" Version="4.1.0-rc2-24027" />
+    <PackageIdentity Id="System.Runtime.Serialization.Json" Version="4.3.0" />
     <PackageIdentity Id="System.Security.AccessControl" Version="4.4.0" />
     <PackageIdentity Id="System.Security.Cryptography.Cng" Version="4.4.0" />
     <PackageIdentity Id="System.Security.Cryptography.OpenSsl" Version="4.4.0" />
     <PackageIdentity Id="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
     <PackageIdentity Id="System.Security.Principal.Windows" Version="4.4.1" />
+    <PackageIdentity Id="System.Text.Encoding.CodePages" Version="4.3.0" />
     <PackageIdentity Id="System.Text.Encoding.CodePages" Version="4.5.1" />
     <PackageIdentity Id="System.Text.Encodings.Web" Version="4.5.0" />
+    <PackageIdentity Id="System.Text.Json" Version="1.0" />
+    <PackageIdentity Id="System.Text.Json" Version="4.6.0-preview7.19362.9" />
     <PackageIdentity Id="System.Threading" Version="4.0.11-rc2-24027" />
+    <PackageIdentity Id="System.Threading.Overlapped" Version="4.0.1" />
     <PackageIdentity Id="System.Threading.Tasks.Dataflow" Version="4.5.24" />
-    <PackageIdentity Id="System.ValueTuple" Version="4.5.0" />
+    <PackageIdentity Id="System.Threading.Tasks.Parallel" Version="4.0.1" />
+    <PackageIdentity Id="System.ValueTuple" Version="4.3.0" />
+    <PackageIdentity Id="System.Xml.XmlSerializer" Version="4.3.0" />
+    <PackageIdentity Id="System.Xml.XPath" Version="4.3.0" />
+    <PackageIdentity Id="System.Xml.XPath.XDocument" Version="4.0.1" />
+    <PackageIdentity Id="System.Xml.XPath.XDocument" Version="4.3.0" />
     <PackageIdentity Id="System.Xml.XPath.XmlDocument" Version="4.3.0" />
     <PackageIdentity Id="vswhere" Version="2.6.7" />
     <PackageIdentity Id="YamlDotNet.Signed" Version="5.3.0" />
   </NeverRestoredTarballPrebuilts>
-  <Usages>
-    <Usage Id="ILLink.Tasks" Version="0.1.5-preview-1461378" IsDirectDependency="true" />
-    <Usage Id="Libuv" Version="1.9.1" />
-    <Usage Id="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0-preview7.19362.9" />
-    <Usage Id="Microsoft.CodeAnalysis.Analyzers" Version="1.1.0" />
-    <Usage Id="Microsoft.CodeAnalysis.Common" Version="1.3.0" />
-    <Usage Id="Microsoft.CodeAnalysis.Common" Version="2.1.0" />
-    <Usage Id="Microsoft.CodeAnalysis.CSharp" Version="1.3.0" />
-    <Usage Id="Microsoft.CodeAnalysis.CSharp" Version="2.1.0" IsDirectDependency="true" />
-    <Usage Id="Microsoft.CodeAnalysis.VisualBasic" Version="1.3.0" />
-    <Usage Id="Microsoft.NETCore.App.Host.linux-x64" Version="3.0.0" />
-    <Usage Id="Microsoft.NETCore.App.Runtime.linux-x64" Version="3.0.1-servicing-19502-09" />
-    <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0-preview.2" />
-    <Usage Id="Microsoft.VisualBasic" Version="10.0.1" />
-    <Usage Id="RoslynTools.Lightup.System.Runtime.Loader" Version="4.3.0" />
-    <Usage Id="System.ComponentModel.Annotations" Version="4.1.0" />
-    <Usage Id="System.Diagnostics.StackTrace" Version="4.0.1" />
-    <Usage Id="System.IO.FileSystem.Watcher" Version="4.0.0" />
-    <Usage Id="System.IO.MemoryMappedFiles" Version="4.0.0" />
-    <Usage Id="System.IO.UnmanagedMemoryStream" Version="4.0.1" />
-    <Usage Id="System.Linq.Expressions" Version="4.1.1" />
-    <Usage Id="System.Linq.Queryable" Version="4.0.1" />
-    <Usage Id="System.Net.Http" Version="4.1.2" />
-    <Usage Id="System.Net.NameResolution" Version="4.0.0" />
-    <Usage Id="System.Net.Security" Version="4.0.1" />
-    <Usage Id="System.Numerics.Vectors" Version="4.1.1" />
-    <Usage Id="System.Reflection.DispatchProxy" Version="4.0.1" />
-    <Usage Id="System.Runtime.CompilerServices.Unsafe" Version="4.6.0-preview7.19362.9" />
-    <Usage Id="System.Text.Encoding.CodePages" Version="4.3.0" />
-    <Usage Id="System.Text.Json" Version="4.6.0-preview7.19362.9" IsDirectDependency="true" />
-    <Usage Id="System.Threading.Overlapped" Version="4.0.1" />
-    <Usage Id="System.Threading.Tasks.Parallel" Version="4.0.1" />
-    <Usage Id="System.ValueTuple" Version="4.3.0" />
-    <Usage Id="System.Xml.XPath" Version="4.3.0" />
-    <Usage Id="System.Xml.XPath.XDocument" Version="4.0.1" />
-    <Usage Id="System.Xml.XPath.XDocument" Version="4.3.0" />
-  </Usages>
 </UsageData>


### PR DESCRIPTION
Without this, the Templating repo loads Microsoft.NETcore.App.Host.linux-x64 during bootstrapping.