### PR TITLE
Always build portable runtime in addition to non-portable.

### DIFF
--- a/.vsts.pipelines/jobs/ci-linux.yml
+++ b/.vsts.pipelines/jobs/ci-linux.yml
@@ -14,7 +14,7 @@ jobs:
   strategy:
     matrix: ${{ parameters.matrix }}
   pool: ${{ parameters.pool }}
-  timeoutInMinutes: 270
+  timeoutInMinutes: 300
   variables:
     # Prefix to distinguish artifacts from different legs.
     artifactName: ${{ format('{0} $(type)', parameters.job) }}
@@ -72,7 +72,7 @@ jobs:
         /p:AzDoPat=$(System.AccessToken)
       du -h $(rootDirectory) | sort -h | tail -n 50
     displayName: Build source-build
-    timeoutInMinutes: 150
+    timeoutInMinutes: 180
 
   # Generate prebuilt burndown data
   - script: |
@@ -208,7 +208,7 @@ jobs:
         $poisonArg
       du -h $(rootDirectory) | sort -h | tail -n 50
     displayName: Build tarball
-    timeoutInMinutes: 120
+    timeoutInMinutes: 150
     condition: and(succeeded(), eq(variables['sb.tarball'], true))
 
   # Run smoke tests.

--- a/.vsts.pipelines/jobs/ci-linux_bootstrap.yml
+++ b/.vsts.pipelines/jobs/ci-linux_bootstrap.yml
@@ -35,6 +35,7 @@ jobs:
     type: Production
 
   steps:
+  - template: ../steps/cleanup-unneeded-files.yml
   - template: ../steps/docker-cleanup-linux.yml
 
   - task: DownloadBuildArtifacts@0
@@ -49,7 +50,7 @@ jobs:
       set -ex
       df -h
       $(docker.run) $(docker.bst.map) $(docker.bst.work) $(imageName) bash -c '
-      git clone https://github.com/dotnet/source-build-reference-packages'
+      git clone --depth 1 https://github.com/dotnet/source-build-reference-packages'
       du -h $(rootDirectory) | sort -h | tail -n 50
     displayName: clone source-build-reference-packages
     condition: always()

--- a/.vsts.pipelines/steps/run-bootstrap.yml
+++ b/.vsts.pipelines/steps/run-bootstrap.yml
@@ -1,6 +1,3 @@
-# Delete some files from the default image since we're tight on disk space.
-# List is from https://github.com/microsoft/azure-pipelines-image-generation/pull/1231#issuecomment-537174621
-
 # Extract the tarball fetched from the previous Offline stage 
 steps:
 - script: |
@@ -108,7 +105,8 @@ steps:
       set -ex 
       df -h 
       $(docker.run) --network=none $(docker.bst.map) $(docker.bst.work) $(imageName) bash -c '
