### PR TITLE
Update sourcelink tasks to build for netcoreapp2.1

### DIFF
--- a/patches/sourcelink/0002-Patch-ref-packages-out.patch
+++ b/patches/sourcelink/0002-Patch-ref-packages-out.patch
@@ -35,7 +35,7 @@ index bb6c3b3..31b47fb 100644
  ﻿<Project Sdk="Microsoft.NET.Sdk">
    <PropertyGroup>
 -    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
-+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
++    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
      <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
  
      <!-- NuGet -->
@@ -47,7 +47,7 @@ index e294f3f..ac3c0a4 100644
  ﻿<Project Sdk="Microsoft.NET.Sdk">
    <PropertyGroup>
 -    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
-+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
++    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
      <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
  
      <!-- Using an explicit nuspec file due to https://github.com/NuGet/Home/issues/6754 -->
@@ -59,7 +59,7 @@ index bc5c152..6e2aac9 100644
  ﻿<Project Sdk="Microsoft.NET.Sdk">
    <PropertyGroup>
 -    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
-+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
++    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
      <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
  
      <!-- Using an explicit nuspec file due to https://github.com/NuGet/Home/issues/6754 -->
@@ -71,7 +71,7 @@ index 7abd791..1147bcb 100644
  ﻿<Project Sdk="Microsoft.NET.Sdk">
    <PropertyGroup>
 -    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
-+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
++    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
      <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
  
      <!-- Using an explicit nuspec file since NuGet Pack target currently doesn't support including dependencies in tools packages -->
@@ -83,7 +83,7 @@ index 11730b8..1e99e38 100644
  ﻿<Project Sdk="Microsoft.NET.Sdk">
    <PropertyGroup>
 -    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
-+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
++    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
      <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
  
      <!-- NuGet -->
@@ -95,7 +95,7 @@ index 651620d..efc3f52 100644
  ﻿<Project Sdk="Microsoft.NET.Sdk">
    <PropertyGroup>
 -    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
-+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
++    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
      <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
  
      <!-- Using an explicit nuspec file due to https://github.com/NuGet/Home/issues/6754 -->
@@ -107,7 +107,7 @@ index 557305a..01c69e6 100644
  ﻿<Project Sdk="Microsoft.NET.Sdk">
    <PropertyGroup>
 -    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
-+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
++    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
      <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
  
      <!-- Using an explicit nuspec file due to https://github.com/NuGet/Home/issues/6754 -->

