### PR TITLE
Fixes to allow tool bootstrapping to succeed

### DIFF
--- a/patches/core-sdk/0001-Don-t-call-dotnet-without-a-path.patch
+++ b/patches/core-sdk/0001-Don-t-call-dotnet-without-a-path.patch
@@ -1,7 +1,7 @@
-From b4094830a51647cb6097e863878a2a8a554976c9 Mon Sep 17 00:00:00 2001
+From 3a91cf574ed014e419733348f4ee586369be6ff3 Mon Sep 17 00:00:00 2001
 From: Chris Rummel <crummel@microsoft.com>
 Date: Wed, 23 Oct 2019 21:14:21 -0500
-Subject: [PATCH 1/2] Don't call dotnet without a path
+Subject: [PATCH] Don't call dotnet without a path
 
 ---
  eng/common/tools.sh | 6 +++---

--- a/patches/core-sdk/0002-Patch-property-used-for-core-setup-version.patch
+++ b/patches/core-sdk/0002-Patch-property-used-for-core-setup-version.patch
@@ -1,14 +1,14 @@
-From 77b5a235bcfdaf2817b252f069d33e81b74177f5 Mon Sep 17 00:00:00 2001
+From db3a5d4787e17bb2967bdd46ae3b1fbc3f0a1b97 Mon Sep 17 00:00:00 2001
 From: adaggarwal <aditya.aggarwal@microsoft.com>
 Date: Tue, 12 Nov 2019 20:27:43 +0000
-Subject: [PATCH 2/2] Patch property used for core-setup version
+Subject: [PATCH] Patch property used for core-setup version
 
 ---
  src/redist/targets/GenerateLayout.targets | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/redist/targets/GenerateLayout.targets b/src/redist/targets/GenerateLayout.targets
-index e46c596..f1c2737 100644
+index 7cf525f..0e41cd9 100644
 --- a/src/redist/targets/GenerateLayout.targets
 +++ b/src/redist/targets/GenerateLayout.targets
 @@ -12,7 +12,7 @@

--- a/patches/core-sdk/0003-Enable-building-on-arm64-machines.patch
+++ b/patches/core-sdk/0003-Enable-building-on-arm64-machines.patch
@@ -1,4 +1,4 @@
-From 4b5c617203cfb9d2c1b12995e12d819fba6d7b6f Mon Sep 17 00:00:00 2001
+From 0047cdf04b38ec1cc7599cd50b33cee0382d3c40 Mon Sep 17 00:00:00 2001
 From: Omair Majid <omajid@redhat.com>
 Date: Tue, 8 Oct 2019 17:02:29 -0400
 Subject: [PATCH] Enable building on arm64 machines
@@ -23,31 +23,30 @@ Use BuildArchitecture to determine whether _crossDir and LibCLRJitRid need to
 be special-cased for arm64 or or not.
 ---
  Directory.Build.props                            | 6 ++++++
- eng/Versions.props                               | 2 +-
  src/redist/targets/Crossgen.targets              | 6 +++---
  src/redist/targets/GenerateLayout.targets        | 4 ++--
  src/redist/targets/GetRuntimeInformation.targets | 1 -
- 5 files changed, 12 insertions(+), 7 deletions(-)
+ 4 files changed, 11 insertions(+), 6 deletions(-)
 
 diff --git a/Directory.Build.props b/Directory.Build.props
-index b65a72410..be3834859 100644
+index fe43161..b173893 100644
 --- a/Directory.Build.props
 +++ b/Directory.Build.props
-@@ -7,6 +7,12 @@
-     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+@@ -8,6 +8,12 @@
    </PropertyGroup>
  
-+  <PropertyGroup>
+   <PropertyGroup>
 +    <BuildArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</BuildArchitecture>
 +    <Architecture Condition="'$(BuildArchitecture)' == 'arm64'">$(BuildArchitecture)</Architecture>
 +    <Architecture Condition="'$(Architecture)' == ''">x64</Architecture>
 +  </PropertyGroup>
 +
-   <PropertyGroup>
++  <PropertyGroup>
      <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
      <DebugType>embedded</DebugType>
+     <DebugSymbols>true</DebugSymbols>
 diff --git a/src/redist/targets/Crossgen.targets b/src/redist/targets/Crossgen.targets
-index 8d3091307..931dff2d9 100644
+index 47adeab..3fccba0 100644
 --- a/src/redist/targets/Crossgen.targets
 +++ b/src/redist/targets/Crossgen.targets
 @@ -5,14 +5,14 @@