-      rm -rf /bst/source-build-reference-packages/* 
+      rm -rf /bst/source-build-reference-packages/*
+      rm -rf /bst/source-build-reference-packages/.git
       pushd /bst/bootstrap_dir/reference-packages
       echo "Removing everything in reference-packages except artifacts"
       find . -type f -not -name '*SourceBuild.ReferencePackages.bootstrap.tar.gz' -delete

--- a/.vsts.pipelines/steps/run-bootstrap.yml
+++ b/.vsts.pipelines/steps/run-bootstrap.yml
@@ -5,11 +5,13 @@
 steps:
 - script: |
       set -ex 
+      mount
       df -h 
       $(docker.run) --network=none $(docker.bst.map) $(docker.bst.work) $(imageName) bash -c '
       mkdir -p /bst/sb/tarball
-      tar -xvf "/bst/Tarball centos71 Offline/$(tarballName).tar.gz" -C /bst/sb/tarball --no-same-owner --strip-components=1
+      tar -xf "/bst/Tarball centos71 Offline/$(tarballName).tar.gz" -C /bst/sb/tarball --no-same-owner --strip-components=1
       rm -rf "/bst/Tarball centos71 Offline"'
+      df -h
   displayName: Unpack Tarball
   condition: always()
 
@@ -19,6 +21,7 @@ steps:
       df -h 
       $(docker.run) --network=none $(docker.bst.map) $(docker.bst.work) $(imageName) bash -c '
       /bst/sb/tarball/tool-bootstrapping/bootstrap.sh /bst/bootstrap_dir /bst/sb/tarball /bst/source-build-reference-packages 1'
+      df -h
   displayName: Build stage1
   condition: succeeded()
 

--- a/dir.props
+++ b/dir.props
@@ -12,7 +12,7 @@
 
     <PortableBuild Condition="'$(OS)' == 'Windows_NT'">true</PortableBuild>
     <PortableBuild Condition="'$(PortableBuild)' == ''">false</PortableBuild>
-    <UseSystemLibraries Condition="'$(UseSystemLibraries)' == '' AND '$(PortableBuild)' != 'true'">true</UseSystemLibraries>
+    <UseSystemLibraries Condition="'$(UseSystemLibraries)' == '' AND '$(PortableBuild)' != 'true' and '$(BuildingPortableRuntime)' != 'true'">true</UseSystemLibraries>
     <UseStableVersions Condition="'$(UseStableVersions)' == ''">true</UseStableVersions>
   </PropertyGroup>
 

--- a/dir.props
+++ b/dir.props
@@ -12,7 +12,7 @@
 
     <PortableBuild Condition="'$(OS)' == 'Windows_NT'">true</PortableBuild>
     <PortableBuild Condition="'$(PortableBuild)' == ''">false</PortableBuild>
-    <UseSystemLibraries Condition="'$(UseSystemLibraries)' == '' AND '$(PortableBuild)' != 'true' and '$(BuildingPortableRuntime)' != 'true'">true</UseSystemLibraries>
+    <UseSystemLibraries Condition="'$(UseSystemLibraries)' == '' AND '$(PortableBuild)' != 'true'">true</UseSystemLibraries>
     <UseStableVersions Condition="'$(UseStableVersions)' == ''">true</UseStableVersions>
   </PropertyGroup>
 

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -32,6 +32,11 @@
       <Sha>1ed7226e39b7214807318d2cc8ff37492527ffa1</Sha>
       <RepoName>coreclr</RepoName>
     </Dependency>
+    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="3.1.0-rtm.19564.2" CoherentParentDependency="Microsoft.Private.CoreFx.NETCoreApp">
+      <Uri>https://github.com/dotnet/coreclr</Uri>
+      <Sha>1ed7226e39b7214807318d2cc8ff37492527ffa1</Sha>
+      <RepoName>coreclr-portable</RepoName>
+    </Dependency>
     <Dependency Name="NETStandard.Library" Version="2.1.0" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/standard</Uri>
       <Sha>a5b5f2e1e369972c8ff1e2183979fab6099f52ef</Sha>
@@ -41,10 +46,20 @@
       <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>
       <RepoName>corefx</RepoName>
     </Dependency>
+    <Dependency Name="Microsoft.Private.CoreFx.NETCoreApp" Version="4.7.0-rtm.19564.4" CoherentParentDependency="Microsoft.NETCore.App">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>0f7f38c4fd323b26da10cce95f857f77f0f09b48</Sha>
+      <RepoName>corefx-portable</RepoName>
+    </Dependency>
     <Dependency Name="Microsoft.NETCore.App" Version="3.1.0-rtm.19565.2" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>65f04fb6db7a5e198d05dbebd5c4ad21eb018f89</Sha>
       <RepoName>core-setup</RepoName>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.App" Version="3.1.0-rtm.19565.2" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>65f04fb6db7a5e198d05dbebd5c4ad21eb018f89</Sha>
+      <RepoName>core-setup-portable</RepoName>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="3.1.0" CoherentParentDependency="Microsoft.AspNetCore.App.Ref">
       <Uri>https://github.com/aspnet/AspNetCore-Tooling</Uri>

--- a/repos/core-setup-portable.proj
+++ b/repos/core-setup-portable.proj
@@ -2,50 +2,10 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <SourceDirectory>core-setup</SourceDirectory>
+    <BuildingPortableRuntime>true</BuildingPortableRuntime>
   </PropertyGroup>
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
-
-  <PropertyGroup>
-    <BuildArguments>$(FlagParameterPrefix)restore $(FlagParameterPrefix)build</BuildArguments>
-    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)configuration $(Configuration)</BuildArguments>
-    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)ci</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:PortableBuild=true</BuildArguments>
-    <BuildArguments Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64'">$(BuildArguments) /p:TargetArchitecture=$(Platform) /p:DisableCrossgen=true /p:CrossBuild=true</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:BuildDebPackage=false</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:BuildAllPackages=true</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:RestoreAllBuildRids=false</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:OutputRid=linux-$(Platform)</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:DotNetOutputBlobFeedDir=$(SourceBuiltBlobFeedDir)</BuildArguments>
-    <BuildArguments>$(BuildArguments) /m:1</BuildArguments>
-
-    <LogVerbosityOptOut>true</LogVerbosityOptOut>
-    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)verbosity $(LogVerbosity)</BuildArguments>
-    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)binaryLog</BuildArguments>
-    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)warnAsError $(ArcadeFalseBoolBuildArg)</BuildArguments>
-    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)nodereuse $(ArcadeFalseBoolBuildArg)</BuildArguments>
-
-    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments)</BuildCommand>
-    <BuildCommand Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64'">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
-
-    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
-    <ShippingPackagesOutput>$(ProjectDirectory)artifacts/packages/$(Configuration)/Shipping/</ShippingPackagesOutput>
-    <NonShippingPackagesOutput>$(ProjectDirectory)artifacts/packages/$(Configuration)/NonShipping/</NonShippingPackagesOutput>
-
-    <NuGetConfigFile>$(ProjectDirectory)/NuGet.config</NuGetConfigFile>
-    <DependencyVersionInputRepoApiImplemented>true</DependencyVersionInputRepoApiImplemented>
-
-    <EnvironmentRestoreSources>$(SourceBuiltPackagesPath)</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources>$(EnvironmentRestoreSources)%3B$(ShippingPackagesOutput)</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources>$(EnvironmentRestoreSources)%3B$(NonShippingPackagesOutput)</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' == 'true'">$(EnvironmentRestoreSources)%3B$(ReferencePackagesDir)%3B$(PrebuiltPackagesPath)</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://api.nuget.org/v3/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json</EnvironmentRestoreSources>
-
-    <!-- core-setup does not destabilize for intermediate servicing builds -->
-    <IsStable>true</IsStable>
-  </PropertyGroup>
+  <Import Project="core-setup.common.props" />
 
   <ItemGroup>
     <RepositoryReference Include="coreclr" />
@@ -56,23 +16,6 @@
     <RepositoryReference Include="standard" />
   </ItemGroup>
 
-  <ItemGroup>
-    <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
-    <UseSourceBuiltSdkOverride Include="@(ArcadePackagingOverride)" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EnvironmentVariables Include="RestoreSources=$(EnvironmentRestoreSources)" />
-    <EnvironmentVariables Include="BuildInParallel=false" />
-  </ItemGroup>
-
-  <Target Name="SetOutputList" AfterTargets="Package" BeforeTargets="GatherBuiltPackages">
-    <ItemGroup>
-      <PackagesOutputList Include="$(ShippingPackagesOutput)" />
-      <PackagesOutputList Include="$(NonShippingPackagesOutput)" />
-    </ItemGroup>
-  </Target>
-
   <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="WriteVersionsFile">
     <ItemGroup>
       <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
@@ -82,7 +25,7 @@
     <RemoveDir Directories="@(DirsToDelete)" />
   </Target>
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
+  <Import Project="core-setup.common.targets" />
 
   <Target Name="GatherBuiltPackages">
     <ItemGroup>

--- a/repos/core-setup-portable.proj
+++ b/repos/core-setup-portable.proj
@@ -16,7 +16,7 @@
     <RepositoryReference Include="standard" />
   </ItemGroup>
 
-  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="RemoveBuiltPackagesFromCache;EnsurePackagesCreated">
+  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="RemoveBuiltPackagesFromCache">
     <ItemGroup>
       <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
       <DirsToDelete Include="$(ProjectDirectory)bin" Condition="Exists('$(ProjectDirectory)bin')" />

--- a/repos/core-setup-portable.proj
+++ b/repos/core-setup-portable.proj
@@ -27,7 +27,7 @@
 
   <Import Project="core-setup.common.targets" />
 
-  <Target Name="GatherBuiltPackages">
+  <Target Name="GatherBuiltPackages" BeforeTargets="CopyPackage">
     <ItemGroup>
       <_BuiltPackages Include="$(ShippingPackagesOutput)/*linux*nupkg" Exclude="$(ShippingPackagesOutput)/*.symbols.nupkg" />
       <_BuiltPackages Include="$(NonShippingPackagesOutput)/*linux*nupkg" Exclude="$(NonShippingPackagesOutput)/*.symbols.nupkg" />

--- a/repos/core-setup-portable.proj
+++ b/repos/core-setup-portable.proj
@@ -15,7 +15,7 @@
     <BuildArguments>$(BuildArguments) /p:BuildDebPackage=false</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:BuildAllPackages=true</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:RestoreAllBuildRids=false</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:OutputRid=linux-x64</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:OutputRid=linux-$(Platform)</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:DotNetOutputBlobFeedDir=$(SourceBuiltBlobFeedDir)</BuildArguments>
     <BuildArguments>$(BuildArguments) /m:1</BuildArguments>
 

--- a/repos/core-setup-portable.proj
+++ b/repos/core-setup-portable.proj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <SourceDirectory>core-setup</SourceDirectory>
-    <BuildingPortableRuntime>true</BuildingPortableRuntime>
+    <PortableBuild>true</PortableBuild>
   </PropertyGroup>
 
   <Import Project="core-setup.common.props" />

--- a/repos/core-setup-portable.proj
+++ b/repos/core-setup-portable.proj
@@ -16,7 +16,7 @@
     <RepositoryReference Include="standard" />
   </ItemGroup>
 
-  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="WriteVersions;EnsurePackagesCreated">
+  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="RemoveBuiltPackagesFromCache">
     <ItemGroup>
       <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
       <DirsToDelete Include="$(ProjectDirectory)bin" Condition="Exists('$(ProjectDirectory)bin')" />

--- a/repos/core-setup-portable.proj
+++ b/repos/core-setup-portable.proj
@@ -86,8 +86,8 @@
 
   <Target Name="GatherBuiltPackages">
     <ItemGroup>
-      <_BuiltPackages Include="$(ShippingPackagesOutput)/*linux*nupkg" />
-      <_BuiltPackages Include="$(NonShippingPackagesOutput)/*linux*nupkg" />
+      <_BuiltPackages Include="$(ShippingPackagesOutput)/*linux*nupkg" Exclude="$(ShippingPackagesOutput)/*.symbols.nupkg" />
+      <_BuiltPackages Include="$(NonShippingPackagesOutput)/*linux*nupkg" Exclude="$(NonShippingPackagesOutput)/*.symbols.nupkg" />
     </ItemGroup>
   </Target>
 </Project>

--- a/repos/core-setup-portable.proj
+++ b/repos/core-setup-portable.proj
@@ -16,7 +16,7 @@
     <RepositoryReference Include="standard" />
   </ItemGroup>
 
-  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="WriteVersionsFile">
+  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="WriteVersions">
     <ItemGroup>
       <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
       <DirsToDelete Include="$(ProjectDirectory)bin" Condition="Exists('$(ProjectDirectory)bin')" />

--- a/repos/core-setup-portable.proj
+++ b/repos/core-setup-portable.proj
@@ -16,7 +16,7 @@
     <RepositoryReference Include="standard" />
   </ItemGroup>
 
-  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="RemoveBuiltPackagesFromCache">
+  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="RemoveBuiltPackagesFromCache;EnsurePackagesCreated">
     <ItemGroup>
       <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
       <DirsToDelete Include="$(ProjectDirectory)bin" Condition="Exists('$(ProjectDirectory)bin')" />

--- a/repos/core-setup-portable.proj
+++ b/repos/core-setup-portable.proj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <SourceDirectory>core-setup</SourceDirectory>
     <PortableBuild>true</PortableBuild>
+    <BuildingPortableRuntime>true</BuildingPortableRuntime>
   </PropertyGroup>
 
   <Import Project="core-setup.common.props" />

--- a/repos/core-setup-portable.proj
+++ b/repos/core-setup-portable.proj
@@ -73,14 +73,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="GatherBuiltPackages">
-    <ItemGroup>
-      <_BuiltPackages Include="$(ShippingPackagesOutput)/*linux*nupkg" />
-      <_BuiltPackages Include="$(NonShippingPackagesOutput)/*linux*nupkg" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="CopyPackage">
+  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="WriteVersionsFile">
     <ItemGroup>
       <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
       <DirsToDelete Include="$(ProjectDirectory)bin" Condition="Exists('$(ProjectDirectory)bin')" />
@@ -90,4 +83,11 @@
   </Target>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
+
+  <Target Name="GatherBuiltPackages">
+    <ItemGroup>
+      <_BuiltPackages Include="$(ShippingPackagesOutput)/*linux*nupkg" />
+      <_BuiltPackages Include="$(NonShippingPackagesOutput)/*linux*nupkg" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/repos/core-setup-portable.proj
+++ b/repos/core-setup-portable.proj
@@ -16,7 +16,7 @@
     <RepositoryReference Include="standard" />
   </ItemGroup>
 
-  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="WriteVersions">
+  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="WriteVersions;EnsurePackagesCreated">
     <ItemGroup>
       <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
       <DirsToDelete Include="$(ProjectDirectory)bin" Condition="Exists('$(ProjectDirectory)bin')" />

--- a/repos/core-setup-portable.proj
+++ b/repos/core-setup-portable.proj
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <SourceDirectory>core-setup</SourceDirectory>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+
+  <PropertyGroup>
+    <BuildArguments>$(FlagParameterPrefix)restore $(FlagParameterPrefix)build</BuildArguments>
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)configuration $(Configuration)</BuildArguments>
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)ci</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:PortableBuild=true</BuildArguments>
+    <BuildArguments Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64'">$(BuildArguments) /p:TargetArchitecture=$(Platform) /p:DisableCrossgen=true /p:CrossBuild=true</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:BuildDebPackage=false</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:BuildAllPackages=true</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:RestoreAllBuildRids=false</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:OutputRid=linux-x64</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:DotNetOutputBlobFeedDir=$(SourceBuiltBlobFeedDir)</BuildArguments>
+    <BuildArguments>$(BuildArguments) /m:1</BuildArguments>
+
+    <LogVerbosityOptOut>true</LogVerbosityOptOut>
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)verbosity $(LogVerbosity)</BuildArguments>
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)binaryLog</BuildArguments>
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)warnAsError $(ArcadeFalseBoolBuildArg)</BuildArguments>
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)nodereuse $(ArcadeFalseBoolBuildArg)</BuildArguments>
+
+    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments)</BuildCommand>
+    <BuildCommand Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64'">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
+
+    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
+    <ShippingPackagesOutput>$(ProjectDirectory)artifacts/packages/$(Configuration)/Shipping/</ShippingPackagesOutput>
+    <NonShippingPackagesOutput>$(ProjectDirectory)artifacts/packages/$(Configuration)/NonShipping/</NonShippingPackagesOutput>
+
+    <NuGetConfigFile>$(ProjectDirectory)/NuGet.config</NuGetConfigFile>
+    <DependencyVersionInputRepoApiImplemented>true</DependencyVersionInputRepoApiImplemented>
+
+    <EnvironmentRestoreSources>$(SourceBuiltPackagesPath)</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources>$(EnvironmentRestoreSources)%3B$(ShippingPackagesOutput)</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources>$(EnvironmentRestoreSources)%3B$(NonShippingPackagesOutput)</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' == 'true'">$(EnvironmentRestoreSources)%3B$(ReferencePackagesDir)%3B$(PrebuiltPackagesPath)</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://api.nuget.org/v3/index.json</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json</EnvironmentRestoreSources>
+
+    <!-- core-setup does not destabilize for intermediate servicing builds -->
+    <IsStable>true</IsStable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <RepositoryReference Include="coreclr" />
+    <RepositoryReference Include="corefx" />
+    <RepositoryReference Include="newtonsoft-json" />
+    <RepositoryReference Include="newtonsoft-json901" />
+    <RepositoryReference Include="roslyn" />
+    <RepositoryReference Include="standard" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
+    <UseSourceBuiltSdkOverride Include="@(ArcadePackagingOverride)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EnvironmentVariables Include="RestoreSources=$(EnvironmentRestoreSources)" />
+    <EnvironmentVariables Include="BuildInParallel=false" />
+  </ItemGroup>
+
+  <Target Name="SetOutputList" AfterTargets="Package" BeforeTargets="GatherBuiltPackages">
+    <ItemGroup>
+      <PackagesOutputList Include="$(ShippingPackagesOutput)" />
+      <PackagesOutputList Include="$(NonShippingPackagesOutput)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GatherBuiltPackages">
+    <ItemGroup>
+      <_BuiltPackages Include="$(ShippingPackagesOutput)/*linux*nupkg" />
+      <_BuiltPackages Include="$(NonShippingPackagesOutput)/*linux*nupkg" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="CopyPackage">
+    <ItemGroup>
+      <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
+      <DirsToDelete Include="$(ProjectDirectory)bin" Condition="Exists('$(ProjectDirectory)bin')" />
+    </ItemGroup>
+
+    <RemoveDir Directories="@(DirsToDelete)" />
+  </Target>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
+</Project>

--- a/repos/core-setup.common.props
+++ b/repos/core-setup.common.props
@@ -7,6 +7,7 @@
     <OverrideTargetRid>$(TargetRid)</OverrideTargetRid>
     <OverrideTargetRid Condition="'$(TargetOS)' == 'OSX'">osx-x64</OverrideTargetRid>
     <OverrideTargetRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-x64</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'Linux' and '$(PortableBuild)' == 'true'">linux-$(Platform)</OverrideTargetRid>
     <OverridePortable>$(PortableBuild)</OverridePortable>
     <OverridePortable Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'FreeBSD'">true</OverridePortable>
 

--- a/repos/core-setup.common.props
+++ b/repos/core-setup.common.props
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+
+  <PropertyGroup>
+    <!-- core-sdk always wants a portable runtime on OSX and FreeBSD-->
+    <OverrideTargetRid>$(TargetRid)</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'OSX'">osx-x64</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-x64</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'Linux' and '$(BuildingPortableRuntime)' == 'true'">linux-$(Platform)</OverrideTargetRid>
+    <OverridePortable>$(PortableBuild)</OverridePortable>
+    <OverridePortable Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'FreeBSD' or '$(BuildingPortableRuntime)' == 'true'">true</OverridePortable>
+
+    <BuildArguments>$(FlagParameterPrefix)restore $(FlagParameterPrefix)build</BuildArguments>
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)configuration $(Configuration)</BuildArguments>
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)ci</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:PortableBuild=$(OverridePortable)</BuildArguments>
+    <BuildArguments Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64'">$(BuildArguments) /p:TargetArchitecture=$(Platform) /p:DisableCrossgen=true /p:CrossBuild=true</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:BuildDebPackage=false</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:BuildAllPackages=true</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:RestoreAllBuildRids=false</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:OutputRid=$(OverrideTargetRid)</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:DotNetOutputBlobFeedDir=$(SourceBuiltBlobFeedDir)</BuildArguments>
+    <BuildArguments>$(BuildArguments) /m:1</BuildArguments>
+
+    <LogVerbosityOptOut>true</LogVerbosityOptOut>
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)verbosity $(LogVerbosity)</BuildArguments>
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)binaryLog</BuildArguments>
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)warnAsError $(ArcadeFalseBoolBuildArg)</BuildArguments>
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)nodereuse $(ArcadeFalseBoolBuildArg)</BuildArguments>
+
+    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments)</BuildCommand>
+    <BuildCommand Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64'">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
+
+    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
+    <ShippingPackagesOutput>$(ProjectDirectory)artifacts/packages/$(Configuration)/Shipping/</ShippingPackagesOutput>
+    <NonShippingPackagesOutput>$(ProjectDirectory)artifacts/packages/$(Configuration)/NonShipping/</NonShippingPackagesOutput>
+
+    <NuGetConfigFile>$(ProjectDirectory)/NuGet.config</NuGetConfigFile>
+    <DependencyVersionInputRepoApiImplemented>true</DependencyVersionInputRepoApiImplemented>
+
+    <EnvironmentRestoreSources>$(SourceBuiltPackagesPath)</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources>$(EnvironmentRestoreSources)%3B$(ShippingPackagesOutput)</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources>$(EnvironmentRestoreSources)%3B$(NonShippingPackagesOutput)</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' == 'true'">$(EnvironmentRestoreSources)%3B$(ReferencePackagesDir)%3B$(PrebuiltPackagesPath)</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://api.nuget.org/v3/index.json</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json</EnvironmentRestoreSources>
+
+    <!-- core-setup does not destabilize for intermediate servicing builds -->
+    <IsStable>true</IsStable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
+    <UseSourceBuiltSdkOverride Include="@(ArcadePackagingOverride)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EnvironmentVariables Include="RestoreSources=$(EnvironmentRestoreSources)" />
+    <EnvironmentVariables Include="BuildInParallel=false" />
+  </ItemGroup>
+
+</Project>

--- a/repos/core-setup.common.props
+++ b/repos/core-setup.common.props
@@ -7,9 +7,10 @@
     <OverrideTargetRid>$(TargetRid)</OverrideTargetRid>
     <OverrideTargetRid Condition="'$(TargetOS)' == 'OSX'">osx-x64</OverrideTargetRid>
     <OverrideTargetRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-x64</OverrideTargetRid>
-    <OverrideTargetRid Condition="'$(TargetOS)' == 'Linux' and '$(PortableBuild)' == 'true'">linux-$(Platform)</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'Linux' and ('$(PortableBuild)' == 'true' or '$(BuildingPortableRuntime)' == 'true')">linux-$(Platform)</OverrideTargetRid>
     <OverridePortable>$(PortableBuild)</OverridePortable>
     <OverridePortable Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'FreeBSD'">true</OverridePortable>
+    <OverridePortable Condition="'$(BuildingPortableRuntime)' == 'true'">true</OverridePortable>
 
     <BuildArguments>$(FlagParameterPrefix)restore $(FlagParameterPrefix)build</BuildArguments>
     <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)configuration $(Configuration)</BuildArguments>

--- a/repos/core-setup.common.props
+++ b/repos/core-setup.common.props
@@ -7,9 +7,8 @@
     <OverrideTargetRid>$(TargetRid)</OverrideTargetRid>
     <OverrideTargetRid Condition="'$(TargetOS)' == 'OSX'">osx-x64</OverrideTargetRid>
     <OverrideTargetRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-x64</OverrideTargetRid>
-    <OverrideTargetRid Condition="'$(TargetOS)' == 'Linux' and '$(BuildingPortableRuntime)' == 'true'">linux-$(Platform)</OverrideTargetRid>
     <OverridePortable>$(PortableBuild)</OverridePortable>
-    <OverridePortable Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'FreeBSD' or '$(BuildingPortableRuntime)' == 'true'">true</OverridePortable>
+    <OverridePortable Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'FreeBSD'">true</OverridePortable>
 
     <BuildArguments>$(FlagParameterPrefix)restore $(FlagParameterPrefix)build</BuildArguments>
     <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)configuration $(Configuration)</BuildArguments>

--- a/repos/core-setup.common.targets
+++ b/repos/core-setup.common.targets
@@ -33,4 +33,11 @@
           Condition="'@(BinariesToCopy)'!=''" />
   </Target>
 
+  <Target Name="SetOutputList" AfterTargets="Package" BeforeTargets="GatherBuiltPackages">
+    <ItemGroup>
+      <PackagesOutputList Include="$(ShippingPackagesOutput)" />
+      <PackagesOutputList Include="$(NonShippingPackagesOutput)" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/repos/core-setup.common.targets
+++ b/repos/core-setup.common.targets
@@ -33,7 +33,7 @@
           Condition="'@(BinariesToCopy)'!=''" />
   </Target>
 
-  <Target Name="SetOutputList" AfterTargets="Package" BeforeTargets="GatherBuiltPackages">
+  <Target Name="SetOutputList" AfterTargets="Package" BeforeTargets="GatherBuiltPackages;CopyPackage">
     <ItemGroup>
       <PackagesOutputList Include="$(ShippingPackagesOutput)" />
       <PackagesOutputList Include="$(NonShippingPackagesOutput)" />

--- a/repos/core-setup.common.targets
+++ b/repos/core-setup.common.targets
@@ -33,7 +33,7 @@
           Condition="'@(BinariesToCopy)'!=''" />
   </Target>
 
-  <Target Name="SetOutputList" AfterTargets="Package">
+  <Target Name="SetOutputList" AfterTargets="RepoBuild">
     <ItemGroup>
       <PackagesOutputList Include="$(ShippingPackagesOutput)" />
       <PackagesOutputList Include="$(NonShippingPackagesOutput)" />

--- a/repos/core-setup.common.targets
+++ b/repos/core-setup.common.targets
@@ -33,7 +33,7 @@
           Condition="'@(BinariesToCopy)'!=''" />
   </Target>
 
-  <Target Name="SetOutputList" AfterTargets="Package" BeforeTargets="GatherBuiltPackages;CopyPackage">
+  <Target Name="SetOutputList" AfterTargets="Package">
     <ItemGroup>
       <PackagesOutputList Include="$(ShippingPackagesOutput)" />
       <PackagesOutputList Include="$(NonShippingPackagesOutput)" />

--- a/repos/core-setup.common.targets
+++ b/repos/core-setup.common.targets
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
+
+  <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="PublishCoreSetupBinaries" />
+
+  <!-- Need to "publish" the tarballs for cli, until cli respects the assets blob -->
+  <Target Name="PublishBinaries" AfterTargets="Package">
+    <ItemGroup>
+      <CoreSetupTarballs Include="$(SourceBuiltAssetsDir)dotnet-runtime-*$(TarBallExtension)" />
+      <CoreSetupTarballs Include="$(SourceBuiltAssetsDir)dotnet-hostfxr-*$(TarBallExtension)" />
+    </ItemGroup>
+    <PublishCoreSetupBinaries Binaries="@(CoreSetupTarballs)"
+                              DestinationFolderTemplate="$(SourceBuiltRuntimeDir){version}/" >
+      <Output TaskParameter="PublishedVersion" PropertyName="PublishedVersion" />
+    </PublishCoreSetupBinaries>
+    <Message Text="Published core-setup binaries version $(PublishedVersion)" Importance="High" />
+  </Target>
+
+  <Target Name="CopyBinariesToBinFolder" AfterTargets="PublishBinaries">
+    <ItemGroup>
+      <_builtRuntimePackages Include="$(SourceBuiltAssetsDir)*.symbols.nupkg" />
+      <_builtRuntimePackages>
+        <TransformedFileName>$([System.String]::Copy('%(FileName)').Replace('symbols', 'nupkg'))</TransformedFileName>
+      </_builtRuntimePackages>
+      <BinariesToCopy Include="$(SourceBuiltAssetsDir)*.*" Exclude="$(SourceBuiltAssetsDir)*.nupkg;$(SourceBuiltAssetsDir)*.requires_nupkg_signing" />
+      <BinariesToCopy Include="@(_builtRuntimePackages->'$(SourceBuiltPackagesPath)%(TransformedFileName)')" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(BinariesToCopy)"
+          DestinationFolder="$(OutputPath)runtime"
+          Condition="'@(BinariesToCopy)'!=''" />
+  </Target>
+
+</Project>

--- a/repos/core-setup.proj
+++ b/repos/core-setup.proj
@@ -57,6 +57,7 @@
     <RepositoryReference Include="newtonsoft-json901" />
     <RepositoryReference Include="roslyn" />
     <RepositoryReference Include="standard" />
+    <RepositoryReference Include="core-setup-portable" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/core-setup.proj
+++ b/repos/core-setup.proj
@@ -57,7 +57,7 @@
     <RepositoryReference Include="newtonsoft-json901" />
     <RepositoryReference Include="roslyn" />
     <RepositoryReference Include="standard" />
-    <RepositoryReference Include="core-setup-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux'" />
+    <RepositoryReference Include="core-setup-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(SkipPortableRuntimeBuild)' != 'true'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/core-setup.proj
+++ b/repos/core-setup.proj
@@ -57,7 +57,7 @@
     <RepositoryReference Include="newtonsoft-json901" />
     <RepositoryReference Include="roslyn" />
     <RepositoryReference Include="standard" />
-    <RepositoryReference Include="core-setup-portable" Condition="'$(PortableBuild)' != 'true'" />
+    <RepositoryReference Include="core-setup-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/core-setup.proj
+++ b/repos/core-setup.proj
@@ -57,7 +57,7 @@
     <RepositoryReference Include="newtonsoft-json901" />
     <RepositoryReference Include="roslyn" />
     <RepositoryReference Include="standard" />
-    <RepositoryReference Include="core-setup-portable" />
+    <RepositoryReference Include="core-setup-portable" Condition="'$(PortableBuild)' != 'true'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/core-setup.proj
+++ b/repos/core-setup.proj
@@ -12,12 +12,6 @@
     <RepositoryReference Include="core-setup-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(SkipPortableRuntimeBuild)' != 'true'" />
   </ItemGroup>
 
-  <Target Name="SetOutputList" AfterTargets="Package" BeforeTargets="GatherBuiltPackages">
-    <ItemGroup>
-      <PackagesOutputList Include="$(ShippingPackagesOutput)" />
-      <PackagesOutputList Include="$(NonShippingPackagesOutput)" />
-    </ItemGroup>
-  </Target>
 
   <Import Project="core-setup.common.targets" />
 

--- a/repos/core-setup.proj
+++ b/repos/core-setup.proj
@@ -12,7 +12,6 @@
     <RepositoryReference Include="core-setup-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(SkipPortableRuntimeBuild)' != 'true'" />
   </ItemGroup>
 
-
   <Import Project="core-setup.common.targets" />
 
 </Project>

--- a/repos/core-setup.proj
+++ b/repos/core-setup.proj
@@ -1,54 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
-
-  <PropertyGroup>
-    <!-- core-sdk always wants a portable runtime on OSX and FreeBSD-->
-    <OverrideTargetRid>$(TargetRid)</OverrideTargetRid>
-    <OverrideTargetRid Condition="'$(TargetOS)' == 'OSX'">osx-x64</OverrideTargetRid>
-    <OverrideTargetRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-x64</OverrideTargetRid>
-    <OverridePortable>$(PortableBuild)</OverridePortable>
-    <OverridePortable Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'FreeBSD'">true</OverridePortable>
-
-    <BuildArguments>$(FlagParameterPrefix)restore $(FlagParameterPrefix)build</BuildArguments>
-    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)configuration $(Configuration)</BuildArguments>
-    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)ci</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:PortableBuild=$(OverridePortable)</BuildArguments>
-    <BuildArguments Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64'">$(BuildArguments) /p:TargetArchitecture=$(Platform) /p:DisableCrossgen=true /p:CrossBuild=true</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:BuildDebPackage=false</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:BuildAllPackages=true</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:RestoreAllBuildRids=false</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:OutputRid=$(OverrideTargetRid)</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:DotNetOutputBlobFeedDir=$(SourceBuiltBlobFeedDir)</BuildArguments>
-    <BuildArguments>$(BuildArguments) /m:1</BuildArguments>
-
-    <LogVerbosityOptOut>true</LogVerbosityOptOut>
-    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)verbosity $(LogVerbosity)</BuildArguments>
-    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)binaryLog</BuildArguments>
-    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)warnAsError $(ArcadeFalseBoolBuildArg)</BuildArguments>
-    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)nodereuse $(ArcadeFalseBoolBuildArg)</BuildArguments>
-
-    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments)</BuildCommand>
-    <BuildCommand Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64'">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
-
-    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
-    <ShippingPackagesOutput>$(ProjectDirectory)artifacts/packages/$(Configuration)/Shipping/</ShippingPackagesOutput>
-    <NonShippingPackagesOutput>$(ProjectDirectory)artifacts/packages/$(Configuration)/NonShipping/</NonShippingPackagesOutput>
-
-    <NuGetConfigFile>$(ProjectDirectory)/NuGet.config</NuGetConfigFile>
-    <DependencyVersionInputRepoApiImplemented>true</DependencyVersionInputRepoApiImplemented>
-
-    <EnvironmentRestoreSources>$(SourceBuiltPackagesPath)</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources>$(EnvironmentRestoreSources)%3B$(ShippingPackagesOutput)</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources>$(EnvironmentRestoreSources)%3B$(NonShippingPackagesOutput)</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' == 'true'">$(EnvironmentRestoreSources)%3B$(ReferencePackagesDir)%3B$(PrebuiltPackagesPath)</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://api.nuget.org/v3/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json</EnvironmentRestoreSources>
-
-    <!-- core-setup does not destabilize for intermediate servicing builds -->
-    <IsStable>true</IsStable>
-  </PropertyGroup>
+  <Import Project="core-setup.common.props" />
 
   <ItemGroup>
     <RepositoryReference Include="coreclr" />
@@ -60,16 +12,6 @@
     <RepositoryReference Include="core-setup-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(SkipPortableRuntimeBuild)' != 'true'" />
   </ItemGroup>
 
-  <ItemGroup>
-    <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
-    <UseSourceBuiltSdkOverride Include="@(ArcadePackagingOverride)" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EnvironmentVariables Include="RestoreSources=$(EnvironmentRestoreSources)" />
-    <EnvironmentVariables Include="BuildInParallel=false" />
-  </ItemGroup>
-
   <Target Name="SetOutputList" AfterTargets="Package" BeforeTargets="GatherBuiltPackages">
     <ItemGroup>
       <PackagesOutputList Include="$(ShippingPackagesOutput)" />
@@ -77,36 +19,6 @@
     </ItemGroup>
   </Target>
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
-
-  <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="PublishCoreSetupBinaries" />
-
-  <!-- Need to "publish" the tarballs for cli, until cli respects the assets blob -->
-  <Target Name="PublishBinaries" AfterTargets="Package">
-    <ItemGroup>
-      <CoreSetupTarballs Include="$(SourceBuiltAssetsDir)dotnet-runtime-*$(TarBallExtension)" />
-      <CoreSetupTarballs Include="$(SourceBuiltAssetsDir)dotnet-hostfxr-*$(TarBallExtension)" />
-    </ItemGroup>
-    <PublishCoreSetupBinaries Binaries="@(CoreSetupTarballs)"
-                              DestinationFolderTemplate="$(SourceBuiltRuntimeDir){version}/" >
-      <Output TaskParameter="PublishedVersion" PropertyName="PublishedVersion" />
-    </PublishCoreSetupBinaries>
-    <Message Text="Published core-setup binaries version $(PublishedVersion)" Importance="High" />
-  </Target>
-
-  <Target Name="CopyBinariesToBinFolder" AfterTargets="PublishBinaries">
-    <ItemGroup>
-      <_builtRuntimePackages Include="$(SourceBuiltAssetsDir)*.symbols.nupkg" />
-      <_builtRuntimePackages>
-        <TransformedFileName>$([System.String]::Copy('%(FileName)').Replace('symbols', 'nupkg'))</TransformedFileName>
-      </_builtRuntimePackages>
-      <BinariesToCopy Include="$(SourceBuiltAssetsDir)*.*" Exclude="$(SourceBuiltAssetsDir)*.nupkg;$(SourceBuiltAssetsDir)*.requires_nupkg_signing" />
-      <BinariesToCopy Include="@(_builtRuntimePackages->'$(SourceBuiltPackagesPath)%(TransformedFileName)')" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(BinariesToCopy)"
-          DestinationFolder="$(OutputPath)runtime"
-          Condition="'@(BinariesToCopy)'!=''" />
-  </Target>
+  <Import Project="core-setup.common.targets" />
 
 </Project>

--- a/repos/coreclr-portable.proj
+++ b/repos/coreclr-portable.proj
@@ -23,7 +23,7 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
 
-  <Target Name="GatherBuiltPackages">
+  <Target Name="GatherBuiltPackages" AfterTargets="Build">
     <ItemGroup>
       <_BuiltPackages Include="$(PackagesOutput)/*linux*nupkg"  Exclude="$(PackagesOutput)/*.symbols.nupkg"/>
     </ItemGroup>

--- a/repos/coreclr-portable.proj
+++ b/repos/coreclr-portable.proj
@@ -23,7 +23,7 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
 
-  <Target Name="GatherBuiltPackages" AfterTargets="Build">
+  <Target Name="GatherBuiltPackages" AfterTargets="Build" BeforeTargets="CopyPackage">
     <ItemGroup>
       <_BuiltPackages Include="$(PackagesOutput)/*linux*nupkg"  Exclude="$(PackagesOutput)/*.symbols.nupkg"/>
     </ItemGroup>

--- a/repos/coreclr-portable.proj
+++ b/repos/coreclr-portable.proj
@@ -43,7 +43,6 @@
   <ItemGroup>
     <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
     <UseSourceBuiltSdkOverride Include="@(ArcadeConfigurationOverride)" />
-    <BuiltSdkPackageOverride Include="@(ILSdkOverride)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/coreclr-portable.proj
+++ b/repos/coreclr-portable.proj
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <SourceDirectory>coreclr</SourceDirectory>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+
+  <PropertyGroup>
+    <BuildArguments>$(Platform) $(Configuration) skiptests</BuildArguments>
+    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) -ignoreWarnings</BuildArguments>
+    <BuildArguments>$(BuildArguments) -skipmanagedtools</BuildArguments>
+    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) -skiprestore</BuildArguments>
+    <BuildArguments Condition="'$(SkipDisablePgo)' != 'true'">$(BuildArguments) -nopgooptimize</BuildArguments>
+    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) msbuildonunsupportedplatform</BuildArguments>
+    <BuildArguments Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64' ">$(BuildArguments) skipnuget cross -skiprestore cmakeargs -DFEATURE_GDBJIT=TRUE</BuildArguments>
+
+    <BuildArguments>$(BuildArguments) /bl</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:ILLinkTrimAssembly=false</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:CheckCDefines=false</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:PackagesDir=$(PackagesDir)</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:ContinuousIntegrationBuild=true</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:VersionSuffix="$(PreReleaseVersionLabel)"</BuildArguments>
+    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) -warnAsError:0</BuildArguments>
+
+    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments)</BuildCommand>
+
+    <BuildCommand Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64' ">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
+
+    <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension)</CleanCommand>
+
+    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
+    <PackagesOutput>$(ProjectDirectory)bin/Product/$(TargetOS).$(Platform).$(Configuration)/.nuget/pkg</PackagesOutput>
+    <NuGetConfigFile>$(ProjectDirectory)/NuGet.config</NuGetConfigFile>
+
+    <EnvironmentRestoreSources>$(SourceBuiltPackagesPath)</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' == 'true'">$(EnvironmentRestoreSources)%3B$(ReferencePackagesDir)%3B$(PrebuiltPackagesPath)</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://api.nuget.org/v3/index.json</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json</EnvironmentRestoreSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
+    <UseSourceBuiltSdkOverride Include="@(ArcadeConfigurationOverride)" />
+    <BuiltSdkPackageOverride Include="@(ILSdkOverride)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <RepositoryReference Include="linker" />
+    <RepositoryReference Include="roslyn" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EnvironmentVariables Include="RestoreSources=$(EnvironmentRestoreSources)" />
+  </ItemGroup>
+
+  <Target Name="GatherBuiltPackages">
+    <ItemGroup>
+      <_BuiltPackages Include="$(PackagesOutput)/*linux*nupkg" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="CopyPackage">
+    <ItemGroup>
+      <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
+      <DirsToDelete Include="$(ProjectDirectory)bin" Condition="Exists('$(ProjectDirectory)bin')" />
+    </ItemGroup>
+
+    <RemoveDir Directories="@(DirsToDelete)" />
+  </Target>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
+</Project>

--- a/repos/coreclr-portable.proj
+++ b/repos/coreclr-portable.proj
@@ -2,8 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <SourceDirectory>coreclr</SourceDirectory>
-    <BuildingPortableRuntime>true</BuildingPortableRuntime>
-    <UseSystemLibraries>false</UseSystemLibraries>
+    <PortableBuild>true</PortableBuild>
   </PropertyGroup>
 
   <Import Project="coreclr.common.props" />

--- a/repos/coreclr-portable.proj
+++ b/repos/coreclr-portable.proj
@@ -12,7 +12,7 @@
     <RepositoryReference Include="roslyn" />
   </ItemGroup>
 
-  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="RemoveBuiltPackagesFromCache;EnsurePackagesCreated">
+  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="RemoveBuiltPackagesFromCache">
     <ItemGroup>
       <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
       <DirsToDelete Include="$(ProjectDirectory)bin" Condition="Exists('$(ProjectDirectory)bin')" />

--- a/repos/coreclr-portable.proj
+++ b/repos/coreclr-portable.proj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <SourceDirectory>coreclr</SourceDirectory>
     <BuildingPortableRuntime>true</BuildingPortableRuntime>
+    <UseSystemLibraries>false</UseSystemLibraries>
   </PropertyGroup>
 
   <Import Project="coreclr.common.props" />

--- a/repos/coreclr-portable.proj
+++ b/repos/coreclr-portable.proj
@@ -12,7 +12,7 @@
     <RepositoryReference Include="roslyn" />
   </ItemGroup>
 
-  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="WriteVersions">
+  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="WriteVersions;EnsurePackagesCreated">
     <ItemGroup>
       <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
       <DirsToDelete Include="$(ProjectDirectory)bin" Condition="Exists('$(ProjectDirectory)bin')" />

--- a/repos/coreclr-portable.proj
+++ b/repos/coreclr-portable.proj
@@ -67,7 +67,7 @@
 
   <Target Name="GatherBuiltPackages">
     <ItemGroup>
-      <_BuiltPackages Include="$(PackagesOutput)/*linux*nupkg" />
+      <_BuiltPackages Include="$(PackagesOutput)/*linux*nupkg"  Exclude="$(PackagesOutput)/*.symbols.nupkg"/>
     </ItemGroup>
   </Target>
 </Project>

--- a/repos/coreclr-portable.proj
+++ b/repos/coreclr-portable.proj
@@ -2,56 +2,14 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <SourceDirectory>coreclr</SourceDirectory>
+    <BuildingPortableRuntime>true</BuildingPortableRuntime>
   </PropertyGroup>
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
-
-  <PropertyGroup>
-    <BuildArguments>$(Platform) $(Configuration) skiptests</BuildArguments>
-    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) -ignoreWarnings</BuildArguments>
-    <BuildArguments>$(BuildArguments) -skipmanagedtools</BuildArguments>
-    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) -skiprestore</BuildArguments>
-    <BuildArguments Condition="'$(SkipDisablePgo)' != 'true'">$(BuildArguments) -nopgooptimize</BuildArguments>
-    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) msbuildonunsupportedplatform</BuildArguments>
-    <BuildArguments Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64' ">$(BuildArguments) skipnuget cross -skiprestore cmakeargs -DFEATURE_GDBJIT=TRUE</BuildArguments>
-
-    <BuildArguments>$(BuildArguments) /bl</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:ILLinkTrimAssembly=false</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:CheckCDefines=false</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:PackagesDir=$(PackagesDir)</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:ContinuousIntegrationBuild=true</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:VersionSuffix="$(PreReleaseVersionLabel)"</BuildArguments>
-    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) -warnAsError:0</BuildArguments>
-
-    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments)</BuildCommand>
-
-    <BuildCommand Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64' ">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
-
-    <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension)</CleanCommand>
-
-    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
-    <PackagesOutput>$(ProjectDirectory)bin/Product/$(TargetOS).$(Platform).$(Configuration)/.nuget/pkg</PackagesOutput>
-    <NuGetConfigFile>$(ProjectDirectory)/NuGet.config</NuGetConfigFile>
-
-    <EnvironmentRestoreSources>$(SourceBuiltPackagesPath)</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' == 'true'">$(EnvironmentRestoreSources)%3B$(ReferencePackagesDir)%3B$(PrebuiltPackagesPath)</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://api.nuget.org/v3/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json</EnvironmentRestoreSources>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
-    <UseSourceBuiltSdkOverride Include="@(ArcadeConfigurationOverride)" />
-  </ItemGroup>
+  <Import Project="coreclr.common.props" />
 
   <ItemGroup>
     <RepositoryReference Include="linker" />
     <RepositoryReference Include="roslyn" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EnvironmentVariables Include="RestoreSources=$(EnvironmentRestoreSources)" />
   </ItemGroup>
 
   <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="WriteVersionsFile">

--- a/repos/coreclr-portable.proj
+++ b/repos/coreclr-portable.proj
@@ -25,7 +25,9 @@
 
   <Target Name="GatherBuiltPackages" AfterTargets="Build" BeforeTargets="CopyPackage">
     <ItemGroup>
-      <_BuiltPackages Include="$(PackagesOutput)/*linux*nupkg"  Exclude="$(PackagesOutput)/*.symbols.nupkg"/>
+      <_BuiltPackages Include="$(PackagesOutput)/*linux*nupkg" Exclude="$(PackagesOutput)/*.symbols.nupkg"/>
+      <AllPackages Include="$(ProjectDirectory)/**/*.nupkg" />
     </ItemGroup>