--- a/patches/sourcelink/0005-Update-targets-to-support-netcoreapp2.1.patch
+++ b/patches/sourcelink/0005-Update-targets-to-support-netcoreapp2.1.patch
@@ -1,0 +1,108 @@
+From 1b9676adf62d2443f4e99966fcf682ba0f06d2af Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Thu, 19 Dec 2019 17:14:05 +0000
+Subject: [PATCH] Update targets to support netcoreapp2.1
+
+---
+ src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.props     | 2 +-
+ .../build/Microsoft.SourceLink.AzureRepos.Git.targets                   | 2 +-
+ .../build/Microsoft.SourceLink.Bitbucket.Git.targets                    | 2 +-
+ src/SourceLink.Common/build/Microsoft.SourceLink.Common.props           | 2 +-
+ src/SourceLink.GitHub/build/Microsoft.SourceLink.GitHub.targets         | 2 +-
+ src/SourceLink.GitLab/build/Microsoft.SourceLink.GitLab.targets         | 2 +-
+ .../build/Microsoft.SourceLink.AzureDevOpsServer.Git.targets            | 2 +-
+ 7 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.props b/src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.props
+index 2078031..2e3c3de 100644
+--- a/src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.props
++++ b/src/Microsoft.Build.Tasks.Git/build/Microsoft.Build.Tasks.Git.props
+@@ -2,6 +2,6 @@
+ <Project>
+   <PropertyGroup>
+     <MicrosoftBuildTasksGitAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net461\Microsoft.Build.Tasks.Git.dll</MicrosoftBuildTasksGitAssemblyFile>
+-    <MicrosoftBuildTasksGitAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\netcoreapp2.0\Microsoft.Build.Tasks.Git.dll</MicrosoftBuildTasksGitAssemblyFile>
++    <MicrosoftBuildTasksGitAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\netcoreapp2.1\Microsoft.Build.Tasks.Git.dll</MicrosoftBuildTasksGitAssemblyFile>
+   </PropertyGroup>
+ </Project>
+diff --git a/src/SourceLink.AzureRepos.Git/build/Microsoft.SourceLink.AzureRepos.Git.targets b/src/SourceLink.AzureRepos.Git/build/Microsoft.SourceLink.AzureRepos.Git.targets
+index e30145e..8d99e2a 100644
+--- a/src/SourceLink.AzureRepos.Git/build/Microsoft.SourceLink.AzureRepos.Git.targets
++++ b/src/SourceLink.AzureRepos.Git/build/Microsoft.SourceLink.AzureRepos.Git.targets
+@@ -2,7 +2,7 @@
+ <Project>
+   <PropertyGroup>
+     <_SourceLinkAzureReposGitAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net461\Microsoft.SourceLink.AzureRepos.Git.dll</_SourceLinkAzureReposGitAssemblyFile>
+-    <_SourceLinkAzureReposGitAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\netcoreapp2.0\Microsoft.SourceLink.AzureRepos.Git.dll</_SourceLinkAzureReposGitAssemblyFile>
++    <_SourceLinkAzureReposGitAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\netcoreapp2.1\Microsoft.SourceLink.AzureRepos.Git.dll</_SourceLinkAzureReposGitAssemblyFile>
+   </PropertyGroup>
+ 
+   <UsingTask TaskName="Microsoft.SourceLink.AzureRepos.Git.GetSourceLinkUrl" AssemblyFile="$(_SourceLinkAzureReposGitAssemblyFile)"/>
+diff --git a/src/SourceLink.Bitbucket.Git/build/Microsoft.SourceLink.Bitbucket.Git.targets b/src/SourceLink.Bitbucket.Git/build/Microsoft.SourceLink.Bitbucket.Git.targets
+index 16576b7..53f35a0 100644
+--- a/src/SourceLink.Bitbucket.Git/build/Microsoft.SourceLink.Bitbucket.Git.targets
++++ b/src/SourceLink.Bitbucket.Git/build/Microsoft.SourceLink.Bitbucket.Git.targets
+@@ -2,7 +2,7 @@
+ <Project>
+   <PropertyGroup>
+     <_SourceLinkBitbucketAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net461\Microsoft.SourceLink.Bitbucket.Git.dll</_SourceLinkBitbucketAssemblyFile>
+-    <_SourceLinkBitbucketAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\netcoreapp2.0\Microsoft.SourceLink.Bitbucket.Git.dll</_SourceLinkBitbucketAssemblyFile>
++    <_SourceLinkBitbucketAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\netcoreapp2.1\Microsoft.SourceLink.Bitbucket.Git.dll</_SourceLinkBitbucketAssemblyFile>
+   </PropertyGroup>
+ 
+   <UsingTask TaskName="Microsoft.SourceLink.Bitbucket.Git.GetSourceLinkUrl" AssemblyFile="$(_SourceLinkBitbucketAssemblyFile)"/>
+diff --git a/src/SourceLink.Common/build/Microsoft.SourceLink.Common.props b/src/SourceLink.Common/build/Microsoft.SourceLink.Common.props
+index 1e2e1f2..d87530f 100644
+--- a/src/SourceLink.Common/build/Microsoft.SourceLink.Common.props
++++ b/src/SourceLink.Common/build/Microsoft.SourceLink.Common.props
+@@ -2,7 +2,7 @@
+ <Project>
+   <PropertyGroup>
+     <_MicrosoftSourceLinkCommonAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net461\Microsoft.SourceLink.Common.dll</_MicrosoftSourceLinkCommonAssemblyFile>
+-    <_MicrosoftSourceLinkCommonAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\netcoreapp2.0\Microsoft.SourceLink.Common.dll</_MicrosoftSourceLinkCommonAssemblyFile>
++    <_MicrosoftSourceLinkCommonAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\netcoreapp2.1\Microsoft.SourceLink.Common.dll</_MicrosoftSourceLinkCommonAssemblyFile>
+   </PropertyGroup>
+ 
+   <PropertyGroup>
+diff --git a/src/SourceLink.GitHub/build/Microsoft.SourceLink.GitHub.targets b/src/SourceLink.GitHub/build/Microsoft.SourceLink.GitHub.targets
+index f0a0c1d..ebda677 100644
+--- a/src/SourceLink.GitHub/build/Microsoft.SourceLink.GitHub.targets
++++ b/src/SourceLink.GitHub/build/Microsoft.SourceLink.GitHub.targets
+@@ -2,7 +2,7 @@
+ <Project>
+   <PropertyGroup>
+     <_SourceLinkGitHubAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net461\Microsoft.SourceLink.GitHub.dll</_SourceLinkGitHubAssemblyFile>
+-    <_SourceLinkGitHubAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\netcoreapp2.0\Microsoft.SourceLink.GitHub.dll</_SourceLinkGitHubAssemblyFile>
++    <_SourceLinkGitHubAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\netcoreapp2.1\Microsoft.SourceLink.GitHub.dll</_SourceLinkGitHubAssemblyFile>
+   </PropertyGroup>
+ 
+   <UsingTask TaskName="Microsoft.SourceLink.GitHub.GetSourceLinkUrl" AssemblyFile="$(_SourceLinkGitHubAssemblyFile)"/>
+diff --git a/src/SourceLink.GitLab/build/Microsoft.SourceLink.GitLab.targets b/src/SourceLink.GitLab/build/Microsoft.SourceLink.GitLab.targets
+index ed8d16b..cae60a8 100644
+--- a/src/SourceLink.GitLab/build/Microsoft.SourceLink.GitLab.targets
++++ b/src/SourceLink.GitLab/build/Microsoft.SourceLink.GitLab.targets
+@@ -2,7 +2,7 @@
+ <Project>
+   <PropertyGroup>
+     <_SourceLinkGitLabAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net461\Microsoft.SourceLink.GitLab.dll</_SourceLinkGitLabAssemblyFile>
+-    <_SourceLinkGitLabAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\netcoreapp2.0\Microsoft.SourceLink.GitLab.dll</_SourceLinkGitLabAssemblyFile>
++    <_SourceLinkGitLabAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\netcoreapp2.1\Microsoft.SourceLink.GitLab.dll</_SourceLinkGitLabAssemblyFile>
+   </PropertyGroup>
+ 
+   <UsingTask TaskName="Microsoft.SourceLink.GitLab.GetSourceLinkUrl" AssemblyFile="$(_SourceLinkGitLabAssemblyFile)"/>
+diff --git a/src/SourceLink.Vsts.Git/build/Microsoft.SourceLink.AzureDevOpsServer.Git.targets b/src/SourceLink.Vsts.Git/build/Microsoft.SourceLink.AzureDevOpsServer.Git.targets
+index c0812e7..0a678b6 100644
+--- a/src/SourceLink.Vsts.Git/build/Microsoft.SourceLink.AzureDevOpsServer.Git.targets
++++ b/src/SourceLink.Vsts.Git/build/Microsoft.SourceLink.AzureDevOpsServer.Git.targets
+@@ -2,7 +2,7 @@
+ <Project>
+   <PropertyGroup>
+     <_SourceLinkAzureDevOpsServerGitAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)..\tools\net461\Microsoft.SourceLink.AzureDevOpsServer.Git.dll</_SourceLinkAzureDevOpsServerGitAssemblyFile>
+-    <_SourceLinkAzureDevOpsServerGitAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\netcoreapp2.0\Microsoft.SourceLink.AzureDevOpsServer.Git.dll</_SourceLinkAzureDevOpsServerGitAssemblyFile>
++    <_SourceLinkAzureDevOpsServerGitAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\tools\netcoreapp2.1\Microsoft.SourceLink.AzureDevOpsServer.Git.dll</_SourceLinkAzureDevOpsServerGitAssemblyFile>
+   </PropertyGroup>
+ 
+   <UsingTask TaskName="Microsoft.SourceLink.AzureDevOpsServer.Git.GetSourceLinkUrl" AssemblyFile="$(_SourceLinkAzureDevOpsServerGitAssemblyFile)"/>
+-- 
+1.8.3.1
+


### PR DESCRIPTION
The bootstrap final build is failing because the bootstrapped stage1 SDK version of Microsoft.Build doesn't support netcoreapp2.0.  Updating sourcelink tasks to build with the stage1 SDK