### PR TITLE
core-sdk: Add target rid to AppHostRuntimeIdentifiers

### DIFF
--- a/patches/core-sdk/0008-Add-target-rid-to-AppHostRuntimeIdentifiers.patch
+++ b/patches/core-sdk/0008-Add-target-rid-to-AppHostRuntimeIdentifiers.patch
@@ -1,0 +1,37 @@
+From 62020f2c4fdf2c0389b4106cac9286f1c3a9eb7c Mon Sep 17 00:00:00 2001
+From: Tom Deseyn <tom.deseyn@gmail.com>
+Date: Thu, 16 Jan 2020 08:37:34 +0100
+Subject: [PATCH] Add target rid to AppHostRuntimeIdentifiers
+
+---
+ src/redist/targets/GenerateBundledVersions.targets | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/redist/targets/GenerateBundledVersions.targets b/src/redist/targets/GenerateBundledVersions.targets
+index a214842a0..2c350f15f 100644
+--- a/src/redist/targets/GenerateBundledVersions.targets
++++ b/src/redist/targets/GenerateBundledVersions.targets
+@@ -48,6 +48,11 @@
+ 
+       <NetCoreRuntimePackRids Include="@(NetCore30RuntimePackRids)"/>
+ 
++      <NetCoreAppHostPackRids Include="
++          $(ProductMonikerRid);
++          @(NetCoreRuntimePackRids)
++          " />
++
+       <AspNetCore30RuntimePackRids Include="
+         win-x64;
+         win-x86;
+@@ -168,7 +173,7 @@ Copyright (c) .NET Foundation. All rights reserved.
+                       TargetFramework="netcoreapp3.1"
+                       AppHostPackNamePattern="Microsoft.NETCore.App.Host.**RID**"
+                       AppHostPackVersion="$(_NETCoreAppPackageVersion)"
+-                      AppHostRuntimeIdentifiers="@(NetCoreRuntimePackRids, '%3B')"
++                      AppHostRuntimeIdentifiers="@(NetCoreAppHostPackRids, '%3B')"
+                       />
+     
+     <KnownFrameworkReference Include="Microsoft.WindowsDesktop.App"
+-- 
+2.23.0
+


### PR DESCRIPTION
Fixes #1444 for 3.1