+    <Message Text="@(AllPackages)" />
   </Target>
 </Project>

--- a/repos/coreclr-portable.proj
+++ b/repos/coreclr-portable.proj
@@ -12,7 +12,7 @@
     <RepositoryReference Include="roslyn" />
   </ItemGroup>
 
-  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="WriteVersionsFile">
+  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="WriteVersions">
     <ItemGroup>
       <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
       <DirsToDelete Include="$(ProjectDirectory)bin" Condition="Exists('$(ProjectDirectory)bin')" />

--- a/repos/coreclr-portable.proj
+++ b/repos/coreclr-portable.proj
@@ -12,7 +12,7 @@
     <RepositoryReference Include="roslyn" />
   </ItemGroup>
 
-  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="RemoveBuiltPackagesFromCache">
+  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="RemoveBuiltPackagesFromCache;EnsurePackagesCreated">
     <ItemGroup>
       <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
       <DirsToDelete Include="$(ProjectDirectory)bin" Condition="Exists('$(ProjectDirectory)bin')" />

--- a/repos/coreclr-portable.proj
+++ b/repos/coreclr-portable.proj
@@ -12,7 +12,7 @@
     <RepositoryReference Include="roslyn" />
   </ItemGroup>
 
-  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="WriteVersions;EnsurePackagesCreated">
+  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="RemoveBuiltPackagesFromCache">
     <ItemGroup>
       <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
       <DirsToDelete Include="$(ProjectDirectory)bin" Condition="Exists('$(ProjectDirectory)bin')" />