@@ -69,10 +68,10 @@ index 8d3091307..931dff2d9 100644
        <SharedFrameworkNameVersionPath>$(RedistLayoutPath)shared/$(SharedFrameworkName)/$(MicrosoftNETCoreAppRuntimePackageVersion)</SharedFrameworkNameVersionPath>
        <DIASymReaderCrossgenFilter>*</DIASymReaderCrossgenFilter>
 diff --git a/src/redist/targets/GenerateLayout.targets b/src/redist/targets/GenerateLayout.targets
-index d2a0b6fd1..a0bcf6f35 100644
+index 0e41cd9..711e1bc 100644
 --- a/src/redist/targets/GenerateLayout.targets
 +++ b/src/redist/targets/GenerateLayout.targets
-@@ -25,11 +25,11 @@
+@@ -47,11 +47,11 @@
  
        <!-- Use the "x64" Rid when downloading Linux shared framework 'DEB' installer files. -->
        <SharedFrameworkInstallerFileRid>$(CoreSetupRid)</SharedFrameworkInstallerFileRid>
@@ -87,7 +86,7 @@ index d2a0b6fd1..a0bcf6f35 100644
        <AlternateArchitecture Condition="'$(Architecture)' == 'x86'">x64</AlternateArchitecture>
        <AlternateArchitecture Condition="'$(Architecture)' == 'x64'">x86</AlternateArchitecture>
 diff --git a/src/redist/targets/GetRuntimeInformation.targets b/src/redist/targets/GetRuntimeInformation.targets
-index 3b14d1203..f49c7262f 100644
+index bdc42db..6e010c5 100644
 --- a/src/redist/targets/GetRuntimeInformation.targets
 +++ b/src/redist/targets/GetRuntimeInformation.targets
 @@ -13,7 +13,6 @@
@@ -99,5 +98,5 @@ index 3b14d1203..f49c7262f 100644
      </PropertyGroup>
      
 -- 
-2.18.1
+1.8.3.1
 

--- a/patches/core-sdk/0004-Exclude-test-folder-from-SourceBuild.patch
+++ b/patches/core-sdk/0004-Exclude-test-folder-from-SourceBuild.patch
@@ -1,4 +1,4 @@
-From 36be37a2455a0fff9fd2dc3bd5550b276fb2c93d Mon Sep 17 00:00:00 2001
+From d8ab1b4b3a8b94fa9179714d582d598885b67eee Mon Sep 17 00:00:00 2001
 From: dseefeld <dseefeld@microsoft.com>
 Date: Tue, 19 Nov 2019 21:58:21 +0000
 Subject: [PATCH] Exclude test folder from SourceBuild

--- a/patches/core-sdk/0005-Use-variable-source-build-sets-for-ASP.NET.patch
+++ b/patches/core-sdk/0005-Use-variable-source-build-sets-for-ASP.NET.patch
@@ -1,14 +1,14 @@
-From ee1a9a3e1e1f0c568cf825d570362cf0a5165848 Mon Sep 17 00:00:00 2001
+From 8f40f56ca2f7a85c3624305090b842385d595dda Mon Sep 17 00:00:00 2001
 From: Chris Rummel <crummel@microsoft.com>
 Date: Tue, 19 Nov 2019 00:34:09 -0600
-Subject: [PATCH 3/3] Use variable source-build sets for ASP.NET
+Subject: [PATCH] Use variable source-build sets for ASP.NET
 
 ---
  src/redist/targets/GenerateLayout.targets | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/redist/targets/GenerateLayout.targets b/src/redist/targets/GenerateLayout.targets
-index 0e41cd93e..d1693725b 100644
+index 711e1bc..78058a8 100644
 --- a/src/redist/targets/GenerateLayout.targets
 +++ b/src/redist/targets/GenerateLayout.targets
 @@ -11,7 +11,7 @@
@@ -21,5 +21,5 @@ index 0e41cd93e..d1693725b 100644
  
      <!-- Change these individually to or $(CoreSetupBlobVersion), $(AspNetCoreBlobVersion), or appropriate fixed version depending if corresponding .Ref packages are unpinned. -->
 -- 
-2.21.0 (Apple Git-122.2)
+1.8.3.1
 

--- a/patches/core-sdk/0006-Remove-debian-package-generation.patch
+++ b/patches/core-sdk/0006-Remove-debian-package-generation.patch
@@ -1,4 +1,4 @@
-From 01655cf5bb915c32ec94a44e151b3b01ed91de92 Mon Sep 17 00:00:00 2001
+From ede2e80a858b8f80c8de0d0f5ca354227d18d10c Mon Sep 17 00:00:00 2001
 From: dseefeld <dseefeld@microsoft.com>
 Date: Tue, 19 Nov 2019 23:04:43 +0000
 Subject: [PATCH] Remove debian package generation

