### PR TITLE
Delete arm64 variants of prebuilts too

### DIFF
--- a/support/additional-prebuilts-to-delete.txt
+++ b/support/additional-prebuilts-to-delete.txt
@@ -23,6 +23,10 @@ runtime.linux-x64.microsoft.netcore.dotnetapphost.*.nupkg
 runtime.linux-x64.microsoft.netcore.dotnethost.*.nupkg
 runtime.linux-x64.microsoft.netcore.dotnethostpolicy.*.nupkg
 runtime.linux-x64.microsoft.netcore.dotnethostresolver.*.nupkg
+runtime.linux-arm64.microsoft.netcore.dotnetapphost.*.nupkg
+runtime.linux-arm64.microsoft.netcore.dotnethost.*.nupkg
+runtime.linux-arm64.microsoft.netcore.dotnethostpolicy.*.nupkg
+runtime.linux-arm64.microsoft.netcore.dotnethostresolver.*.nupkg
 sn.1.0.0.nupkg
 system.composition.attributedmodel.1.0.31.nupkg
 system.composition.convention.1.0.31.nupkg


### PR DESCRIPTION
We delete the x64 variants of the prebuilts, but not arm64 variants. When source-build is compiled on arm64, the presence of those prebuilts causes the tarball-construction (through ./build-source-tarball.sh) to fail.

Fix that by handling the arm64 prebuilts exactly like the x64 prebuilts.

Fixes #1409