--- a/repos/coreclr-portable.proj
+++ b/repos/coreclr-portable.proj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <SourceDirectory>coreclr</SourceDirectory>
     <PortableBuild>true</PortableBuild>
+    <BuildingPortableRuntime>true</BuildingPortableRuntime>
+    <UseSystemLibraries>false</UseSystemLibraries>
   </PropertyGroup>
 
   <Import Project="coreclr.common.props" />
@@ -25,9 +27,8 @@
 
   <Target Name="GatherBuiltPackages" AfterTargets="Build" BeforeTargets="CopyPackage">
     <ItemGroup>
-      <_BuiltPackages Include="$(PackagesOutput)/*linux*nupkg" Exclude="$(PackagesOutput)/*.symbols.nupkg"/>
+      <_BuiltPackages Include="$(PackagesOutput)/*linux*.nupkg" Exclude="$(PackagesOutput)/*.symbols.nupkg"/>
       <AllPackages Include="$(ProjectDirectory)/**/*.nupkg" />
     </ItemGroup>
-    <Message Text="@(AllPackages)" />
   </Target>
 </Project>

--- a/repos/coreclr-portable.proj
+++ b/repos/coreclr-portable.proj
@@ -55,13 +55,7 @@
     <EnvironmentVariables Include="RestoreSources=$(EnvironmentRestoreSources)" />
   </ItemGroup>
 
-  <Target Name="GatherBuiltPackages">
-    <ItemGroup>
-      <_BuiltPackages Include="$(PackagesOutput)/*linux*nupkg" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="CopyPackage">
+  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="WriteVersionsFile">
     <ItemGroup>
       <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
       <DirsToDelete Include="$(ProjectDirectory)bin" Condition="Exists('$(ProjectDirectory)bin')" />
@@ -71,4 +65,10 @@
   </Target>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
+
+  <Target Name="GatherBuiltPackages">
+    <ItemGroup>
+      <_BuiltPackages Include="$(PackagesOutput)/*linux*nupkg" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/repos/coreclr.common.props
+++ b/repos/coreclr.common.props
@@ -9,13 +9,13 @@
     <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) -skiprestore</BuildArguments>
     <BuildArguments Condition="'$(SkipDisablePgo)' != 'true'">$(BuildArguments) -nopgooptimize</BuildArguments>
     <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) msbuildonunsupportedplatform</BuildArguments>
-    <BuildArguments Condition="( '$(UseSystemLibraries)' == 'true' or '$(BuildingPortableRuntime)' == 'true' ) AND '$(OS)' != 'Windows_NT'">$(BuildArguments) cmakeargs -DCLR_CMAKE_USE_SYSTEM_LIBUNWIND=TRUE</BuildArguments>
+    <BuildArguments Condition="'$(UseSystemLibraries)' == 'true' AND '$(OS)' != 'Windows_NT'">$(BuildArguments) cmakeargs -DCLR_CMAKE_USE_SYSTEM_LIBUNWIND=TRUE</BuildArguments>
     <BuildArguments Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64' ">$(BuildArguments) skipnuget cross -skiprestore cmakeargs -DFEATURE_GDBJIT=TRUE</BuildArguments>
     <BuildArguments Condition="'$(TargetOS)' == 'FreeBSD'">$(BuildArguments) -clang6.0 /p:PortableBuild=true</BuildArguments>
 
     <!-- Portable builds only apply to Linux - Mac and Windows are both always portable.
          Additionally, Linux builds are portable by default and only have a switch to turn it off -->
-    <BuildArguments Condition="'$(TargetOS)' == 'Linux' and '$(PortableBuild)' == 'false' and '$(BuildingPortableRuntime)' == 'false'">$(BuildArguments) -PortableBuild=false</BuildArguments>
+    <BuildArguments Condition="'$(TargetOS)' == 'Linux' and '$(PortableBuild)' == 'false'">$(BuildArguments) -PortableBuild=false</BuildArguments>
 
     <BuildArguments>$(BuildArguments) /bl</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:ILLinkTrimAssembly=false</BuildArguments>

