### PR TITLE
Some changes to support internal builds

### DIFF
--- a/.vsts.pipelines/jobs/ci-linux.yml
+++ b/.vsts.pipelines/jobs/ci-linux.yml
@@ -68,7 +68,8 @@ jobs:
         /p:PortableBuild=$(sb.portable) \
         /p:ArchiveDownloadedPackages=$(sb.tarball) \
         /p:FailOnPrebuiltBaselineError=$failOnBaselineError \
-        /p:ProdConBlobFeedUrlPrefix=$(prodConBlobFeedUrlPrefix)
+        /p:ProdConBlobFeedUrlPrefix=$(prodConBlobFeedUrlPrefix) \
+        /p:AzDoPat=$(System.AccessToken)
       du -h $(rootDirectory) | sort -h | tail -n 50
     displayName: Build source-build
     timeoutInMinutes: 150

--- a/.vsts.pipelines/jobs/ci-linux.yml
+++ b/.vsts.pipelines/jobs/ci-linux.yml
@@ -56,10 +56,6 @@ jobs:
       du -h $(rootDirectory) | sort -h | tail -n 50
     displayName: Clean sb directory and copy source from cloned directory
 
-  - template: ../steps/init-submodules.yml
-    parameters:
-      commandPrefix: $(docker.run) $(docker.src.map) $(docker.src.work) $(imageName)
-
   # Build source-build.
   - script: |
       set -ex

--- a/.vsts.pipelines/jobs/ci-local.yml
+++ b/.vsts.pipelines/jobs/ci-local.yml
@@ -22,6 +22,7 @@ jobs:
       /p:PortableBuild=$(sb.portable)
       /p:FailOnPrebuiltBaselineError=$(failOnPrebuiltBaselineError)
       /p:ProdConBlobFeedUrlPrefix=$(prodConBlobFeedUrlPrefix)
+      /p:AzDoPat=$(System.AccessToken)
     args.smokeTest: >
       --run-smoke-test
       /p:Configuration=$(sb.configuration)

--- a/.vsts.pipelines/jobs/ci-local.yml
+++ b/.vsts.pipelines/jobs/ci-local.yml
@@ -40,10 +40,6 @@ jobs:
 
   - template: ../steps/cleanup-unneeded-files.yml
 
-  # If the machine is dirty, submodule URLs may be from a different branch. Sync to prevent that.
-  - script: git submodule sync
-    displayName: Sync submodule urls
-
   # Make sure submodules from other branches are removed: pass extra f.
   - script: git clean -xdff
     displayName: Clean leftover submodules
@@ -62,8 +58,6 @@ jobs:
     - template: ../steps/setup-windows-python.yml
 
   - template: ../steps/calculate-config-flags.yml
-
-  - template: ../steps/init-submodules.yml
 
   - template: ../steps/check-space-powershell.yml
 

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -30,6 +30,7 @@
     <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="3.1.0-rtm.19564.2" CoherentParentDependency="Microsoft.Private.CoreFx.NETCoreApp">
       <Uri>https://github.com/dotnet/coreclr</Uri>
       <Sha>1ed7226e39b7214807318d2cc8ff37492527ffa1</Sha>
+      <RepoName>coreclr</RepoName>
     </Dependency>
     <Dependency Name="NETStandard.Library" Version="2.1.0" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/standard</Uri>
@@ -38,10 +39,12 @@
     <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="4.7.0-rtm.19564.4" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>
+      <RepoName>corefx</RepoName>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App" Version="3.1.0-rtm.19565.2" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>65f04fb6db7a5e198d05dbebd5c4ad21eb018f89</Sha>
+      <RepoName>core-setup</RepoName>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="3.1.0" CoherentParentDependency="Microsoft.AspNetCore.App.Ref">
       <Uri>https://github.com/aspnet/AspNetCore-Tooling</Uri>
