### PR TITLE
Allow user to skip downloading the previously-source-built packages and supply their own.

### DIFF
--- a/.vsts.pipelines/jobs/ci-linux.yml
+++ b/.vsts.pipelines/jobs/ci-linux.yml
@@ -201,7 +201,7 @@ jobs:
       if [ "$(reportPrebuiltLeaks)" = "true" ]; then
         poisonArg="/p:EnablePoison=true"
       fi
-      $(docker.run) $(docker.tb.map) $(docker.tb.work) $networkArg $(imageName) "$(tarballName)/build.sh" \
+      $(docker.run) $(docker.tb.map) $(docker.tb.work) $networkArg $(imageName) "$(tarballName)/build.sh" -- \
         /p:Configuration=$(sb.configuration) \
         /p:PortableBuild=$(sb.portable) \
         /p:FailOnPrebuiltBaselineError=true \

--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -285,7 +285,7 @@ cp -r $SCRIPT_ROOT/bin/obj/$targetArchitecture/Release/reference-packages/source
 cp -r $SCRIPT_ROOT/bin/obj/$targetArchitecture/Release/reference-packages/staging $TARBALL_ROOT/packages/reference/staging
 
 # Copy tarballs to ./packages/archive directory
-if [ -d "$SCRIPT_ROOT/bin/obj/$targetArchitecture/Release/external-tarballs" && ! -z "$(find \"$SCRIPT_ROOT/bin/obj/$targetArchitecture/Release/external-tarballs\" -iname '*.tar.gz')" ]; then
+if [[ -d "$SCRIPT_ROOT/bin/obj/$targetArchitecture/Release/external-tarballs" && ! -z "$(find $SCRIPT_ROOT/bin/obj/$targetArchitecture/Release/external-tarballs -iname '*.tar.gz')" ]]; then
     mkdir -p $TARBALL_ROOT/packages/archive
     cp -r $SCRIPT_ROOT/bin/obj/$targetArchitecture/Release/external-tarballs/*.tar.gz $TARBALL_ROOT/packages/archive/
 fi

--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -273,8 +273,10 @@ cp -r $SCRIPT_ROOT/bin/obj/$targetArchitecture/Release/reference-packages/source
 cp -r $SCRIPT_ROOT/bin/obj/$targetArchitecture/Release/reference-packages/staging $TARBALL_ROOT/packages/reference/staging
 
 # Copy tarballs to ./packages/archive directory
-mkdir -p $TARBALL_ROOT/packages/archive
-cp -r $SCRIPT_ROOT/bin/obj/$targetArchitecture/Release/external-tarballs/*.tar.gz $TARBALL_ROOT/packages/archive/
+if [ -d "$SCRIPT_ROOT/bin/obj/$targetArchitecture/Release/external-tarballs" && ! -z "$(find \"$SCRIPT_ROOT/bin/obj/$targetArchitecture/Release/external-tarballs\" -iname '*.tar.gz')" ]; then
+    mkdir -p $TARBALL_ROOT/packages/archive
+    cp -r $SCRIPT_ROOT/bin/obj/$targetArchitecture/Release/external-tarballs/*.tar.gz $TARBALL_ROOT/packages/archive/
+fi
 
 # Copy generated source from bin to src/generatedSrc
 cp -r $SCRIPT_ROOT/bin/obj/$targetArchitecture/Release/generatedSrc $TARBALL_ROOT/src/generatedSrc

--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -151,7 +151,7 @@ if [ $SKIP_BUILD -ne 1 ]; then
     fi
 
     $SCRIPT_ROOT/clean.sh
-    $SCRIPT_ROOT/build.sh  ${MAIN_BUILD_ARGUMENTS[@]} "$@"
+    $SCRIPT_ROOT/build.sh  ${MAIN_BUILD_ARGS[@]} "$@"
 fi
 
 mkdir -p "$TARBALL_ROOT"

--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -81,6 +81,7 @@ while :; do
                 echo "Custom reference packages directory '$CUSTOM_REF_PACKAGES_DIR' does not exist"
                 exit 1
             fi
+            MAIN_BUILD_ARGS+=( "/p:SkipDownloadingReferencePackages=true" )
             shift
             ;;
         --with-packages)
@@ -89,6 +90,7 @@ while :; do
                 echo "Custom reference packages directory '$CUSTOM_PREVIOUSLY_BUILT_PACKAGES_DIR' does not exist"
                 exit 1
             fi
+            MAIN_BUILD_ARGS+=( "/p:SkipDownloadingPreviouslySourceBuiltPackages=true" )
             shift
             ;;
         --)
@@ -109,10 +111,6 @@ while :; do
 
     shift
 done
-
-if [[ -d "$CUSTOM_REF_PACKAGES_DIR" && -d "$CUSTOM_PREVIOUSLY_BUILT_PACKAGES_DIR" ]]; then
-    MAIN_BUILD_ARGS+=( "/p:SkipDownloadingPreviouslyBuiltArtifacts=true" )
-fi
 
 if [ $MINIMIZE_DISK_USAGE -eq 1 ]; then
     echo "WARNING"

--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -8,7 +8,6 @@ usage() {
     echo "  --skip-build                       assume we have already built (requires you have built with the /p:ArchiveDownloadedPackages=true flag)"
     echo "  --enable-leak-detection            build leaked-binary detection tasts for later use while building from this tarball"
     echo "  --skip-prebuilt-check              do not confirm that all prebuilt packages used are either reference packages, previously-built, or known extras"
-    echo "  --assume-no-prebuilts              assume that no prebuilts are necessary and reference packages and a previously-built set of packages will be provided when building the tarball.  implies --skip-prebuilt-check, makes --with-ref-packages and --with-packages redundant"
     echo "  --with-ref-packages <dir>          use the specified directory of available reference packages to determine what prebuilts to delete, instead of downloading the most recent version"
     echo "  --with-packages <dir>              use the specified directory of available previously-built packages to determine what prebuilts to delete, instead of downloading the most recent version"
     echo "use -- to send the remaining arguments to build.sh"
@@ -52,7 +51,6 @@ SKIP_BUILD=0
 INCLUDE_LEAK_DETECTION=0
 MINIMIZE_DISK_USAGE=0
 SKIP_PREBUILT_ENFORCEMENT=0
-DELETE_ALL_PREBUILTS=0
 CUSTOM_REF_PACKAGES_DIR=''
 CUSTOM_PREVIOUSLY_BUILT_PACKAGES_DIR=''
 MAIN_BUILD_ARGS=("/p:ArchiveDownloadedPackages=true")
@@ -76,11 +74,6 @@ while :; do
             ;;
         --skip-prebuilt-check)
             SKIP_PREBUILT_ENFORCEMENT=1
-            ;;
-        --assume-no-prebuilts)
-            DELETE_ALL_PREBUILTS=1
-            SKIP_PREBUILT_ENFORCEMENT=1
-            MAIN_BUILD_ARGS+=( "/p:SkipDownloadingPreviouslyBuiltArtifacts=true" )
             ;;
         --with-ref-packages)
             CUSTOM_REF_PACKAGES_DIR="$2"
@@ -116,6 +109,10 @@ while :; do
 
     shift
 done
+
+if [[ -d "$CUSTOM_REF_PACKAGES_DIR" && -d "$CUSTOM_PREVIOUSLY_BUILT_PACKAGES_DIR" ]]; then
+    MAIN_BUILD_ARGS+=( "/p:SkipDownloadingPreviouslyBuiltArtifacts=true" )
+fi
 
 if [ $MINIMIZE_DISK_USAGE -eq 1 ]; then
     echo "WARNING"
@@ -325,77 +322,69 @@ if [ $INCLUDE_LEAK_DETECTION -eq 1 ]; then
   "$CLI_PATH/dotnet" publish -o $FULL_TARBALL_ROOT/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection $SCRIPT_ROOT/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection/Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.csproj
 fi
 
-if [ "$DELETE_ALL_PREBUILTS" == "0" ]; then
+echo 'Removing reference-only packages from tarball prebuilts...'
 
-  echo 'Removing reference-only packages from tarball prebuilts...'
-
-  for ref_package in $(find $SCRIPT_ROOT/bin/obj/$targetArchitecture/Release/reference-packages/packages-to-delete/ -name '*.nupkg' | tr '[:upper:]' '[:lower:]')
-  do
-      if [ -e $TARBALL_ROOT/packages/prebuilt/$(basename $ref_package) ]; then
-          rm $TARBALL_ROOT/packages/prebuilt/$(basename $ref_package)
-      fi
-  done
-
-  if [ -d "$CUSTOM_REF_PACKAGES_DIR" ]; then
-      allRefPkgs=(`ls "$CUSTOM_REF_PACKAGES_DIR"  | tr '[:upper:]' '[:lower:]'`)
-  else
-      allRefPkgs=(`tar -tf $TARBALL_ROOT/packages/archive/Private.SourceBuild.ReferencePackages.*.tar.gz | tr '[:upper:]' '[:lower:]'`)
-  fi
-  if [ -d "$CUSTOM_PREVIOUSLY_BUILT_PACKAGES_DIR" ]; then
-      allSourceBuiltPkgs=(`ls "$CUSTOM_PREVIOUSLY_BUILT_PACKAGES_DIR"  | tr '[:upper:]' '[:lower:]'`)
-  else
-      allSourceBuiltPkgs=(`tar -tf $TARBALL_ROOT/packages/archive/Private.SourceBuilt.Artifacts.*.tar.gz | tr '[:upper:]' '[:lower:]'`)
-  fi
-
-  echo 'Removing reference-packages from tarball prebuilts...'
-
-  for ref_package in ${allRefPkgs[@]}
-  do
-      if [ -e $TARBALL_ROOT/packages/prebuilt/$ref_package ]; then
-          rm $TARBALL_ROOT/packages/prebuilt/$ref_package
-      fi
-  done
-
-  echo 'Removing previously source-built packages from tarball prebuilts...'
-
-  for ref_package in ${allSourceBuiltPkgs[@]}
-  do
-      if [ -e $TARBALL_ROOT/packages/prebuilt/$ref_package ]; then
-          rm $TARBALL_ROOT/packages/prebuilt/$ref_package
-      fi
-  done
-
-  echo 'Removing known extra packages from tarball prebuilts...'
-  while IFS= read -r packagePattern
-  do
-      if [[ "$packagePattern" =~ ^# ]]; then
-          continue
-      fi
-      rm -f $TARBALL_ROOT/packages/prebuilt/$packagePattern
-  done < $SCRIPT_ROOT/support/additional-prebuilts-to-delete.txt
-
-  if [ $SKIP_PREBUILT_ENFORCEMENT -ne 1 ]; then
-    echo 'Checking for extra prebuilts...'
-    error_encountered=false
-    for package in `ls -A $TARBALL_ROOT/packages/prebuilt`
-    do
-        if grep -q "$package" $SCRIPT_ROOT/support/allowed-prebuilts.txt; then
-            echo "Allowing prebuilt $package"
-        else
-            echo "ERROR: $package is not in the allowed prebuilts list ($SCRIPT_ROOT/support/allowed-prebuilts.txt)"
-            error_encountered=true
-        fi
-    done
-    if [ "$error_encountered" = "true" ]; then
-      echo "Either remove this prebuilt, add it to the known extras list ($SCRIPT_ROOT/support/additional-prebuilts-to-delete.txt) or add it to the allowed prebuilts list."
-      exit 1
+for ref_package in $(find $SCRIPT_ROOT/bin/obj/$targetArchitecture/Release/reference-packages/packages-to-delete/ -name '*.nupkg' | tr '[:upper:]' '[:lower:]')
+do
+    if [ -e $TARBALL_ROOT/packages/prebuilt/$(basename $ref_package) ]; then
+        rm $TARBALL_ROOT/packages/prebuilt/$(basename $ref_package)
     fi
-  fi
+done
 
+if [ -d "$CUSTOM_REF_PACKAGES_DIR" ]; then
+    allRefPkgs=(`ls "$CUSTOM_REF_PACKAGES_DIR"  | tr '[:upper:]' '[:lower:]'`)
 else
-  echo "Deleting all prebuilt packages..."
-  # leave the actual directory so we can use it as a NuGet source later without problems
-  rm -rf $TARBALL_ROOT/packages/prebuilt/*
+    allRefPkgs=(`tar -tf $TARBALL_ROOT/packages/archive/Private.SourceBuild.ReferencePackages.*.tar.gz | tr '[:upper:]' '[:lower:]'`)
+fi
+if [ -d "$CUSTOM_PREVIOUSLY_BUILT_PACKAGES_DIR" ]; then
+    allSourceBuiltPkgs=(`ls "$CUSTOM_PREVIOUSLY_BUILT_PACKAGES_DIR"  | tr '[:upper:]' '[:lower:]'`)
+else
+    allSourceBuiltPkgs=(`tar -tf $TARBALL_ROOT/packages/archive/Private.SourceBuilt.Artifacts.*.tar.gz | tr '[:upper:]' '[:lower:]'`)
+fi
+
+echo 'Removing reference-packages from tarball prebuilts...'
+
+for ref_package in ${allRefPkgs[@]}
+do
+    if [ -e $TARBALL_ROOT/packages/prebuilt/$ref_package ]; then
+        rm $TARBALL_ROOT/packages/prebuilt/$ref_package
+    fi
+done
+
+echo 'Removing previously source-built packages from tarball prebuilts...'
+
+for ref_package in ${allSourceBuiltPkgs[@]}
+do
+    if [ -e $TARBALL_ROOT/packages/prebuilt/$ref_package ]; then
+        rm $TARBALL_ROOT/packages/prebuilt/$ref_package
+    fi
+done
+
+echo 'Removing known extra packages from tarball prebuilts...'
+while IFS= read -r packagePattern
+do
+    if [[ "$packagePattern" =~ ^# ]]; then
+        continue
+    fi
+    rm -f $TARBALL_ROOT/packages/prebuilt/$packagePattern
+done < $SCRIPT_ROOT/support/additional-prebuilts-to-delete.txt
+
+if [ $SKIP_PREBUILT_ENFORCEMENT -ne 1 ]; then
+  echo 'Checking for extra prebuilts...'
+  error_encountered=false
+  for package in `ls -A $TARBALL_ROOT/packages/prebuilt`
+  do
+      if grep -q "$package" $SCRIPT_ROOT/support/allowed-prebuilts.txt; then
+          echo "Allowing prebuilt $package"
+      else
+          echo "ERROR: $package is not in the allowed prebuilts list ($SCRIPT_ROOT/support/allowed-prebuilts.txt)"
+          error_encountered=true
+      fi
+  done
+  if [ "$error_encountered" = "true" ]; then
+    echo "Either remove this prebuilt, add it to the known extras list ($SCRIPT_ROOT/support/additional-prebuilts-to-delete.txt) or add it to the allowed prebuilts list."
+    exit 1
+  fi
 fi
 
 echo 'Removing source-built, previously source-built packages and reference packages from il pkg src...'

--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -55,6 +55,7 @@ SKIP_PREBUILT_ENFORCEMENT=0
 DELETE_ALL_PREBUILTS=0
 CUSTOM_REF_PACKAGES_DIR=''
 CUSTOM_PREVIOUSLY_BUILT_PACKAGES_DIR=''
+MAIN_BUILD_ARGS=("/p:ArchiveDownloadedPackages=true")
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
 while :; do
@@ -79,6 +80,7 @@ while :; do
         --assume-no-prebuilts)
             DELETE_ALL_PREBUILTS=1
             SKIP_PREBUILT_ENFORCEMENT=1
+            MAIN_BUILD_ARGS+=( "/p:SkipDownloadingPreviouslyBuiltArtifacts=true" )
             ;;
         --with-ref-packages)
             CUSTOM_REF_PACKAGES_DIR="$2"
@@ -149,7 +151,7 @@ if [ $SKIP_BUILD -ne 1 ]; then
     fi
 
     $SCRIPT_ROOT/clean.sh
-    $SCRIPT_ROOT/build.sh /p:ArchiveDownloadedPackages=true "$@"
+    $SCRIPT_ROOT/build.sh  ${MAIN_BUILD_ARGUMENTS[@]} "$@"
 fi
 
 mkdir -p "$TARBALL_ROOT"

--- a/build.proj
+++ b/build.proj
@@ -147,7 +147,7 @@
 
   <Target Name="DownloadSourceBuildReferencePackages"
           AfterTargets="Build"
-          Condition="'$(OfflineBuild)' != 'true' and '$(OS)' != 'Windows_NT'">
+          Condition="'$(OfflineBuild)' != 'true' and '$(OS)' != 'Windows_NT' and '$(SkipDownloadingPreviouslyBuiltArtifacts)' != 'true'">
     <DownloadFile 
           SourceUrl="$(ReferencePackagesTarballUrl)$(ReferencePackagesTarballName).$(PrivateSourceBuildReferencePackagesPackageVersion).tar.gz"
           DestinationFolder="$(ExternalTarballsDir)" />

--- a/build.proj
+++ b/build.proj
@@ -155,7 +155,7 @@
 
   <Target Name="DownloadSourceBuiltArtifacts"
           AfterTargets="Build"
-          Condition="'$(OfflineBuild)' != 'true' and '$(OS)' != 'Windows_NT'">
+          Condition="'$(OfflineBuild)' != 'true' and '$(OS)' != 'Windows_NT' and '$(SkipDownloadingPreviouslyBuiltArtifacts)' != 'true'">
     <DownloadFile 
           SourceUrl="$(SourceBuiltArtifactsTarballUrl)$(SourceBuiltArtifactsTarballName).$(PrivateSourceBuiltArtifactsPackageVersion).tar.gz"
           DestinationFolder="$(ExternalTarballsDir)" />

--- a/build.proj
+++ b/build.proj
@@ -147,7 +147,7 @@
 
   <Target Name="DownloadSourceBuildReferencePackages"
           AfterTargets="Build"
-          Condition="'$(OfflineBuild)' != 'true' and '$(OS)' != 'Windows_NT' and '$(SkipDownloadingPreviouslyBuiltArtifacts)' != 'true'">
+          Condition="'$(OfflineBuild)' != 'true' and '$(OS)' != 'Windows_NT' and '$(SkipDownloadingReferencePackages)' != 'true'">
     <DownloadFile 
           SourceUrl="$(ReferencePackagesTarballUrl)$(ReferencePackagesTarballName).$(PrivateSourceBuildReferencePackagesPackageVersion).tar.gz"
           DestinationFolder="$(ExternalTarballsDir)" />
@@ -155,7 +155,7 @@
 
   <Target Name="DownloadSourceBuiltArtifacts"
           AfterTargets="Build"
-          Condition="'$(OfflineBuild)' != 'true' and '$(OS)' != 'Windows_NT' and '$(SkipDownloadingPreviouslyBuiltArtifacts)' != 'true'">
+          Condition="'$(OfflineBuild)' != 'true' and '$(OS)' != 'Windows_NT' and '$(SkipDownloadingPreviouslySourceBuiltPackages)' != 'true'">
     <DownloadFile 
           SourceUrl="$(SourceBuiltArtifactsTarballUrl)$(SourceBuiltArtifactsTarballName).$(PrivateSourceBuiltArtifactsPackageVersion).tar.gz"
           DestinationFolder="$(ExternalTarballsDir)" />

--- a/dir.props
+++ b/dir.props
@@ -84,6 +84,7 @@
     <PrebuiltPackagesPath>$(ProjectDir)packages/prebuilt/</PrebuiltPackagesPath>
     <PreviouslyRestoredPackagesPath>$(ProjectDir)packages/previouslyRestored/</PreviouslyRestoredPackagesPath>
     <PrebuiltSourceBuiltPackagesPath>$(ProjectDir)packages/source-built/</PrebuiltSourceBuiltPackagesPath>
+    <PrebuiltSourceBuiltPackagesPath Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' != ''">$(CustomPrebuiltSourceBuiltPackagesPath)/</PrebuiltSourceBuiltPackagesPath>
     <SourceBuiltTarBallPath>$(OutputPath)</SourceBuiltTarBallPath>
     <SourceBuiltToolsetDir>$(LocalBlobStorageRoot)Toolset/</SourceBuiltToolsetDir>
     <SourceBuiltRuntimeDir>$(LocalBlobStorageRoot)Runtime/</SourceBuiltRuntimeDir>
@@ -135,6 +136,7 @@
     <ReferencePackagesStagingDir>$(ReferencePackagesBaseDir)staging/</ReferencePackagesStagingDir>
     <ReferencePackagesSourceDir>$(ReferencePackagesBaseDir)source/</ReferencePackagesSourceDir>
     <ReferencePackagesDir>$(ReferencePackagesBaseDir)packages/</ReferencePackagesDir>
+    <ReferencePackagesDir Condition="'$(CustomReferencePackagesPath)' != ''">$(CustomReferencePackagesPath)/</ReferencePackagesDir>
     <SourceBuiltArtifactsTarballName>Private.SourceBuilt.Artifacts</SourceBuiltArtifactsTarballName>
     <SourceBuiltArtifactsTarballUrl>https://dotnetcli.blob.core.windows.net/source-built-artifacts/assets/</SourceBuiltArtifactsTarballUrl>
     <ReferencePackagesTarballName>Private.SourceBuild.ReferencePackages</ReferencePackagesTarballName>

--- a/support/tarball/build.sh
+++ b/support/tarball/build.sh
@@ -2,34 +2,105 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+usage() {
+    echo "usage: $0 [options]"
+    echo "options:"
+    echo "  --with-ref-packages <dir>          use the specified directory of available reference packages to determine what prebuilts to delete, instead of downloading the most recent version"
+    echo "  --with-packages <dir>              use the specified directory of available previously-built packages to determine what prebuilts to delete, instead of downloading the most recent version"
+    echo "use -- to send the remaining arguments to MSBuild"
+    echo ""
+}
+
 SCRIPT_ROOT="$(cd -P "$( dirname "$0" )" && pwd)"
+
+MSBUILD_ARGUMENTS=("/p:OfflineBuild=true" "/flp:v=detailed")
+CUSTOM_REF_PACKAGES_DIR=''
+CUSTOM_PREVIOUSLY_BUILT_PACKAGES_DIR=''
+
+while :; do
+    if [ $# -le 0 ]; then
+        break
+    fi
+
+    lowerI="$(echo $1 | awk '{print tolower($0)}')"
+    case $lowerI in
+        --with-ref-packages)
+            CUSTOM_REF_PACKAGES_DIR="$2"
+            if [ ! -d "$CUSTOM_REF_PACKAGES_DIR" ]; then
+                echo "Custom reference packages directory '$CUSTOM_REF_PACKAGES_DIR' does not exist"
+                exit 1
+            fi
+            shift
+            ;;
+        --with-packages)
+            CUSTOM_PREVIOUSLY_BUILT_PACKAGES_DIR="$2"
+            if [ ! -d "$CUSTOM_PREVIOUSLY_BUILT_PACKAGES_DIR" ]; then
+                echo "Custom prviously built packages directory '$CUSTOM_PREVIOUSLY_BUILT_PACKAGES_DIR' does not exist"
+                exit 1
+            fi
+            shift
+            ;;
+        --)
+            shift
+            echo "Detected '--': passing remaining parameters '$@' as build.sh arguments."
+            break
+            ;;
+        -?|-h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unrecognized argument '$1'"
+            usage
+            exit 1
+            ;;
+    esac
+
 sdkLine=`grep -m 1 'dotnet' "$SCRIPT_ROOT/global.json"`
 sdkPattern="\"dotnet\" *: *\"(.*)\""
 if [[ $sdkLine =~ $sdkPattern ]]; then
   export SDK_VERSION=${BASH_REMATCH[1]}
 fi
 
-sourceBuiltArchive=`find $SCRIPT_ROOT/packages/archive -maxdepth 1 -name 'Private.SourceBuilt.Artifacts*.tar.gz'`
-if [ -f "$sourceBuiltArchive" ]; then
-  tar -xzf "$sourceBuiltArchive" -C /tmp PackageVersions.props
-  arcadeSdkLine=`grep -m 1 'MicrosoftDotNetArcadeSdkVersion' /tmp/PackageVersions.props`
-  versionPattern="<MicrosoftDotNetArcadeSdkVersion>(.*)</MicrosoftDotNetArcadeSdkVersion>"
-  if [[ $arcadeSdkLine =~ $versionPattern ]]; then
-    export ARCADE_BOOTSTRAP_VERSION=${BASH_REMATCH[1]}
-  fi
+packageVersionsPath=''
 
-  sourceLinkLine=`grep -m 1 'MicrosoftSourceLinkCommonVersion' /tmp/PackageVersions.props`
-  versionPattern="<MicrosoftSourceLinkCommonVersion>(.*)</MicrosoftSourceLinkCommonVersion>"
-  if [[ $sourceLinkLine =~ $versionPattern ]]; then
-    export SOURCE_LINK_BOOTSTRAP_VERSION=${BASH_REMATCH[1]}
+if [ -d "$SCRIPT_ROOT/packages/archive" ]; then
+  sourceBuiltArchive=`find $SCRIPT_ROOT/packages/archive -maxdepth 1 -name 'Private.SourceBuilt.Artifacts*.tar.gz'`
+  if [ -f "$sourceBuiltArchive" ]; then
+    tar -xzf "$sourceBuiltArchive" -C /tmp PackageVersions.props
+    packageVersionsPath=/tmp/PackageVersions.props
   fi
-
-  dotNetHostLine=`grep -m 1 'MicrosoftNETCoreDotNetHostVersion' /tmp/PackageVersions.props`
-  versionPattern="<MicrosoftNETCoreDotNetHostVersion>(.*)</MicrosoftNETCoreDotNetHostVersion>"
-  if [[ $dotNetHostLine =~ $versionPattern ]]; then
-    export DOTNET_HOST_BOOTSTRAP_VERSION=${BASH_REMATCH[1]}
+else
+  if [ -f "$CUSTOM_PREVIOUSLY_BUILT_PACKAGES_DIR/PackageVersions.props" ]; then
+    packageVersionsPath="$CUSTOM_PREVIOUSLY_BUILT_PACKAGES_DIR/PackageVersions.props"
   fi
 fi
+
+if [ ! -f "$packageVersionsPath" ]; then
+  echo "Cannot find PackagesVersions.props.  Debugging info:"
+  echo "  Attempted archive path: $SCRIPT_ROOT/packages/archive"
+  echo "  Attempted custom PVP path: $CUSTOM_PREVIOUSLY_BUILT_PACKAGES_DIR/PackageVersions.props"
+  exit 1
+fi
+
+arcadeSdkLine=`grep -m 1 'MicrosoftDotNetArcadeSdkVersion' "$packageVersionsPath"
+versionPattern="<MicrosoftDotNetArcadeSdkVersion>(.*)</MicrosoftDotNetArcadeSdkVersion>"
+if [[ $arcadeSdkLine =~ $versionPattern ]]; then
+  export ARCADE_BOOTSTRAP_VERSION=${BASH_REMATCH[1]}
+fi
+
+sourceLinkLine=`grep -m 1 'MicrosoftSourceLinkCommonVersion' "$packageVersionsPath"
+versionPattern="<MicrosoftSourceLinkCommonVersion>(.*)</MicrosoftSourceLinkCommonVersion>"
+if [[ $sourceLinkLine =~ $versionPattern ]]; then
+  export SOURCE_LINK_BOOTSTRAP_VERSION=${BASH_REMATCH[1]}
+fi
+
+dotNetHostLine=`grep -m 1 'MicrosoftNETCoreDotNetHostVersion' "$packageVersionsPath"
+versionPattern="<MicrosoftNETCoreDotNetHostVersion>(.*)</MicrosoftNETCoreDotNetHostVersion>"
+if [[ $dotNetHostLine =~ $versionPattern ]]; then
+  export DOTNET_HOST_BOOTSTRAP_VERSION=${BASH_REMATCH[1]}
+fi
+
 echo "Found bootstrap SDK $SDK_VERSION, bootstrap Arcade $ARCADE_BOOTSTRAP_VERSION, bootstrap SourceLink $SOURCE_LINK_BOOTSTRAP_VERSION, bootstrap DotNetHost $DOTNET_HOST_BOOTSTRAP_VERSION"
 CLI_ROOT="$SCRIPT_ROOT/.dotnet"
 
@@ -37,7 +108,6 @@ export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export NUGET_PACKAGES="$SCRIPT_ROOT/packages/restored/"
 
-MSBUILD_ARGUMENTS=("/p:OfflineBuild=true" "/flp:v=detailed")
 
 $CLI_ROOT/dotnet $CLI_ROOT/sdk/$SDK_VERSION/MSBuild.dll /bl:BuildXPlatTasks.binlog $SCRIPT_ROOT/tools-local/init-build.proj /t:BuildXPlatTasks ${MSBUILD_ARGUMENTS[@]} "$@"
 

--- a/support/tarball/build.sh
+++ b/support/tarball/build.sh
@@ -5,8 +5,8 @@ IFS=$'\n\t'
 usage() {
     echo "usage: $0 [options]"
     echo "options:"
-    echo "  --with-ref-packages <dir>          use the specified directory of available reference packages to determine what prebuilts to delete, instead of downloading the most recent version"
-    echo "  --with-packages <dir>              use the specified directory of available previously-built packages to determine what prebuilts to delete, instead of downloading the most recent version"
+    echo "  --with-ref-packages <dir>          use the specified directory of reference packages"
+    echo "  --with-packages <dir>              use the specified directory of previously-built packages"
     echo "use -- to send the remaining arguments to MSBuild"
     echo ""
 }

--- a/tools-local/init-build.proj
+++ b/tools-local/init-build.proj
@@ -42,9 +42,14 @@
     <Exec Command="tar -xzf $(ExternalTarballsDir)$(ReferencePackagesTarballName).*.tar.gz"
           WorkingDirectory="$(ReferencePackagesDir)" />
 
-    <MakeDir Directories="$(PrebuiltSourceBuiltPackagesPath)" />
+    <MakeDir Directories="$(PrebuiltSourceBuiltPackagesPath)" Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == ''" />
     <Exec Command="tar -xzf $(ExternalTarballsDir)$(SourceBuiltArtifactsTarballName).*.tar.gz"
-          WorkingDirectory="$(PrebuiltSourceBuiltPackagesPath)" />
+          WorkingDirectory="$(PrebuiltSourceBuiltPackagesPath)"
+          Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == ''" />
+
+    <PropertyGroup>
+      <PrebuiltSourceBuiltPackagesPath Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == ''">$(CustomPrebuiltSourceBuiltPackagesPath)</PrebuiltSourceBuiltPackagesPath>
+    </PropertyGroup>
 
     <Copy SourceFiles="$(PrebuiltSourceBuiltPackagesPath)PackageVersions.props" DestinationFiles="$(IntermediatePath)SourceBuiltPackageVersions.props" />
   </Target>

--- a/tools-local/init-build.proj
+++ b/tools-local/init-build.proj
@@ -48,13 +48,6 @@
           WorkingDirectory="$(PrebuiltSourceBuiltPackagesPath)"
           Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == ''" />
 
-    <PropertyGroup>
-      <PrebuiltSourceBuiltPackagesPath Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == ''">$(CustomPrebuiltSourceBuiltPackagesPath)</PrebuiltSourceBuiltPackagesPath>
-    </PropertyGroup>
-    <PropertyGroup>
-      <ReferencePackagesDir Condition="'$(CustomReferencePackagesPath)' == ''">$(CustomReferencePackagesPath)</ReferencePackagesDir>
-    </PropertyGroup>
-
     <Copy SourceFiles="$(PrebuiltSourceBuiltPackagesPath)PackageVersions.props" DestinationFiles="$(IntermediatePath)SourceBuiltPackageVersions.props" />
   </Target>
 

--- a/tools-local/init-build.proj
+++ b/tools-local/init-build.proj
@@ -38,9 +38,10 @@
 
   <Target Name="UnpackTarballs" 
           Condition="'$(OfflineBuild)' == 'true'">
-    <MakeDir Directories="$(ReferencePackagesDir)" />
+    <MakeDir Directories="$(ReferencePackagesDir)"  Condition="'$(CustomReferencePackagesPath)' == ''" />
     <Exec Command="tar -xzf $(ExternalTarballsDir)$(ReferencePackagesTarballName).*.tar.gz"
-          WorkingDirectory="$(ReferencePackagesDir)" />
+          WorkingDirectory="$(ReferencePackagesDir)"
+          Condition="'$(CustomReferencePackagesPath)' == ''" />
 
     <MakeDir Directories="$(PrebuiltSourceBuiltPackagesPath)" Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == ''" />
     <Exec Command="tar -xzf $(ExternalTarballsDir)$(SourceBuiltArtifactsTarballName).*.tar.gz"
@@ -49,6 +50,9 @@
 
     <PropertyGroup>
       <PrebuiltSourceBuiltPackagesPath Condition="'$(CustomPrebuiltSourceBuiltPackagesPath)' == ''">$(CustomPrebuiltSourceBuiltPackagesPath)</PrebuiltSourceBuiltPackagesPath>
+    </PropertyGroup>
+    <PropertyGroup>
+      <ReferencePackagesDir Condition="'$(CustomReferencePackagesPath)' == ''">$(CustomReferencePackagesPath)</ReferencePackagesDir>
     </PropertyGroup>
 
     <Copy SourceFiles="$(PrebuiltSourceBuiltPackagesPath)PackageVersions.props" DestinationFiles="$(IntermediatePath)SourceBuiltPackageVersions.props" />


### PR DESCRIPTION
Distro maintainers will want to use their own builds of the source-build-reference-packages and previously-built-packages instead of using our prebuilt tarballs.  This changes the tarball production script and tarball build to support that.

Fixes #1436.