### PR TITLE
Build Compilers packages in roslyn

### DIFF
--- a/patches/roslyn/0001-Conditionally-remove-net472-from-TargetFrameworks.patch
+++ b/patches/roslyn/0001-Conditionally-remove-net472-from-TargetFrameworks.patch
@@ -1,7 +1,7 @@
-From 15561b54085b87a16b327fdc05aef8b82e6849b1 Mon Sep 17 00:00:00 2001
+From 636698993f3294d2c783aee1586d62aa81e5d502 Mon Sep 17 00:00:00 2001
 From: dseefeld <dseefeld@microsoft.com>
 Date: Mon, 15 Jul 2019 19:26:42 +0000
-Subject: [PATCH 1/6] Conditionally remove net472 from TargetFrameworks
+Subject: [PATCH] Conditionally remove net472 from TargetFrameworks
 
 ---
  .../Microsoft.Net.Compilers.Toolset.Package.csproj                     | 3 ++-

--- a/patches/roslyn/0002-Don-t-install-2.1.503-for-testing.patch
+++ b/patches/roslyn/0002-Don-t-install-2.1.503-for-testing.patch
@@ -1,7 +1,7 @@
-From 35c0366bea36061615786d9718ec69407dc3ef1b Mon Sep 17 00:00:00 2001
+From 2e8e34bf2dfa389b5d6c7c57b1498d1e445a5166 Mon Sep 17 00:00:00 2001
 From: Chris Rummel <crummel@microsoft.com>
 Date: Thu, 17 Oct 2019 20:42:17 -0500
-Subject: [PATCH 2/6] Don't install 2.1.503 for testing.
+Subject: [PATCH] Don't install 2.1.503 for testing.
 
 ---
  eng/build.sh | 2 +-

--- a/patches/roslyn/0003-.NET-Core-only-for-VBCSCompiler.patch
+++ b/patches/roslyn/0003-.NET-Core-only-for-VBCSCompiler.patch
@@ -1,7 +1,7 @@
-From f68c112518bdc76a86620d5433971cae11c2ccdd Mon Sep 17 00:00:00 2001
+From da85454fd715f57968df3aa1b032d0fe3f958ad0 Mon Sep 17 00:00:00 2001
 From: Chris Rummel <crummel@microsoft.com>
 Date: Wed, 23 Oct 2019 13:58:31 -0500
-Subject: [PATCH 3/6] .NET Core only for VBCSCompiler
+Subject: [PATCH] .NET Core only for VBCSCompiler
 
 ---
  src/Compilers/CSharp/csc/csc.csproj                   | 2 +-

--- a/patches/roslyn/0004-Do-not-build-NET-Fx-binaries-in-source-build.patch
+++ b/patches/roslyn/0004-Do-not-build-NET-Fx-binaries-in-source-build.patch
@@ -1,7 +1,7 @@
-From 78017d90dcac734b781b714487fe54ea8ff9d451 Mon Sep 17 00:00:00 2001
+From 2c5fb7835fc2b5a0d9f6de87c4b899811eec15e9 Mon Sep 17 00:00:00 2001
 From: adaggarwal <aditya.aggarwal@microsoft.com>
 Date: Wed, 20 Nov 2019 22:31:11 +0000
-Subject: [PATCH 4/6] Do not build NET Fx binaries in source build
+Subject: [PATCH] Do not build NET Fx binaries in source build
 
 ---
  eng/Versions.props         | 2 +-
@@ -9,7 +9,7 @@ Subject: [PATCH 4/6] Do not build NET Fx binaries in source build
  2 files changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/eng/Versions.props b/eng/Versions.props
-index 69a4f16..87c3523 100644
+index 9466663..4e6836d 100644
 --- a/eng/Versions.props
 +++ b/eng/Versions.props
 @@ -310,7 +310,7 @@

--- a/patches/roslyn/0005-Import-PackageVersions-props-if-exists.patch
+++ b/patches/roslyn/0005-Import-PackageVersions-props-if-exists.patch
@@ -1,14 +1,14 @@
-From db0b16b469094e8f37623cdf86902491f502d575 Mon Sep 17 00:00:00 2001
+From e45fac66805a4ec0262391dda414a5a80b05379e Mon Sep 17 00:00:00 2001
 From: adaggarwal <aditya.aggarwal@microsoft.com>
 Date: Wed, 20 Nov 2019 22:32:33 +0000
-Subject: [PATCH 5/6] Import PackageVersions props if exists
+Subject: [PATCH] Import PackageVersions props if exists
 
 ---
  eng/Versions.props | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/eng/Versions.props b/eng/Versions.props