--- a/repos/coreclr.common.props
+++ b/repos/coreclr.common.props
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+
+  <PropertyGroup>
+    <BuildArguments>$(Platform) $(Configuration) skiptests</BuildArguments>
+    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) -ignoreWarnings</BuildArguments>
+    <BuildArguments>$(BuildArguments) -skipmanagedtools</BuildArguments>
+    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) -skiprestore</BuildArguments>
+    <BuildArguments Condition="'$(SkipDisablePgo)' != 'true'">$(BuildArguments) -nopgooptimize</BuildArguments>
+    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) msbuildonunsupportedplatform</BuildArguments>
+    <BuildArguments Condition="( '$(UseSystemLibraries)' == 'true' or '$(BuildingPortableRuntime)' == 'true' ) AND '$(OS)' != 'Windows_NT'">$(BuildArguments) cmakeargs -DCLR_CMAKE_USE_SYSTEM_LIBUNWIND=TRUE</BuildArguments>
+    <BuildArguments Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64' ">$(BuildArguments) skipnuget cross -skiprestore cmakeargs -DFEATURE_GDBJIT=TRUE</BuildArguments>
+    <BuildArguments Condition="'$(TargetOS)' == 'FreeBSD'">$(BuildArguments) -clang6.0 /p:PortableBuild=true</BuildArguments>
+
+    <!-- Portable builds only apply to Linux - Mac and Windows are both always portable.
+         Additionally, Linux builds are portable by default and only have a switch to turn it off -->
+    <BuildArguments Condition="'$(TargetOS)' == 'Linux' and ( '$(PortableBuild)' == 'false' and '$(BuildingPortableRuntime)' == 'false' )">$(BuildArguments) -PortableBuild=false</BuildArguments>
+
+    <BuildArguments>$(BuildArguments) /bl</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:ILLinkTrimAssembly=false</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:CheckCDefines=false</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:PackagesDir=$(PackagesDir)</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:ContinuousIntegrationBuild=true</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:VersionSuffix="$(PreReleaseVersionLabel)"</BuildArguments>
+    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) -warnAsError:0</BuildArguments>
+
+    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments)</BuildCommand>
+
+    <BuildCommand Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64' ">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
+
+    <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension)</CleanCommand>
+
+    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
+    <PackagesOutput>$(ProjectDirectory)bin/Product/$(TargetOS).$(Platform).$(Configuration)/.nuget/pkg</PackagesOutput>
+    <NuGetConfigFile>$(ProjectDirectory)/NuGet.config</NuGetConfigFile>
+
+    <EnvironmentRestoreSources>$(SourceBuiltPackagesPath)</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' == 'true'">$(EnvironmentRestoreSources)%3B$(ReferencePackagesDir)%3B$(PrebuiltPackagesPath)</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://api.nuget.org/v3/index.json</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json</EnvironmentRestoreSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
+    <UseSourceBuiltSdkOverride Include="@(ArcadeConfigurationOverride)" />
+    <BuiltSdkPackageOverride Include="@(ILSdkOverride)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EnvironmentVariables Include="RestoreSources=$(EnvironmentRestoreSources)" />
+  </ItemGroup>
+
+</Project>

--- a/repos/coreclr.common.props
+++ b/repos/coreclr.common.props
@@ -15,7 +15,7 @@
 
     <!-- Portable builds only apply to Linux - Mac and Windows are both always portable.
          Additionally, Linux builds are portable by default and only have a switch to turn it off -->
-    <BuildArguments Condition="'$(TargetOS)' == 'Linux' and '$(PortableBuild)' == 'false' and '$(BuildingPortableRuntime)' == 'false'">$(BuildArguments) -PortableBuild=false</BuildArguments>
+    <BuildArguments Condition="'$(TargetOS)' == 'Linux' and '$(PortableBuild)' == 'false' and '$(BuildingPortableRuntime)' != 'true'">$(BuildArguments) -PortableBuild=false</BuildArguments>
 
     <BuildArguments>$(BuildArguments) /bl</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:ILLinkTrimAssembly=false</BuildArguments>

--- a/repos/coreclr.common.props
+++ b/repos/coreclr.common.props
@@ -45,7 +45,6 @@
   <ItemGroup>
     <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
     <UseSourceBuiltSdkOverride Include="@(ArcadeConfigurationOverride)" />
-    <BuiltSdkPackageOverride Include="@(ILSdkOverride)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/coreclr.common.props
+++ b/repos/coreclr.common.props
@@ -15,7 +15,7 @@
 
     <!-- Portable builds only apply to Linux - Mac and Windows are both always portable.
          Additionally, Linux builds are portable by default and only have a switch to turn it off -->
-    <BuildArguments Condition="'$(TargetOS)' == 'Linux' and '$(PortableBuild)' == 'false'">$(BuildArguments) -PortableBuild=false</BuildArguments>
+    <BuildArguments Condition="'$(TargetOS)' == 'Linux' and '$(PortableBuild)' == 'false' and '$(BuildingPortableRuntime)' == 'false'">$(BuildArguments) -PortableBuild=false</BuildArguments>
 
     <BuildArguments>$(BuildArguments) /bl</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:ILLinkTrimAssembly=false</BuildArguments>

--- a/repos/coreclr.common.props
+++ b/repos/coreclr.common.props
@@ -15,7 +15,7 @@
 
     <!-- Portable builds only apply to Linux - Mac and Windows are both always portable.
          Additionally, Linux builds are portable by default and only have a switch to turn it off -->
-    <BuildArguments Condition="'$(TargetOS)' == 'Linux' and ( '$(PortableBuild)' == 'false' and '$(BuildingPortableRuntime)' == 'false' )">$(BuildArguments) -PortableBuild=false</BuildArguments>
+    <BuildArguments Condition="'$(TargetOS)' == 'Linux' and '$(PortableBuild)' == 'false' and '$(BuildingPortableRuntime)' == 'false'">$(BuildArguments) -PortableBuild=false</BuildArguments>
 
     <BuildArguments>$(BuildArguments) /bl</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:ILLinkTrimAssembly=false</BuildArguments>

--- a/repos/coreclr.proj
+++ b/repos/coreclr.proj
@@ -1,61 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
-
-  <PropertyGroup>
-    <BuildArguments>$(Platform) $(Configuration) skiptests</BuildArguments>
-    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) -ignoreWarnings</BuildArguments>
-    <BuildArguments>$(BuildArguments) -skipmanagedtools</BuildArguments>
-    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) -skiprestore</BuildArguments>
-    <BuildArguments Condition="'$(SkipDisablePgo)' != 'true'">$(BuildArguments) -nopgooptimize</BuildArguments>
-    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) msbuildonunsupportedplatform</BuildArguments>
-    <BuildArguments Condition="'$(UseSystemLibraries)' == 'true' AND '$(OS)' != 'Windows_NT'">$(BuildArguments) cmakeargs -DCLR_CMAKE_USE_SYSTEM_LIBUNWIND=TRUE</BuildArguments>
-    <BuildArguments Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64' ">$(BuildArguments) skipnuget cross -skiprestore cmakeargs -DFEATURE_GDBJIT=TRUE</BuildArguments>
-    <BuildArguments Condition="'$(TargetOS)' == 'FreeBSD'">$(BuildArguments) -clang6.0 /p:PortableBuild=true</BuildArguments>
-
-    <!-- Portable builds only apply to Linux - Mac and Windows are both always portable.
-         Additionally, Linux builds are portable by default and only have a switch to turn it off -->
-    <BuildArguments Condition="'$(TargetOS)' == 'Linux' and '$(PortableBuild)' == 'false'">$(BuildArguments) -PortableBuild=false</BuildArguments>
-
-    <BuildArguments>$(BuildArguments) /bl</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:ILLinkTrimAssembly=false</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:CheckCDefines=false</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:PackagesDir=$(PackagesDir)</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:ContinuousIntegrationBuild=true</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:VersionSuffix="$(PreReleaseVersionLabel)"</BuildArguments>
-    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) -warnAsError:0</BuildArguments>
-
-    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments)</BuildCommand>
-
-    <BuildCommand Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64' ">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
-
-    <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension)</CleanCommand>
-
-    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
-    <PackagesOutput>$(ProjectDirectory)bin/Product/$(TargetOS).$(Platform).$(Configuration)/.nuget/pkg</PackagesOutput>
-    <NuGetConfigFile>$(ProjectDirectory)/NuGet.config</NuGetConfigFile>
-
-    <EnvironmentRestoreSources>$(SourceBuiltPackagesPath)</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' == 'true'">$(EnvironmentRestoreSources)%3B$(ReferencePackagesDir)%3B$(PrebuiltPackagesPath)</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://api.nuget.org/v3/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json</EnvironmentRestoreSources>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
-    <UseSourceBuiltSdkOverride Include="@(ArcadeConfigurationOverride)" />
-    <BuiltSdkPackageOverride Include="@(ILSdkOverride)" />
-  </ItemGroup>
+  <Import Project="coreclr.common.props" />
 
   <ItemGroup>
     <RepositoryReference Include="linker" />
     <RepositoryReference Include="roslyn" />
     <RepositoryReference Include="coreclr-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(SkipPortableRuntimeBuild)' != 'true'" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EnvironmentVariables Include="RestoreSources=$(EnvironmentRestoreSources)" />
   </ItemGroup>
 
   <Target Name="CopyTools"

--- a/repos/coreclr.proj
+++ b/repos/coreclr.proj
@@ -51,7 +51,7 @@
   <ItemGroup>
     <RepositoryReference Include="linker" />
     <RepositoryReference Include="roslyn" />
-    <RepositoryReference Include="coreclr-portable" />
+    <RepositoryReference Include="coreclr-portable" Condition="'$(PortableBuild)' != 'true'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/coreclr.proj
+++ b/repos/coreclr.proj
@@ -51,7 +51,7 @@
   <ItemGroup>
     <RepositoryReference Include="linker" />
     <RepositoryReference Include="roslyn" />
-    <RepositoryReference Include="coreclr-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux'" />
+    <RepositoryReference Include="coreclr-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(SkipPortableRuntimeBuild)' != 'true'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/coreclr.proj
+++ b/repos/coreclr.proj
@@ -51,6 +51,7 @@
   <ItemGroup>
     <RepositoryReference Include="linker" />
     <RepositoryReference Include="roslyn" />
+    <RepositoryReference Include="coreclr-portable" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/coreclr.proj
+++ b/repos/coreclr.proj
@@ -8,6 +8,10 @@
     <RepositoryReference Include="coreclr-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(SkipPortableRuntimeBuild)' != 'true'" />
   </ItemGroup>
 
+  <ItemGroup>
+    <BuiltSdkPackageOverride Include="@(ILSdkOverride)" />
+  </ItemGroup>
+
   <Target Name="CopyTools"
           AfterTargets="Package">
     <PropertyGroup>

--- a/repos/coreclr.proj
+++ b/repos/coreclr.proj
@@ -51,7 +51,7 @@
   <ItemGroup>
     <RepositoryReference Include="linker" />
     <RepositoryReference Include="roslyn" />
-    <RepositoryReference Include="coreclr-portable" Condition="'$(PortableBuild)' != 'true'" />
+    <RepositoryReference Include="coreclr-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/corefx-portable.proj
+++ b/repos/corefx-portable.proj
@@ -14,7 +14,7 @@
     <RepositoryReference Include="standard" />
   </ItemGroup>
 
-  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="RemoveBuiltPackagesFromCache;EnsurePackagesCreated">
+  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="RemoveBuiltPackagesFromCache">
     <ItemGroup>
       <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
       <DirsToDelete Include="$(ProjectDirectory)bin" Condition="Exists('$(ProjectDirectory)bin')" />

--- a/repos/corefx-portable.proj
+++ b/repos/corefx-portable.proj
@@ -14,7 +14,7 @@
     <RepositoryReference Include="standard" />
   </ItemGroup>
 
-  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="WriteVersions;EnsurePackagesCreated">
+  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="RemoveBuiltPackagesFromCache">
     <ItemGroup>
       <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
       <DirsToDelete Include="$(ProjectDirectory)bin" Condition="Exists('$(ProjectDirectory)bin')" />

--- a/repos/corefx-portable.proj
+++ b/repos/corefx-portable.proj
@@ -84,14 +84,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="GatherBuiltPackages">
-    <ItemGroup>
-      <_BuiltPackages Include="$(ShippingPackagesOutput)/*linux*nupkg" />
-      <_BuiltPackages Include="$(NonShippingPackagesOutput)/*linux*nupkg" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="CopyPackage">
+  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="WriteVersionsFile">
     <ItemGroup>
       <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
       <DirsToDelete Include="$(ProjectDirectory)bin" Condition="Exists('$(ProjectDirectory)bin')" />
@@ -101,6 +94,13 @@
   </Target>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
+
+  <Target Name="GatherBuiltPackages">
+    <ItemGroup>
+      <_BuiltPackages Include="$(ShippingPackagesOutput)/*linux*nupkg" />
+      <_BuiltPackages Include="$(NonShippingPackagesOutput)/*linux*nupkg" />
+    </ItemGroup>
+  </Target>
 
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="AddRidToRuntimeJson" />
 

--- a/repos/corefx-portable.proj
+++ b/repos/corefx-portable.proj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <SourceDirectory>corefx</SourceDirectory>
-    <BuildingPortableRuntime>true</BuildingPortableRuntime>
+    <PortableBuild>true</PortableBuild>
   </PropertyGroup>
 
   <Import Project="corefx.common.props" />

--- a/repos/corefx-portable.proj
+++ b/repos/corefx-portable.proj
@@ -13,7 +13,7 @@
     <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)restore $(FlagParameterPrefix)build $(FlagParameterPrefix)pack /p:SkipTests=true</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:ArchGroup=$(Platform)</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:ConfigurationGroup=$(Configuration)</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:PackageRid=linux-x64</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:PackageRid=linux-$(Platform)</BuildArguments>
     <!-- CoreFX parses this argument for a OS "family", i.e. rhel.7 to rhel.  OSX doesn't have the extra identifier so we need to include the
          "-x64" so CoreFX can find a character to break on (digits, hyphen, period).  -->
     <BuildArguments Condition="'$(TargetOS)' != 'OSX'">$(BuildArguments) /p:RuntimeOS=linux</BuildArguments>

--- a/repos/corefx-portable.proj
+++ b/repos/corefx-portable.proj
@@ -14,7 +14,7 @@
     <RepositoryReference Include="standard" />
   </ItemGroup>
 
-  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="RemoveBuiltPackagesFromCache">
+  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="RemoveBuiltPackagesFromCache;EnsurePackagesCreated">
     <ItemGroup>
       <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
       <DirsToDelete Include="$(ProjectDirectory)bin" Condition="Exists('$(ProjectDirectory)bin')" />

--- a/repos/corefx-portable.proj
+++ b/repos/corefx-portable.proj
@@ -14,7 +14,7 @@
     <RepositoryReference Include="standard" />
   </ItemGroup>
 
-  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="WriteVersionsFile;EnsurePackagesCreated">
+  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="WriteVersions;EnsurePackagesCreated">
     <ItemGroup>
       <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
       <DirsToDelete Include="$(ProjectDirectory)bin" Condition="Exists('$(ProjectDirectory)bin')" />

