### PR TITLE
Add *.cache to excluded files when copying ref packages.

### DIFF
--- a/support/additional-prebuilts-to-delete.txt
+++ b/support/additional-prebuilts-to-delete.txt
@@ -22,9 +22,6 @@ microsoft.sourcelink.common.1.0.0-beta2-18618-05.nupkg
 microsoft.sourcelink.github.1.0.0-beta2-18618-05.nupkg
 microsoft.sourcelink.vsts.git.1.0.0-beta2-18618-05.nupkg
 microsoft.visualstudio.setup.configuration.interop.1.16.30.nupkg
-# this should just be some text templates, but 1.5.3 appears to mistakely contain
-# actual binary files which causes our ref-only package detection to fail.
-nunit3.dotnetnew.template.1.5.3.nupkg
 runtime.*.runtime.native.system.security.cryptography.apple.*.nupkg
 runtime.*.runtime.native.system.security.cryptography.openssl.*.nupkg
 runtime.linux-x64.microsoft.netcore.dotnetapphost.*.nupkg

--- a/support/additional-prebuilts-to-delete.txt
+++ b/support/additional-prebuilts-to-delete.txt
@@ -22,6 +22,9 @@ microsoft.sourcelink.common.1.0.0-beta2-18618-05.nupkg
 microsoft.sourcelink.github.1.0.0-beta2-18618-05.nupkg
 microsoft.sourcelink.vsts.git.1.0.0-beta2-18618-05.nupkg
 microsoft.visualstudio.setup.configuration.interop.1.16.30.nupkg
+# this should just be some text templates, but 1.5.3 appears to mistakely contain
+# actual binary files which causes our ref-only package detection to fail.
+nunit3.dotnetnew.template.1.5.3.nupkg
 runtime.*.runtime.native.system.security.cryptography.apple.*.nupkg
 runtime.*.runtime.native.system.security.cryptography.openssl.*.nupkg
 runtime.linux-x64.microsoft.netcore.dotnetapphost.*.nupkg

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/CopyReferenceOnlyPackages.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/CopyReferenceOnlyPackages.cs
@@ -96,7 +96,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
                     {
                         // skip these files
                     }
-                    if (file.EndsWith(".nupkg")) 
+                    else if (file.EndsWith(".nupkg"))
                     {
                         File.Copy(file, Path.Combine(IdentifiedPackagesDir, Path.GetFileName(file)), true);
                     }

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/CopyReferenceOnlyPackages.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/CopyReferenceOnlyPackages.cs
@@ -20,7 +20,8 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
     /// </summary>
     public class CopyReferenceOnlyPackages : Task
     {
-        private static readonly string[] extensionsToExclude = { ".exe", ".dylib", ".so", ".profdata", ".pgd", ".a", ".cache" };
+        private static readonly string[] extensionsToExclude = { ".exe", ".dylib", ".so", ".profdata", ".pgd", ".a" };
+        private static readonly string[] extensionsToRemove = { ".cache" };
         private static readonly string[] pathsToExclude = { "testdata" };
         private static readonly string refPath = string.Concat(Path.DirectorySeparatorChar, "ref", Path.DirectorySeparatorChar);
 
@@ -91,6 +92,10 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
             {
                 foreach (var file in EnumerateAllFiles(dir, "*"))
                 {
+                    if (extensionsToRemove.Contains(Path.GetExtension(file))
+                    {
+                        // skip these files
+                    }
                     if (file.EndsWith(".nupkg")) 
                     {
                         File.Copy(file, Path.Combine(IdentifiedPackagesDir, Path.GetFileName(file)), true);

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/CopyReferenceOnlyPackages.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/CopyReferenceOnlyPackages.cs
@@ -20,8 +20,8 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
     /// </summary>
     public class CopyReferenceOnlyPackages : Task
     {
-        private static readonly string[] extensionsToExclude = { ".exe", ".dylib", ".so", ".profdata", ".pgd", ".a" };
-        private static readonly string[] pathsToExclude = { "testdata", "obj", "bin", "Debug", "Release" };
+        private static readonly string[] extensionsToExclude = { ".exe", ".dylib", ".so", ".profdata", ".pgd", ".a", ".cache" };
+        private static readonly string[] pathsToExclude = { "testdata" };
         private static readonly string refPath = string.Concat(Path.DirectorySeparatorChar, "ref", Path.DirectorySeparatorChar);
 
         /// <summary>

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/CopyReferenceOnlyPackages.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/CopyReferenceOnlyPackages.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
     /// </summary>
     public class CopyReferenceOnlyPackages : Task
     {
-        private static readonly string[] extensionsToExclude = { ".exe", ".dylib", ".so", ".profdata", ".pgd", ".a" };
+        private static readonly string[] extensionsToExclude = { ".exe", ".dylib", ".so", ".profdata", ".pgd", ".a", ".cache" };
         private static readonly string[] pathsToExclude = { "testdata" };
         private static readonly string refPath = string.Concat(Path.DirectorySeparatorChar, "ref", Path.DirectorySeparatorChar);
 

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/CopyReferenceOnlyPackages.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/CopyReferenceOnlyPackages.cs
@@ -20,8 +20,8 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
     /// </summary>
     public class CopyReferenceOnlyPackages : Task
     {
-        private static readonly string[] extensionsToExclude = { ".exe", ".dylib", ".so", ".profdata", ".pgd", ".a", ".cache" };
-        private static readonly string[] pathsToExclude = { "testdata" };
+        private static readonly string[] extensionsToExclude = { ".exe", ".dylib", ".so", ".profdata", ".pgd", ".a" };
+        private static readonly string[] pathsToExclude = { "testdata", "obj", "bin", "Debug", "Release" };
         private static readonly string refPath = string.Concat(Path.DirectorySeparatorChar, "ref", Path.DirectorySeparatorChar);
 
         /// <summary>

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/CopyReferenceOnlyPackages.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/CopyReferenceOnlyPackages.cs
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
             {
                 foreach (var file in EnumerateAllFiles(dir, "*"))
                 {
-                    if (extensionsToRemove.Contains(Path.GetExtension(file))
+                    if (extensionsToRemove.Contains(Path.GetExtension(file)))
                     {
                         // skip these files
                     }


### PR DESCRIPTION
Some template packages we use erroneously include .cache files, which are text like:
```
{
  "version": 1,
  "dgSpecHash": "vODEZsXQI5BwPuuSe1Hzd5XIVnUkcaoRo2EnUbZriP5/DirtEEti1rvaejH0cCazlJ03IjAsmHvbrSO0i7iwaQ==",
  "success": true
}
```

so aren't detected as binary files by the reference-package disassembly and assembly.  These have no real effect but it's more correct to skip them.

Fixes #1438.