### PR TITLE
core-sdk: Add target rid to AppHostRuntimeIdentifiers

### DIFF
--- a/patches/core-sdk/0006-Add-target-rid-to-AppHostRuntimeIdentifiers.patch
+++ b/patches/core-sdk/0006-Add-target-rid-to-AppHostRuntimeIdentifiers.patch
@@ -1,0 +1,37 @@
+From c422a75a14945adf578727ac0b4f50ca3caa819b Mon Sep 17 00:00:00 2001
+From: Tom Deseyn <tom.deseyn@gmail.com>
+Date: Thu, 16 Jan 2020 08:29:38 +0100
+Subject: [PATCH] Add target rid to AppHostRuntimeIdentifiers
+
+---
+ src/redist/targets/GenerateBundledVersions.targets | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/redist/targets/GenerateBundledVersions.targets b/src/redist/targets/GenerateBundledVersions.targets
+index 3a2726493..b50a928c2 100644
+--- a/src/redist/targets/GenerateBundledVersions.targets
++++ b/src/redist/targets/GenerateBundledVersions.targets
+@@ -38,6 +38,11 @@
+           win-x86;
+           " />
+ 
++      <NetCoreAppHostPackRids Include="
++          $(ProductMonikerRid);
++          @(NetCoreRuntimePackRids)
++          " />
++
+       <AspNetCoreRuntimePackRids Include="
+         win-x64;
+         win-x86;
+@@ -157,7 +162,7 @@ Copyright (c) .NET Foundation. All rights reserved.
+                       TargetFramework="netcoreapp3.0"
+                       AppHostPackNamePattern="Microsoft.NETCore.App.Host.**RID**"
+                       AppHostPackVersion="$(_NETCoreAppPackageVersion)"
+-                      AppHostRuntimeIdentifiers="@(NetCoreRuntimePackRids, '%3B')"
++                      AppHostRuntimeIdentifiers="@(NetCoreAppHostPackRids, '%3B')"
+                       />
+     
+     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App"
+-- 
+2.23.0
+


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/1444 for 3.0

cc @nguerrera @dagood @crummel @omajid @dseefeld