--- a/repos/corefx-portable.proj
+++ b/repos/corefx-portable.proj
@@ -2,69 +2,10 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <SourceDirectory>corefx</SourceDirectory>
+    <BuildingPortableRuntime>true</BuildingPortableRuntime>
   </PropertyGroup>
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
-
-  <PropertyGroup>
-    <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
-
-    <BuildArguments>$(FlagParameterPrefix)configuration $(Configuration)</BuildArguments>
-    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)restore $(FlagParameterPrefix)build $(FlagParameterPrefix)pack /p:SkipTests=true</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:ArchGroup=$(Platform)</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:ConfigurationGroup=$(Configuration)</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:PackageRid=linux-$(Platform)</BuildArguments>
-    <!-- CoreFX parses this argument for a OS "family", i.e. rhel.7 to rhel.  OSX doesn't have the extra identifier so we need to include the
-         "-x64" so CoreFX can find a character to break on (digits, hyphen, period).  -->
-    <BuildArguments Condition="'$(TargetOS)' != 'OSX'">$(BuildArguments) /p:RuntimeOS=linux</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:PortableBuild=true</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:ILAsmToolPath=$(ToolPackageExtractDir)coreclr-tools/</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:EnableVSTestReferences=false</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:ILLinkTrimAssembly=false</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:BuildAllPackages=true</BuildArguments>
-    <BuildArguments Condition="'$(OfflineBuild)' != 'true'">$(BuildArguments) /p:DotNetSourceBuildIntermediatePath=$(GeneratedSourcePathOnline)</BuildArguments>
-    <BuildArguments Condition="'$(OfflineBuild)' == 'true'">$(BuildArguments) /p:DotNetSourceBuildIntermediatePath=$(GeneratedSourcePathOffline)</BuildArguments>
-    <BuildArguments Condition="'$(OfflineBuild)' == 'true'">$(BuildArguments) /p:MicrosoftNETCoreDotNetHostPackageVersion=$(DOTNET_HOST_BOOTSTRAP_VERSION)</BuildArguments>
-    <BuildArguments Condition="'$(OfflineBuild)' == 'true'">$(BuildArguments) /p:MicrosoftNETCoreDotNetHostPolicyPackageVersion=$(DOTNET_HOST_BOOTSTRAP_VERSION)</BuildArguments>
-
-    <LogVerbosityOptOut>true</LogVerbosityOptOut>
-    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)verbosity $(LogVerbosity)</BuildArguments>
-    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)binaryLog</BuildArguments>
-    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)ci</BuildArguments>
-    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) -warnAsError:0</BuildArguments>
-
-    <!--
-      Disable node reuse (in the new/Arcade way) to avoid errors like this:
-
-      error MSB4062: The "Microsoft.CodeAnalysis.BuildTasks.Csc" task could not be loaded from the
-      assembly .../build/../tools/Microsoft.Build.Tasks.CodeAnalysis.dll. Assembly with same name
-      is already loaded
-    -->
-    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)nodereuse $(ArcadeFalseBoolBuildArg) $(FlagParameterPrefix)ci</BuildArguments>
-
-    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments)</BuildCommand>
-    <BuildCommand Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64'">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
-
-    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
-    <ShippingPackagesOutput>$(ProjectDirectory)artifacts/packages/$(Configuration)/Shipping/</ShippingPackagesOutput>
-    <NonShippingPackagesOutput>$(ProjectDirectory)artifacts/packages/$(Configuration)/NonShipping/</NonShippingPackagesOutput>
-
-    <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension)</CleanCommand>
-
-    <NuGetConfigFile>$(ProjectDirectory)/NuGet.config</NuGetConfigFile>
-    <EnvironmentRestoreSources>$(SourceBuiltPackagesPath)</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' == 'true'">$(EnvironmentRestoreSources)%3B$(ReferencePackagesDir)%3B$(PrebuiltPackagesPath)</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://api.nuget.org/v3/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json</EnvironmentRestoreSources>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
-    <UseSourceBuiltSdkOverride Include="@(ArcadeConfigurationOverride)" />
-    <UseSourceBuiltSdkOverride Include="@(ArcadeCoreFxTestingOverride)" />
-    <UseSourceBuiltSdkOverride Include="@(ILSdkOverride)" />
-  </ItemGroup>
+  <Import Project="corefx.common.props" />
 
   <ItemGroup>
     <RepositoryReference Include="arcade" />
@@ -72,17 +13,6 @@
     <RepositoryReference Include="coreclr" />
     <RepositoryReference Include="standard" />
   </ItemGroup>
-
-  <ItemGroup>
-    <EnvironmentVariables Include="RestoreSources=$(EnvironmentRestoreSources)" />
-  </ItemGroup>
-
-  <Target Name="SetOutputList" AfterTargets="Package" BeforeTargets="GatherBuiltPackages">
-    <ItemGroup>
-      <PackagesOutputList Include="$(ShippingPackagesOutput)" />
-      <PackagesOutputList Include="$(NonShippingPackagesOutput)" />
-    </ItemGroup>
-  </Target>
 
   <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="WriteVersionsFile">
     <ItemGroup>
@@ -93,27 +23,13 @@
     <RemoveDir Directories="@(DirsToDelete)" />
   </Target>
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
+  <Import Project="corefx.common.targets" />
 
   <Target Name="GatherBuiltPackages">
     <ItemGroup>
       <_BuiltPackages Include="$(ShippingPackagesOutput)/*linux*nupkg" Exclude="$(ShippingPackagesOutput)/*.symbols.nupkg" />
       <_BuiltPackages Include="$(NonShippingPackagesOutput)/*linux*nupkg" Exclude="$(NonShippingPackagesOutput)/*.symbols.nupkg" />
     </ItemGroup>
-  </Target>
-
-  <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="AddRidToRuntimeJson" />
-
-  <Target Name="UpdateRuntimeGraph"
-          BeforeTargets="Build"
-          Condition="'$(_IsBootstrapping)' == 'true'">
-    <PropertyGroup>
-      <RuntimeJsonFile>$(ProjectDirectory)pkg/Microsoft.NETCore.Platforms/runtime.json</RuntimeJsonFile>
-    </PropertyGroup>
-
-    <Message Importance="High" Text="Adding rid, $(TargetRid), to $(RuntimeJsonFile)" />
-    <AddRidToRuntimeJson RuntimeJson="$(RuntimeJsonFile)"
-                         Rid="$(TargetRid)-$(Platform)" />
   </Target>
 
 </Project>

--- a/repos/corefx-portable.proj
+++ b/repos/corefx-portable.proj
@@ -14,7 +14,7 @@
     <RepositoryReference Include="standard" />
   </ItemGroup>
 
-  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="WriteVersionsFile">
+  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="WriteVersionsFile;EnsurePackagesCreated">
     <ItemGroup>
       <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
       <DirsToDelete Include="$(ProjectDirectory)bin" Condition="Exists('$(ProjectDirectory)bin')" />

--- a/repos/corefx-portable.proj
+++ b/repos/corefx-portable.proj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <SourceDirectory>corefx</SourceDirectory>
     <PortableBuild>true</PortableBuild>
+    <BuildingPortableRuntime>true</BuildingPortableRuntime>
   </PropertyGroup>
 
   <Import Project="corefx.common.props" />

--- a/repos/corefx-portable.proj
+++ b/repos/corefx-portable.proj
@@ -25,7 +25,7 @@
 
   <Import Project="corefx.common.targets" />
 
-  <Target Name="GatherBuiltPackages">
+  <Target Name="GatherBuiltPackages" BeforeTargets="CopyPackage">
     <ItemGroup>
       <_BuiltPackages Include="$(ShippingPackagesOutput)/*linux*nupkg" Exclude="$(ShippingPackagesOutput)/*.symbols.nupkg" />
       <_BuiltPackages Include="$(NonShippingPackagesOutput)/*linux*nupkg" Exclude="$(NonShippingPackagesOutput)/*.symbols.nupkg" />

--- a/repos/corefx-portable.proj
+++ b/repos/corefx-portable.proj
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <SourceDirectory>corefx</SourceDirectory>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+
+  <PropertyGroup>
+    <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
+
+    <BuildArguments>$(FlagParameterPrefix)configuration $(Configuration)</BuildArguments>
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)restore $(FlagParameterPrefix)build $(FlagParameterPrefix)pack /p:SkipTests=true</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:ArchGroup=$(Platform)</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:ConfigurationGroup=$(Configuration)</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:PackageRid=linux-x64</BuildArguments>
+    <!-- CoreFX parses this argument for a OS "family", i.e. rhel.7 to rhel.  OSX doesn't have the extra identifier so we need to include the
+         "-x64" so CoreFX can find a character to break on (digits, hyphen, period).  -->
+    <BuildArguments Condition="'$(TargetOS)' != 'OSX'">$(BuildArguments) /p:RuntimeOS=linux</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:PortableBuild=true</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:ILAsmToolPath=$(ToolPackageExtractDir)coreclr-tools/</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:EnableVSTestReferences=false</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:ILLinkTrimAssembly=false</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:BuildAllPackages=true</BuildArguments>
+    <BuildArguments Condition="'$(OfflineBuild)' != 'true'">$(BuildArguments) /p:DotNetSourceBuildIntermediatePath=$(GeneratedSourcePathOnline)</BuildArguments>
+    <BuildArguments Condition="'$(OfflineBuild)' == 'true'">$(BuildArguments) /p:DotNetSourceBuildIntermediatePath=$(GeneratedSourcePathOffline)</BuildArguments>
+    <BuildArguments Condition="'$(OfflineBuild)' == 'true'">$(BuildArguments) /p:MicrosoftNETCoreDotNetHostPackageVersion=$(DOTNET_HOST_BOOTSTRAP_VERSION)</BuildArguments>
+    <BuildArguments Condition="'$(OfflineBuild)' == 'true'">$(BuildArguments) /p:MicrosoftNETCoreDotNetHostPolicyPackageVersion=$(DOTNET_HOST_BOOTSTRAP_VERSION)</BuildArguments>
+
+    <LogVerbosityOptOut>true</LogVerbosityOptOut>
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)verbosity $(LogVerbosity)</BuildArguments>
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)binaryLog</BuildArguments>
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)ci</BuildArguments>
+    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) -warnAsError:0</BuildArguments>
+
+    <!--
+      Disable node reuse (in the new/Arcade way) to avoid errors like this:
+
+      error MSB4062: The "Microsoft.CodeAnalysis.BuildTasks.Csc" task could not be loaded from the
+      assembly .../build/../tools/Microsoft.Build.Tasks.CodeAnalysis.dll. Assembly with same name
+      is already loaded
+    -->
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)nodereuse $(ArcadeFalseBoolBuildArg) $(FlagParameterPrefix)ci</BuildArguments>
+
+    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments)</BuildCommand>
+    <BuildCommand Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64'">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
+
+    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
+    <ShippingPackagesOutput>$(ProjectDirectory)artifacts/packages/$(Configuration)/Shipping/</ShippingPackagesOutput>
+    <NonShippingPackagesOutput>$(ProjectDirectory)artifacts/packages/$(Configuration)/NonShipping/</NonShippingPackagesOutput>
+
+    <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension)</CleanCommand>
+
+    <NuGetConfigFile>$(ProjectDirectory)/NuGet.config</NuGetConfigFile>
+    <EnvironmentRestoreSources>$(SourceBuiltPackagesPath)</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' == 'true'">$(EnvironmentRestoreSources)%3B$(ReferencePackagesDir)%3B$(PrebuiltPackagesPath)</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://api.nuget.org/v3/index.json</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json</EnvironmentRestoreSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
+    <UseSourceBuiltSdkOverride Include="@(ArcadeConfigurationOverride)" />
+    <UseSourceBuiltSdkOverride Include="@(ArcadeCoreFxTestingOverride)" />
+    <UseSourceBuiltSdkOverride Include="@(ILSdkOverride)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <RepositoryReference Include="arcade" />
+    <RepositoryReference Include="linker" />
+    <RepositoryReference Include="coreclr" />
+    <RepositoryReference Include="standard" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EnvironmentVariables Include="RestoreSources=$(EnvironmentRestoreSources)" />
+  </ItemGroup>
+
+  <Target Name="SetOutputList" AfterTargets="Package" BeforeTargets="GatherBuiltPackages">
+    <ItemGroup>
+      <PackagesOutputList Include="$(ShippingPackagesOutput)" />
+      <PackagesOutputList Include="$(NonShippingPackagesOutput)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GatherBuiltPackages">
+    <ItemGroup>
+      <_BuiltPackages Include="$(ShippingPackagesOutput)/*linux*nupkg" />
+      <_BuiltPackages Include="$(NonShippingPackagesOutput)/*linux*nupkg" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="CleanupRepoForNonPortableBuild" AfterTargets="CopyPackage">
+    <ItemGroup>
+      <DirsToDelete Include="$(ProjectDirectory)artifacts" Condition="Exists('$(ProjectDirectory)artifacts')" />
+      <DirsToDelete Include="$(ProjectDirectory)bin" Condition="Exists('$(ProjectDirectory)bin')" />
+    </ItemGroup>
+
+    <RemoveDir Directories="@(DirsToDelete)" />
+  </Target>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
+
+  <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="AddRidToRuntimeJson" />
+
+  <Target Name="UpdateRuntimeGraph"
+          BeforeTargets="Build"
+          Condition="'$(_IsBootstrapping)' == 'true'">
+    <PropertyGroup>
+      <RuntimeJsonFile>$(ProjectDirectory)pkg/Microsoft.NETCore.Platforms/runtime.json</RuntimeJsonFile>
+    </PropertyGroup>
+
+    <Message Importance="High" Text="Adding rid, $(TargetRid), to $(RuntimeJsonFile)" />
+    <AddRidToRuntimeJson RuntimeJson="$(RuntimeJsonFile)"
+                         Rid="$(TargetRid)-$(Platform)" />
+  </Target>
+
+</Project>

--- a/repos/corefx-portable.proj
+++ b/repos/corefx-portable.proj
@@ -97,8 +97,8 @@
 
   <Target Name="GatherBuiltPackages">
     <ItemGroup>
