### PR TITLE
Set PATH for OSX as well as DOTNET_ROOT.

### DIFF
--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -356,6 +356,10 @@ fi
 export NUGET_PACKAGES="$restoredPackagesDir"
 SOURCE_BUILT_PKGS_PATH="$SCRIPT_ROOT/bin/obj/x64/$configuration/blob-feed/packages/"
 export DOTNET_ROOT="$dotnetDir"
+# OSX also requires DOTNET_ROOT to be on the PATH
+if [ `uname` == 'Darwin' ]; then
+    export PATH="$dotnetDir:$PATH"
+fi
 
 # Run all tests, local restore sources first, online restore sources second
 if [ "$excludeLocalTests" == "false" ]; then


### PR DESCRIPTION
OSX requires the `dotnet` being used to be on the path, or else it won't find the runtime.

Fixes #1344.