--- a/patches/core-sdk/0007-Don-t-set-SourceLinkVersion-in-core-sdk.patch
+++ b/patches/core-sdk/0007-Don-t-set-SourceLinkVersion-in-core-sdk.patch
@@ -1,0 +1,24 @@
+From 2cd6c070c058b1de400d47eb99813c9a8d45a619 Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Wed, 4 Dec 2019 21:53:35 +0000
+Subject: [PATCH] Don't set SourceLinkVersion in core-sdk
+
+---
+ eng/Versions.props | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/eng/Versions.props b/eng/Versions.props
+index 422a9b2..0ac6245 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -117,7 +117,6 @@
+     <VersionToolsVersion>$(BuildTasksFeedToolVersion)</VersionToolsVersion>
+     <DotnetDebToolVersion>2.0.0</DotnetDebToolVersion>
+     <MicrosoftNETTestSdkVersion>15.8.0</MicrosoftNETTestSdkVersion>
+-    <MicrosoftSourceLinkVersion>1.0.0-beta2-18618-05</MicrosoftSourceLinkVersion>
+   </PropertyGroup>
+   <PropertyGroup>
+     <!-- pinned dependency. This package is not being produced outside of the 2.0 branch of corefx and should not change. -->
+-- 
+1.8.3.1
+

--- a/patches/msbuild/0001-Don-t-call-dotnet-without-path.patch
+++ b/patches/msbuild/0001-Don-t-call-dotnet-without-path.patch
@@ -1,4 +1,4 @@
-From f9c2189c5c622672ba588f00e11a25cb4bc6230e Mon Sep 17 00:00:00 2001
+From 95372a80ae67d4b5e653e43f243196578254010e Mon Sep 17 00:00:00 2001
 From: Chris Rummel <crummel@microsoft.com>
 Date: Wed, 23 Oct 2019 17:23:58 -0500
 Subject: [PATCH] Don't call dotnet without path
@@ -8,7 +8,7 @@ Subject: [PATCH] Don't call dotnet without path
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/eng/common/tools.sh b/eng/common/tools.sh
-index 757d5b9e..5a4cfeb1 100755
+index 757d5b9..5a4cfeb 100755
 --- a/eng/common/tools.sh
 +++ b/eng/common/tools.sh
 @@ -340,9 +340,9 @@ function MSBuild {
@@ -25,5 +25,5 @@ index 757d5b9e..5a4cfeb1 100755
      local toolset_dir="${_InitializeToolset%/*}"
      local logger_path="$toolset_dir/$_InitializeBuildToolFramework/Microsoft.DotNet.Arcade.Sdk.dll"
 -- 
-2.18.0
+1.8.3.1
 

--- a/patches/msbuild/0002-Remove-runtime-identifiers-to-break-runtime-prebuilt.patch
+++ b/patches/msbuild/0002-Remove-runtime-identifiers-to-break-runtime-prebuilt.patch
@@ -1,4 +1,4 @@
-From 8b4193dc8fb9cb2e614c7918d56317bb9764d50c Mon Sep 17 00:00:00 2001
+From 7b16b05fbf94dab369f3198be59e2e911500b579 Mon Sep 17 00:00:00 2001
 From: dseefeld <dseefeld@microsoft.com>
 Date: Wed, 9 Oct 2019 14:55:27 +0000
 Subject: [PATCH] Remove runtime identifiers to break runtime prebuilt restore

--- a/patches/msbuild/0003-Use-source-built-version-of-SystemResourcesExtension.patch
+++ b/patches/msbuild/0003-Use-source-built-version-of-SystemResourcesExtension.patch
@@ -1,0 +1,25 @@
+From 1d6e1710f22bf5c1cd8e71ffa900e57b0addb056 Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Tue, 3 Dec 2019 14:05:42 +0000
+Subject: [PATCH] Use source-built version of SystemResourcesExtensions
+
+---
+ eng/Packages.props | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/eng/Packages.props b/eng/Packages.props
+index b45719f..a2dcce8 100644
+--- a/eng/Packages.props
++++ b/eng/Packages.props
+@@ -32,7 +32,7 @@
+     <PackageReference Update="System.Net.Http" Version="4.3.4" />
+     <PackageReference Update="System.Reflection.Metadata" Version="1.6.0" />
+     <PackageReference Update="System.Reflection.TypeExtensions" Version="4.1.0" />
+-    <PackageReference Update="System.Resources.Extensions" Version="4.6.0" />
++    <PackageReference Update="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
+     <PackageReference Update="System.Resources.Writer" Version="4.0.0" />
+     <PackageReference Update="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+     <PackageReference Update="System.Runtime.Loader" Version="4.0.0" />
+-- 
+1.8.3.1
+


### PR DESCRIPTION
Patches for two issues that were preventing the final sdk build from completing:

1. Make msbuild use the source built version of System.Resources.Extensions
2. Don't set the source-link version in core-sdk, get it from arcade