-      <_BuiltPackages Include="$(ShippingPackagesOutput)/*linux*nupkg" />
-      <_BuiltPackages Include="$(NonShippingPackagesOutput)/*linux*nupkg" />
+      <_BuiltPackages Include="$(ShippingPackagesOutput)/*linux*nupkg" Exclude="$(ShippingPackagesOutput)/*.symbols.nupkg" />
+      <_BuiltPackages Include="$(NonShippingPackagesOutput)/*linux*nupkg" Exclude="$(NonShippingPackagesOutput)/*.symbols.nupkg" />
     </ItemGroup>
   </Target>
 

--- a/repos/corefx.common.props
+++ b/repos/corefx.common.props
@@ -7,12 +7,12 @@
 
     <!-- OSX core-setup build always uses the portable RID, so override it -->
     <OverridePortableBuild>$(PortableBuild)</OverridePortableBuild>
-    <OverridePortableBuild Condition="'$(TargetOS)' == 'OSX' OR '$(TargetOS)' == 'Windows_NT' or '$(BuildingPortableRuntime)' == 'true'">true</OverridePortableBuild>
+    <OverridePortableBuild Condition="'$(TargetOS)' == 'OSX' OR '$(TargetOS)' == 'Windows_NT'">true</OverridePortableBuild>
     <OverrideTargetRid>$(TargetRid)</OverrideTargetRid>
     <OverrideTargetRid Condition="'$(TargetOS)' == 'OSX'">osx-x64</OverrideTargetRid>
     <OverrideTargetRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-x64</OverrideTargetRid>
     <OverrideTargetRid Condition="'$(TargetOS)' == 'Windows_NT'">win-x64</OverrideTargetRid>
-    <OverrideTargetRid Condition="'$(TargetOS)' == 'Linux' and '$(BuildingPortableRuntime)' == 'true'">linux-$(Platform)</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'Linux'">linux-$(Platform)</OverrideTargetRid>
 
     <BuildArguments>$(FlagParameterPrefix)configuration $(Configuration)</BuildArguments>
     <BuildArguments Condition="'$(RunTests)' != 'true' AND '$(PrepForTests)' != 'true'">$(BuildArguments) $(FlagParameterPrefix)restore $(FlagParameterPrefix)build $(FlagParameterPrefix)pack /p:SkipTests=true</BuildArguments>

--- a/repos/corefx.common.props
+++ b/repos/corefx.common.props
@@ -8,11 +8,12 @@
     <!-- OSX core-setup build always uses the portable RID, so override it -->
     <OverridePortableBuild>$(PortableBuild)</OverridePortableBuild>
     <OverridePortableBuild Condition="'$(TargetOS)' == 'OSX' OR '$(TargetOS)' == 'Windows_NT'">true</OverridePortableBuild>
+    <OverridePortableBuild Condition="'$(BuildingPortableRuntime)' == 'true'">true</OverridePortableBuild>
     <OverrideTargetRid>$(TargetRid)</OverrideTargetRid>
     <OverrideTargetRid Condition="'$(TargetOS)' == 'OSX'">osx-x64</OverrideTargetRid>
     <OverrideTargetRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-x64</OverrideTargetRid>
     <OverrideTargetRid Condition="'$(TargetOS)' == 'Windows_NT'">win-x64</OverrideTargetRid>
-    <OverrideTargetRid Condition="'$(TargetOS)' == 'Linux' and '$(PortableBuild)' == 'true'">linux-$(Platform)</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'Linux' and ('$(PortableBuild)' == 'true' or '$(BuildingPortableRuntime)' == 'true')">linux-$(Platform)</OverrideTargetRid>
 
     <BuildArguments>$(FlagParameterPrefix)configuration $(Configuration)</BuildArguments>
     <BuildArguments Condition="'$(RunTests)' != 'true' AND '$(PrepForTests)' != 'true'">$(BuildArguments) $(FlagParameterPrefix)restore $(FlagParameterPrefix)build $(FlagParameterPrefix)pack /p:SkipTests=true</BuildArguments>

--- a/repos/corefx.common.props
+++ b/repos/corefx.common.props
@@ -12,7 +12,7 @@
     <OverrideTargetRid Condition="'$(TargetOS)' == 'OSX'">osx-x64</OverrideTargetRid>
     <OverrideTargetRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-x64</OverrideTargetRid>
     <OverrideTargetRid Condition="'$(TargetOS)' == 'Windows_NT'">win-x64</OverrideTargetRid>
-    <OverrideTargetRid Condition="'$(TargetOS)' == 'Linux'">linux-$(Platform)</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'Linux' and '$(PortableBuild)' == 'true'">linux-$(Platform)</OverrideTargetRid>
 
     <BuildArguments>$(FlagParameterPrefix)configuration $(Configuration)</BuildArguments>
     <BuildArguments Condition="'$(RunTests)' != 'true' AND '$(PrepForTests)' != 'true'">$(BuildArguments) $(FlagParameterPrefix)restore $(FlagParameterPrefix)build $(FlagParameterPrefix)pack /p:SkipTests=true</BuildArguments>

--- a/repos/corefx.common.props
+++ b/repos/corefx.common.props
@@ -7,7 +7,7 @@
 
     <!-- OSX core-setup build always uses the portable RID, so override it -->
     <OverridePortableBuild>$(PortableBuild)</OverridePortableBuild>
-    <OverridePortableBuild Condition="'$(TargetOS)' == 'OSX' OR '$(TargetOS)' == 'Windows_NT' or '$(BuildingPortableRuntime) == 'true'">true</OverridePortableBuild>
+    <OverridePortableBuild Condition="'$(TargetOS)' == 'OSX' OR '$(TargetOS)' == 'Windows_NT' or '$(BuildingPortableRuntime)' == 'true'">true</OverridePortableBuild>
     <OverrideTargetRid>$(TargetRid)</OverrideTargetRid>
     <OverrideTargetRid Condition="'$(TargetOS)' == 'OSX'">osx-x64</OverrideTargetRid>
     <OverrideTargetRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-x64</OverrideTargetRid>

--- a/repos/corefx.common.props
+++ b/repos/corefx.common.props
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+
+  <PropertyGroup>
+    <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
+
+    <!-- OSX core-setup build always uses the portable RID, so override it -->
+    <OverridePortableBuild>$(PortableBuild)</OverridePortableBuild>
+    <OverridePortableBuild Condition="'$(TargetOS)' == 'OSX' OR '$(TargetOS)' == 'Windows_NT' or '$(BuildingPortableRuntime) == 'true'">true</OverridePortableBuild>
+    <OverrideTargetRid>$(TargetRid)</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'OSX'">osx-x64</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-x64</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'Windows_NT'">win-x64</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'Linux' and '$(BuildingPortableRuntime) == 'true'">linux-$(Platform)</OverrideTargetRid>
+
+    <BuildArguments>$(FlagParameterPrefix)configuration $(Configuration)</BuildArguments>
+    <BuildArguments Condition="'$(RunTests)' != 'true' AND '$(PrepForTests)' != 'true'">$(BuildArguments) $(FlagParameterPrefix)restore $(FlagParameterPrefix)build $(FlagParameterPrefix)pack /p:SkipTests=true</BuildArguments>
+    <BuildArguments Condition="'$(PrepForTests)' == 'true'">$(BuildArguments) $(FlagParameterPrefix)restore $(FlagParameterPrefix)build /p:IncludeTestUtils=true</BuildArguments>
+    <BuildArguments Condition="'$(RunTests)' == 'true'">$(BuildArguments)  $(FlagParameterPrefix)restore $(FlagParameterPrefix)buildtests $(FlagParameterPrefix)test /p:IncludeTestUtils=true</BuildArguments>
+    <BuildArguments Condition="'$(RunTests)' == 'true' AND '$(DotNetRunningInDocker)' == '1' AND '$(TargetOS)' == 'Linux'">$(BuildArguments) /p:TestRspFile=$(TestExclusionsDir)corefx/linux.docker.rsp</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:ArchGroup=$(Platform)</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:ConfigurationGroup=$(Configuration)</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:PackageRid=$(OverrideTargetRid)</BuildArguments>
+    <!-- CoreFX parses this argument for a OS "family", i.e. rhel.7 to rhel.  OSX doesn't have the extra identifier so we need to include the
+         "-x64" so CoreFX can find a character to break on (digits, hyphen, period).  -->
+    <BuildArguments Condition="'$(TargetOS)' != 'OSX'">$(BuildArguments) /p:RuntimeOS=$(OverrideTargetRid.Substring(0, $(OverrideTargetRid.IndexOf("-"))))</BuildArguments>
+    <BuildArguments Condition="'$(TargetOS)' == 'OSX'">$(BuildArguments) /p:RuntimeOS=$(OverrideTargetRid)</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:PortableBuild=$(OverridePortableBuild)</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:ILAsmToolPath=$(ToolPackageExtractDir)coreclr-tools/</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:EnableVSTestReferences=false</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:ILLinkTrimAssembly=false</BuildArguments>
+    <BuildArguments>$(BuildArguments) /p:BuildAllPackages=true</BuildArguments>
+    <BuildArguments Condition="'$(OfflineBuild)' != 'true'">$(BuildArguments) /p:DotNetSourceBuildIntermediatePath=$(GeneratedSourcePathOnline)</BuildArguments>
+    <BuildArguments Condition="'$(OfflineBuild)' == 'true'">$(BuildArguments) /p:DotNetSourceBuildIntermediatePath=$(GeneratedSourcePathOffline)</BuildArguments>
+    <BuildArguments Condition="'$(OfflineBuild)' == 'true'">$(BuildArguments) /p:MicrosoftNETCoreDotNetHostPackageVersion=$(DOTNET_HOST_BOOTSTRAP_VERSION)</BuildArguments>
+    <BuildArguments Condition="'$(OfflineBuild)' == 'true'">$(BuildArguments) /p:MicrosoftNETCoreDotNetHostPolicyPackageVersion=$(DOTNET_HOST_BOOTSTRAP_VERSION)</BuildArguments>
+
+    <LogVerbosityOptOut>true</LogVerbosityOptOut>
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)verbosity $(LogVerbosity)</BuildArguments>
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)binaryLog</BuildArguments>
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)ci</BuildArguments>
+    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) -warnAsError:0</BuildArguments>
+
+    <!--
+      Disable node reuse (in the new/Arcade way) to avoid errors like this:
+
+      error MSB4062: The "Microsoft.CodeAnalysis.BuildTasks.Csc" task could not be loaded from the
+      assembly .../build/../tools/Microsoft.Build.Tasks.CodeAnalysis.dll. Assembly with same name
+      is already loaded
+    -->
+    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)nodereuse $(ArcadeFalseBoolBuildArg) $(FlagParameterPrefix)ci</BuildArguments>
+
+    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments)</BuildCommand>
+    <BuildCommand Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64'">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
+
+    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
+    <ShippingPackagesOutput>$(ProjectDirectory)artifacts/packages/$(Configuration)/Shipping/</ShippingPackagesOutput>
+    <NonShippingPackagesOutput>$(ProjectDirectory)artifacts/packages/$(Configuration)/NonShipping/</NonShippingPackagesOutput>
+
+    <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension)</CleanCommand>
+
+    <NuGetConfigFile>$(ProjectDirectory)/NuGet.config</NuGetConfigFile>
+    <EnvironmentRestoreSources>$(SourceBuiltPackagesPath)</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' == 'true'">$(EnvironmentRestoreSources)%3B$(ReferencePackagesDir)%3B$(PrebuiltPackagesPath)</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://api.nuget.org/v3/index.json</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json</EnvironmentRestoreSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
+    <UseSourceBuiltSdkOverride Include="@(ArcadeConfigurationOverride)" />
+    <UseSourceBuiltSdkOverride Include="@(ArcadeCoreFxTestingOverride)" />
+    <UseSourceBuiltSdkOverride Include="@(ILSdkOverride)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EnvironmentVariables Include="RestoreSources=$(EnvironmentRestoreSources)" />
+  </ItemGroup>
+
+</Project>

--- a/repos/corefx.common.props
+++ b/repos/corefx.common.props
@@ -12,7 +12,7 @@
     <OverrideTargetRid Condition="'$(TargetOS)' == 'OSX'">osx-x64</OverrideTargetRid>
     <OverrideTargetRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-x64</OverrideTargetRid>
     <OverrideTargetRid Condition="'$(TargetOS)' == 'Windows_NT'">win-x64</OverrideTargetRid>
-    <OverrideTargetRid Condition="'$(TargetOS)' == 'Linux' and '$(BuildingPortableRuntime) == 'true'">linux-$(Platform)</OverrideTargetRid>
+    <OverrideTargetRid Condition="'$(TargetOS)' == 'Linux' and '$(BuildingPortableRuntime)' == 'true'">linux-$(Platform)</OverrideTargetRid>
 
     <BuildArguments>$(FlagParameterPrefix)configuration $(Configuration)</BuildArguments>
     <BuildArguments Condition="'$(RunTests)' != 'true' AND '$(PrepForTests)' != 'true'">$(BuildArguments) $(FlagParameterPrefix)restore $(FlagParameterPrefix)build $(FlagParameterPrefix)pack /p:SkipTests=true</BuildArguments>

--- a/repos/corefx.common.targets
+++ b/repos/corefx.common.targets
@@ -12,7 +12,7 @@
                          Rid="$(OverrideTargetRid)" />
   </Target>
 
-  <Target Name="SetOutputList" AfterTargets="Package" BeforeTargets="GatherBuiltPackages">
+  <Target Name="SetOutputList" AfterTargets="Package" BeforeTargets="GatherBuiltPackages;CopyPackage">
     <ItemGroup>
       <PackagesOutputList Include="$(ShippingPackagesOutput)" />
       <PackagesOutputList Include="$(NonShippingPackagesOutput)" />

--- a/repos/corefx.common.targets
+++ b/repos/corefx.common.targets
@@ -12,5 +12,12 @@
                          Rid="$(TargetRid)-$(Platform)" />
   </Target>
 
