### PR TITLE
Set PATH for OSX as well as DOTNET_ROOT.

### DIFF
--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -344,6 +344,11 @@ echo SDK under test is:
 # setup restore path
 export NUGET_PACKAGES="$restoredPackagesDir"
 SOURCE_BUILT_PKGS_PATH="$SCRIPT_ROOT/bin/obj/x64/$configuration/blob-feed/packages/"
+export DOTNET_ROOT="$dotnetDir"
+# OSX also requires DOTNET_ROOT to be on the PATH
+if [ `uname` == 'Darwin' ]; then
+    export PATH="$dotnetDir:$PATH"
+fi
 
 # Run all tests, local restore sources first, online restore sources second
 if [ "$excludeLocalTests" == "false" ]; then


### PR DESCRIPTION
Porting https://github.com/dotnet/source-build/pull/1353/commits/c0ba010804ebaf06c3732abc5b5fe9be9728a7ab from release/3.1 to release/3.0 to fix the OSX build.