@@ -73,6 +76,7 @@
     <Dependency Name="Microsoft.NET.Sdk" Version="3.1.100-rtm.19565.4" CoherentParentDependency="Microsoft.Dotnet.Toolset.Internal">
       <Uri>https://github.com/dotnet/sdk</Uri>
       <Sha>fc412c7e032c25a17da0e8ca4556b34897313d7c</Sha>
+      <RepoName>sdk</RepoName>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Cli.CommandLine" Version="1.0.0-preview.19208.1" CoherentParentDependency="Microsoft.DotNet.Cli.Runtime">
       <Uri>https://github.com/dotnet/cliCommandLineParser</Uri>
@@ -97,6 +101,7 @@
     <Dependency Name="Microsoft.DotNet.Cli.Runtime" Version="3.1.100-rtm.19566.1" CoherentParentDependency="Microsoft.Dotnet.Toolset.Internal">
       <Uri>https://github.com/dotnet/cli</Uri>
       <Sha>56fe2cca1ad3b1e450ece97a226ce8a655d31271</Sha>
+      <RepoName>cli</RepoName>
     </Dependency>
     <Dependency Name="Microsoft.FSharp.Compiler" Version="10.7.0-beta.19556.5" CoherentParentDependency="Microsoft.Dotnet.Toolset.Internal">
       <Uri>https://github.com/dotnet/fsharp</Uri>
@@ -113,10 +118,12 @@
     <Dependency Name="Microsoft.Dotnet.Toolset.Internal" Version="3.1.100-rtm.19566.4" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/toolset</Uri>
       <Sha>575b1c9f9636e57881fc41817d3f049dff6ff470</Sha>
+      <RepoName>toolset</RepoName>
     </Dependency>
     <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="1.0.0-preview.19566.10">
       <Uri>https://github.com/dotnet/core-sdk</Uri>
       <Sha>cd82f021f4c2c8901bd7975fcaefc34fdeec3ded</Sha>
+      <RepoName>core-sdk</RepoName>
     </Dependency>
     <!-- external dependencies, not handled by Maestro/Arcade -->
     <Dependency Name="Newtonsoft.Json" Version="12.0.2">

--- a/tools-local/init-build.proj
+++ b/tools-local/init-build.proj
@@ -167,7 +167,8 @@
       <IgnoredRepos>$(IgnoredRepos);https://github.com/dotnet/source-build-reference-packages</IgnoredRepos>
       <DarcCloneArguments>$(DarcCloneArguments) --ignore-repos "$(IgnoredRepos)"</DarcCloneArguments>
       <!-- required so Darc doesn't throw an error for missing auth -->
-      <DarcCloneArguments>$(DarcCloneArguments) --azdev-pat bogus</DarcCloneArguments>
+      <AzDoPat Condition="'$(AzDoPat)' == ''">bogus</AzDoPat>
+      <DarcCloneArguments>$(DarcCloneArguments) --azdev-pat $(AzDoPat)</DarcCloneArguments>
       <DarcCloneArguments>$(DarcCloneArguments) --github-pat bogus</DarcCloneArguments>
       <!-- depth 0 should be sufficient for us since we explictly declare all our dependencies -->
       <DarcCloneArguments>$(DarcCloneArguments) --depth 0</DarcCloneArguments>


### PR DESCRIPTION
- Remove init-submodule steps - this breaks with internal-only builds and is no longer applicable.
- Pass in AzDo's PAT for cloning source repos.
- Add `<RepoName>` tags for the repos we have serviced in the past.
  - In addition to this, specifically only for repos we actually service, we will have to add `<SourceDirectory>` tags to their repo.projs à la [ASP.NET-Extensions](https://github.com/dotnet/source-build/blob/7ec46364487c3b458d64651f598685a8cd512554/repos/aspnet-extensions.proj#L3).  I'm trying to figure out a way around this but I'm not sure we can do it without quite a bit of hackery.