+  <Target Name="SetOutputList" AfterTargets="Package" BeforeTargets="GatherBuiltPackages">
+    <ItemGroup>
+      <PackagesOutputList Include="$(ShippingPackagesOutput)" />
+      <PackagesOutputList Include="$(NonShippingPackagesOutput)" />
+    </ItemGroup>
+  </Target>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
 </Project>

--- a/repos/corefx.common.targets
+++ b/repos/corefx.common.targets
@@ -9,7 +9,7 @@
 
     <Message Importance="High" Text="Adding rid, $(TargetRid), to $(RuntimeJsonFile)" />
     <AddRidToRuntimeJson RuntimeJson="$(RuntimeJsonFile)"
-                         Rid="$(TargetRid)-$(Platform)" />
+                         Rid="$(OverrideTargetRid)" />
   </Target>
 
   <Target Name="SetOutputList" AfterTargets="Package" BeforeTargets="GatherBuiltPackages">

--- a/repos/corefx.common.targets
+++ b/repos/corefx.common.targets
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="UpdateRuntimeGraph"
+          BeforeTargets="Build"
+          Condition="'$(_IsBootstrapping)' == 'true'">
+    <PropertyGroup>
+      <RuntimeJsonFile>$(ProjectDirectory)pkg/Microsoft.NETCore.Platforms/runtime.json</RuntimeJsonFile>
+    </PropertyGroup>
+
+    <Message Importance="High" Text="Adding rid, $(TargetRid), to $(RuntimeJsonFile)" />
+    <AddRidToRuntimeJson RuntimeJson="$(RuntimeJsonFile)"
+                         Rid="$(TargetRid)-$(Platform)" />
+  </Target>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
+</Project>

--- a/repos/corefx.proj
+++ b/repos/corefx.proj
@@ -1,78 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
-
-  <PropertyGroup>
-    <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
-
-    <!-- OSX core-setup build always uses the portable RID, so override it -->
-    <OverridePortableBuild>$(PortableBuild)</OverridePortableBuild>
-    <OverridePortableBuild Condition="'$(TargetOS)' == 'OSX' OR '$(TargetOS)' == 'Windows_NT'">true</OverridePortableBuild>
-    <OverrideTargetRid>$(TargetRid)</OverrideTargetRid>
-    <OverrideTargetRid Condition="'$(TargetOS)' == 'OSX'">osx-x64</OverrideTargetRid>
-    <OverrideTargetRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-x64</OverrideTargetRid>
-    <OverrideTargetRid Condition="'$(TargetOS)' == 'Windows_NT'">win-x64</OverrideTargetRid>
-
-    <BuildArguments>$(FlagParameterPrefix)configuration $(Configuration)</BuildArguments>
-    <BuildArguments Condition="'$(RunTests)' != 'true' AND '$(PrepForTests)' != 'true'">$(BuildArguments) $(FlagParameterPrefix)restore $(FlagParameterPrefix)build $(FlagParameterPrefix)pack /p:SkipTests=true</BuildArguments>
-    <BuildArguments Condition="'$(PrepForTests)' == 'true'">$(BuildArguments) $(FlagParameterPrefix)restore $(FlagParameterPrefix)build /p:IncludeTestUtils=true</BuildArguments>
-    <BuildArguments Condition="'$(RunTests)' == 'true'">$(BuildArguments)  $(FlagParameterPrefix)restore $(FlagParameterPrefix)buildtests $(FlagParameterPrefix)test /p:IncludeTestUtils=true</BuildArguments>
-    <BuildArguments Condition="'$(RunTests)' == 'true' AND '$(DotNetRunningInDocker)' == '1' AND '$(TargetOS)' == 'Linux'">$(BuildArguments) /p:TestRspFile=$(TestExclusionsDir)corefx/linux.docker.rsp</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:ArchGroup=$(Platform)</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:ConfigurationGroup=$(Configuration)</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:PackageRid=$(OverrideTargetRid)</BuildArguments>
-    <!-- CoreFX parses this argument for a OS "family", i.e. rhel.7 to rhel.  OSX doesn't have the extra identifier so we need to include the
-         "-x64" so CoreFX can find a character to break on (digits, hyphen, period).  -->
-    <BuildArguments Condition="'$(TargetOS)' != 'OSX'">$(BuildArguments) /p:RuntimeOS=$(OverrideTargetRid.Substring(0, $(OverrideTargetRid.IndexOf("-"))))</BuildArguments>
-    <BuildArguments Condition="'$(TargetOS)' == 'OSX'">$(BuildArguments) /p:RuntimeOS=$(OverrideTargetRid)</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:PortableBuild=$(OverridePortableBuild)</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:ILAsmToolPath=$(ToolPackageExtractDir)coreclr-tools/</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:EnableVSTestReferences=false</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:ILLinkTrimAssembly=false</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:BuildAllPackages=true</BuildArguments>
-    <BuildArguments Condition="'$(OfflineBuild)' != 'true'">$(BuildArguments) /p:DotNetSourceBuildIntermediatePath=$(GeneratedSourcePathOnline)</BuildArguments>
-    <BuildArguments Condition="'$(OfflineBuild)' == 'true'">$(BuildArguments) /p:DotNetSourceBuildIntermediatePath=$(GeneratedSourcePathOffline)</BuildArguments>
-    <BuildArguments Condition="'$(OfflineBuild)' == 'true'">$(BuildArguments) /p:MicrosoftNETCoreDotNetHostPackageVersion=$(DOTNET_HOST_BOOTSTRAP_VERSION)</BuildArguments>
-    <BuildArguments Condition="'$(OfflineBuild)' == 'true'">$(BuildArguments) /p:MicrosoftNETCoreDotNetHostPolicyPackageVersion=$(DOTNET_HOST_BOOTSTRAP_VERSION)</BuildArguments>
-
-    <LogVerbosityOptOut>true</LogVerbosityOptOut>
-    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)verbosity $(LogVerbosity)</BuildArguments>
-    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)binaryLog</BuildArguments>
-    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)ci</BuildArguments>
-    <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) -warnAsError:0</BuildArguments>
-
-    <!--
-      Disable node reuse (in the new/Arcade way) to avoid errors like this:
-
-      error MSB4062: The "Microsoft.CodeAnalysis.BuildTasks.Csc" task could not be loaded from the
-      assembly .../build/../tools/Microsoft.Build.Tasks.CodeAnalysis.dll. Assembly with same name
-      is already loaded
-    -->
-    <BuildArguments>$(BuildArguments) $(FlagParameterPrefix)nodereuse $(ArcadeFalseBoolBuildArg) $(FlagParameterPrefix)ci</BuildArguments>
-
-    <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments)</BuildCommand>
-    <BuildCommand Condition="$(Platform.Contains('arm')) AND '$(BuildArchitecture)' != 'arm64'">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
-
-    <OutputPlacementRepoApiImplemented>false</OutputPlacementRepoApiImplemented>
-    <ShippingPackagesOutput>$(ProjectDirectory)artifacts/packages/$(Configuration)/Shipping/</ShippingPackagesOutput>
-    <NonShippingPackagesOutput>$(ProjectDirectory)artifacts/packages/$(Configuration)/NonShipping/</NonShippingPackagesOutput>
-
-    <CleanCommand>$(ProjectDirectory)/clean$(ShellExtension)</CleanCommand>
-
-    <NuGetConfigFile>$(ProjectDirectory)/NuGet.config</NuGetConfigFile>
-    <EnvironmentRestoreSources>$(SourceBuiltPackagesPath)</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' == 'true'">$(EnvironmentRestoreSources)%3B$(ReferencePackagesDir)%3B$(PrebuiltPackagesPath)</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://api.nuget.org/v3/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json</EnvironmentRestoreSources>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
-    <UseSourceBuiltSdkOverride Include="@(ArcadeConfigurationOverride)" />
-    <UseSourceBuiltSdkOverride Include="@(ArcadeCoreFxTestingOverride)" />
-    <UseSourceBuiltSdkOverride Include="@(ILSdkOverride)" />
-  </ItemGroup>
+  <Import Project="corefx.common.props" />
 
   <ItemGroup Condition="'$(RunTests)' != 'true' AND '$(PrepForTests)' != 'true'">
     <RepositoryReference Include="arcade" />
@@ -82,10 +10,6 @@
     <RepositoryReference Include="corefx-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(SkipPortableRuntimeBuild)' != 'true'" />
   </ItemGroup>
 
-  <ItemGroup>
-    <EnvironmentVariables Include="RestoreSources=$(EnvironmentRestoreSources)" />
-  </ItemGroup>
-
   <Target Name="SetOutputList" AfterTargets="Package" BeforeTargets="GatherBuiltPackages">
     <ItemGroup>
       <PackagesOutputList Include="$(ShippingPackagesOutput)" />
@@ -93,20 +17,6 @@
     </ItemGroup>
   </Target>
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
-
-  <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="AddRidToRuntimeJson" />
-
-  <Target Name="UpdateRuntimeGraph"
-          BeforeTargets="Build"
-          Condition="'$(_IsBootstrapping)' == 'true'">
-    <PropertyGroup>
-      <RuntimeJsonFile>$(ProjectDirectory)pkg/Microsoft.NETCore.Platforms/runtime.json</RuntimeJsonFile>
-    </PropertyGroup>
-
-    <Message Importance="High" Text="Adding rid, $(TargetRid), to $(RuntimeJsonFile)" />
-    <AddRidToRuntimeJson RuntimeJson="$(RuntimeJsonFile)"
-                         Rid="$(TargetRid)-$(Platform)" />
-  </Target>
+  <Import Project="corefx.common.targets" />
 
 </Project>

--- a/repos/corefx.proj
+++ b/repos/corefx.proj
@@ -79,6 +79,7 @@
     <RepositoryReference Include="linker" />
     <RepositoryReference Include="coreclr" />
     <RepositoryReference Include="standard" />
+    <RepositoryReference Include="corefx-portable" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/corefx.proj
+++ b/repos/corefx.proj
@@ -79,7 +79,7 @@
     <RepositoryReference Include="linker" />
     <RepositoryReference Include="coreclr" />
     <RepositoryReference Include="standard" />
-    <RepositoryReference Include="corefx-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux'" />
+    <RepositoryReference Include="corefx-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(SkipPortableRuntimeBuild)' != 'true'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/corefx.proj
+++ b/repos/corefx.proj
@@ -10,13 +10,6 @@
     <RepositoryReference Include="corefx-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(SkipPortableRuntimeBuild)' != 'true'" />
   </ItemGroup>
 
-  <Target Name="SetOutputList" AfterTargets="Package" BeforeTargets="GatherBuiltPackages">
-    <ItemGroup>
-      <PackagesOutputList Include="$(ShippingPackagesOutput)" />
-      <PackagesOutputList Include="$(NonShippingPackagesOutput)" />
-    </ItemGroup>
-  </Target>
-
   <Import Project="corefx.common.targets" />
 
 </Project>

--- a/repos/corefx.proj
+++ b/repos/corefx.proj
@@ -79,7 +79,7 @@
     <RepositoryReference Include="linker" />
     <RepositoryReference Include="coreclr" />
     <RepositoryReference Include="standard" />
-    <RepositoryReference Include="corefx-portable" Condition="'$(PortableBuild)' != 'true'" />
+    <RepositoryReference Include="corefx-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/corefx.proj
+++ b/repos/corefx.proj
@@ -79,7 +79,7 @@
     <RepositoryReference Include="linker" />
     <RepositoryReference Include="coreclr" />
     <RepositoryReference Include="standard" />
-    <RepositoryReference Include="corefx-portable" />
+    <RepositoryReference Include="corefx-portable" Condition="'$(PortableBuild)' != 'true'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/known-good.proj
+++ b/repos/known-good.proj
@@ -48,7 +48,7 @@
         <RepositoryReference Include="nuget-client" />
         <RepositoryReference Include="websdk" />
         <RepositoryReference Include="coreclr" />
-        <RepositoryReference Include="coreclr-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux'" />
+        <RepositoryReference Include="coreclr-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(SkipPortableRuntimeBuild)' != 'true'" />
 
         <RepositoryReference Include="templating" />
 
@@ -56,12 +56,12 @@
 
         <RepositoryReference Include="aspnet-extensions" />
         <RepositoryReference Include="corefx" />
-        <RepositoryReference Include="corefx-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux'" />
+        <RepositoryReference Include="corefx-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(SkipPortableRuntimeBuild)' != 'true'" />
 
         <!-- Tier 4 -->
 
         <RepositoryReference Include="core-setup" />
-        <RepositoryReference Include="core-setup-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux'" />
+        <RepositoryReference Include="core-setup-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(SkipPortableRuntimeBuild)' != 'true'" />
 
         <!-- Tier 5 -->
 

--- a/repos/known-good.proj
+++ b/repos/known-good.proj
@@ -48,6 +48,7 @@
         <RepositoryReference Include="nuget-client" />
         <RepositoryReference Include="websdk" />
         <RepositoryReference Include="coreclr" />
+        <RepositoryReference Include="coreclr-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux'" />
 
         <RepositoryReference Include="templating" />
 
@@ -55,10 +56,12 @@
 
         <RepositoryReference Include="aspnet-extensions" />
         <RepositoryReference Include="corefx" />
+        <RepositoryReference Include="corefx-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux'" />
 
         <!-- Tier 4 -->
 
         <RepositoryReference Include="core-setup" />
+        <RepositoryReference Include="core-setup-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux'" />
 
         <!-- Tier 5 -->
 


### PR DESCRIPTION
This allows somebody to build source-build and create portable projects offline in addition to non-portable.  It also makes life easier for bootstrapping, as the portable bits serve as a fallback for all RIDs.

- Copy `coreclr.proj`, `corefx.proj`, and `core-setup.proj` to create additional portable versions that are included as references in the non-portable Linux builds.  These are just always forced to portable.
- Add extra entries to Version.Details.xml.  These don't create extra source directories because the repo URLs are the same for both entries, so we build the portable versions first, copy any packages with `linux` in the name, then delete `artifacts` and `bin` folders, which seems to work reasonably well to reset the repo.
