### PR TITLE
[release/3.0] Fix extensions nupkg, enable aspnet crossgen

### DIFF
--- a/patches/aspnet-extensions/0006-Fix-packing-on-nix-systems.patch
+++ b/patches/aspnet-extensions/0006-Fix-packing-on-nix-systems.patch
@@ -1,0 +1,64 @@
+From 09795b550c1cd32faeaf4d122d6bfd47a5e362ef Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Thu, 23 Jan 2020 21:04:40 -0600
+Subject: [PATCH] Fix packing on *nix systems
+
+Without this fix, the nupkg will be missing files if packed on *nix systems
+---
+ .../src/Microsoft.Extensions.FileProviders.Embedded.csproj  | 4 +---
+ ...oft.Extensions.FileProviders.Embedded.multitarget.nuspec | 6 +++---
+ ...t.Extensions.FileProviders.Embedded.netcoreapp3.0.nuspec | 6 +++---
+ 3 files changed, 7 insertions(+), 9 deletions(-)
+
+diff --git a/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.csproj b/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.csproj
+index 9a752c3e6..1f34d6dd9 100644
+--- a/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.csproj
++++ b/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.csproj
+@@ -27,9 +27,7 @@
+ 
+   <ItemGroup>
+     <NuspecProperty Include="AssemblyName=$(AssemblyName)" />
+-    <NuspecProperty Include="OutputBinary=$(OutputPath)**\$(AssemblyName).dll" />
+-    <NuspecProperty Include="OutputSymbol=$(OutputPath)**\$(AssemblyName).pdb" />
+-    <NuspecProperty Include="OutputDocumentation=$(OutputPath)**\$(AssemblyName).xml" />
++    <NuspecProperty Include="OutputPath=$(OutputPath)" />
+     <NuspecProperty Include="TaskAssemblyNetStandard=$(ArtifactsDir)bin\$(AssemblyName).Manifest.Task\$(Configuration)\netstandard2.1\$(AssemblyName).Manifest.Task.dll"/>
+     <NuspecProperty Include="TaskSymbolNetStandard=$(ArtifactsDir)bin\$(AssemblyName).Manifest.Task\$(Configuration)\netstandard2.1\$(AssemblyName).Manifest.Task.pdb" Condition="'$(DebugType)'!='embedded'"/>
+     <NuspecProperty Include="PackageIcon=$(PackageIconFullPath)" />
+diff --git a/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.multitarget.nuspec b/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.multitarget.nuspec
+index 7e2fa61df..c1af0040a 100644
+--- a/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.multitarget.nuspec
++++ b/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.multitarget.nuspec
+@@ -14,9 +14,9 @@
+   </metadata>
+ 
+   <files>
+-    <file src="$OutputBinary$" target="lib\" />
+-    <file src="$OutputSymbol$" target="lib\" />
+-    <file src="$OutputDocumentation$" target="lib\" />
++    <file src="$OutputPath$**\$AssemblyName$.dll" target="lib\" />
++    <file src="$OutputPath$**\$AssemblyName$.pdb" target="lib\" />
++    <file src="$OutputPath$**\$AssemblyName$.xml" target="lib\" />
+     <file src="build\**\*" target="build\" />
+     <file src="buildMultiTargeting\**\*" target="buildMultiTargeting\" />
+     <file src="$PackageIcon$" target="" />
+diff --git a/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.netcoreapp3.0.nuspec b/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.netcoreapp3.0.nuspec
+index 590b84c9a..c27cffcce 100644
+--- a/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.netcoreapp3.0.nuspec
++++ b/src/FileProviders/Embedded/src/Microsoft.Extensions.FileProviders.Embedded.netcoreapp3.0.nuspec
+@@ -11,9 +11,9 @@
+   </metadata>
+ 
+   <files>
+-    <file src="$OutputBinary$" target="lib\" />
+-    <file src="$OutputSymbol$" target="lib\" />
+-    <file src="$OutputDocumentation$" target="lib\" />
++    <file src="$OutputPath$**\$AssemblyName$.dll" target="lib\" />
++    <file src="$OutputPath$**\$AssemblyName$.pdb" target="lib\" />
++    <file src="$OutputPath$**\$AssemblyName$.xml" target="lib\" />
+     <file src="build\**\*" target="build\" />
+     <file src="buildMultiTargeting\**\*" target="buildMultiTargeting\" />
+     <file src="$PackageIcon$" target="" />
+-- 
+2.23.0.windows.1
+

--- a/repos/aspnetcore.proj
+++ b/repos/aspnetcore.proj
@@ -14,7 +14,6 @@
     <BuildCommandArgs>$(BuildCommandArgs) /p:BuildNodeJs=false</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:SourceBuildRuntimeIdentifier=$(TargetRid)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:UseAppHost=false</BuildCommandArgs>
-    <BuildCommandArgs>$(BuildCommandArgs) /p:CrossgenOutput=false</BuildCommandArgs>
 
     <LogVerbosityOptOut>true</LogVerbosityOptOut>
     <BuildCommandArgs>$(BuildCommandArgs) -v $(LogVerbosity)</BuildCommandArgs>


### PR DESCRIPTION
See https://github.com/dotnet/source-build/issues/1452

> Now I see that 3.0.0 has a patch called [`Fix packing on *nix systems`](https://github.com/dotnet/source-build/blob/v3.0.0-runtime/patches/aspnet-extensions/0002-Fix-packing-on-nix-systems.patch) that was deleted in https://github.com/dotnet/source-build/pull/1260/commits/afdf3d6a69a860f807f4e37251821e89fe4ca5e8. 😕 I'm running a build now with it restored on source-build@v3.0.1-runtime to see if that fixes the `lib` issue and lets crossgen run.

It worked for me in a basic build.