-index 87c3523..eecfde6 100644
+index 4e6836d..450705b 100644
 --- a/eng/Versions.props
 +++ b/eng/Versions.props
 @@ -322,4 +322,5 @@

--- a/patches/roslyn/0006-Get-rid-of-analyzers.patch
+++ b/patches/roslyn/0006-Get-rid-of-analyzers.patch
@@ -1,7 +1,7 @@
-From f13b054c8eca2ecb8d8352f9538fe57c120638c6 Mon Sep 17 00:00:00 2001
+From 6ff818dc7a4c1ba1927495416f493a87f6dd9b16 Mon Sep 17 00:00:00 2001
 From: adaggarwal <aditya.aggarwal@microsoft.com>
 Date: Fri, 22 Nov 2019 16:56:41 +0000
-Subject: [PATCH 6/6] Get rid of analyzers
+Subject: [PATCH] Get rid of analyzers
 
 ---
  eng/targets/Settings.props | 4 ++--

--- a/patches/roslyn/0007-Include-Compilers-package-projects-in-source-build.patch
+++ b/patches/roslyn/0007-Include-Compilers-package-projects-in-source-build.patch
@@ -1,0 +1,53 @@
+From 03e30b5df6c29538b6363f491b02103a74c72272 Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Mon, 25 Nov 2019 17:10:34 +0000
+Subject: [PATCH] Include Compilers package projects in source-build
+
+---
+ .../Microsoft.NETCore.Compilers.Package.csproj                          | 2 +-
+ .../Microsoft.Net.Compilers.Toolset.Package.csproj                      | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/NuGet/Microsoft.NETCore.Compilers/Microsoft.NETCore.Compilers.Package.csproj b/src/NuGet/Microsoft.NETCore.Compilers/Microsoft.NETCore.Compilers.Package.csproj
+index 3873372..a9269aa 100644
+--- a/src/NuGet/Microsoft.NETCore.Compilers/Microsoft.NETCore.Compilers.Package.csproj
++++ b/src/NuGet/Microsoft.NETCore.Compilers/Microsoft.NETCore.Compilers.Package.csproj
+@@ -4,6 +4,7 @@
+     <TargetFramework>netcoreapp2.1</TargetFramework>
+ 
+     <IsPackable>true</IsPackable>
++    <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
+     <NuspecPackageId>Microsoft.NETCore.Compilers</NuspecPackageId>
+     <IncludeBuildOutput>false</IncludeBuildOutput>
+     <DevelopmentDependency>true</DevelopmentDependency>
+@@ -16,7 +17,6 @@
+   <ItemGroup>
+     <ProjectReference Include="..\..\Compilers\CSharp\csc\csc.csproj"/>
+     <ProjectReference Include="..\..\Compilers\VisualBasic\vbc\vbc.csproj"/>
+-    <ProjectReference Include="..\..\Interactive\csi\csi.csproj"/>
+     <ProjectReference Include="..\..\Compilers\Core\MSBuildTask\Microsoft.Build.Tasks.CodeAnalysis.csproj"/>
+     <ProjectReference Include="..\..\Compilers\Server\VBCSCompiler\VBCSCompiler.csproj"/>
+   </ItemGroup>
+diff --git a/src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj b/src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj
+index 878f2ac..e7fcbb8 100644
+--- a/src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj
++++ b/src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj
+@@ -5,6 +5,7 @@
+     <TargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">netcoreapp2.1</TargetFrameworks>
+ 
+     <IsPackable>true</IsPackable>
++    <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
+     <NuspecPackageId>Microsoft.Net.Compilers.Toolset</NuspecPackageId>
+     <IncludeBuildOutput>false</IncludeBuildOutput>
+     <DevelopmentDependency>true</DevelopmentDependency>
+@@ -26,7 +27,6 @@
+   <ItemGroup>
+     <ProjectReference Include="..\..\Compilers\CSharp\csc\csc.csproj" PrivateAssets="All"/>
+     <ProjectReference Include="..\..\Compilers\VisualBasic\vbc\vbc.csproj" PrivateAssets="All"/>
+-    <ProjectReference Include="..\..\Interactive\csi\csi.csproj" PrivateAssets="All"/>
+     <ProjectReference Include="..\..\Compilers\Core\MSBuildTask\Microsoft.Build.Tasks.CodeAnalysis.csproj" PrivateAssets="All"/>
+     <ProjectReference Include="..\..\Compilers\Server\VBCSCompiler\VBCSCompiler.csproj" PrivateAssets="All"/>
+ 
+-- 
+1.8.3.1
+


### PR DESCRIPTION
Microsoft.NETCore.Compilers and Microsoft.Net.Compilers.Toolset packages were not being produced when building roslyn in source-build.  This patch enables roslyn to produce these packages.