### PR TITLE
Add GraphViz dependency graph generator project

### DIFF
--- a/repos/dir.targets
+++ b/repos/dir.targets
@@ -498,6 +498,7 @@
   <Target Name="GetProjectDirectory" Outputs="$(ProjectDirectory)" />
   <Target Name="GetOrchestratedManifestBuildName" Outputs="$(OrchestratedManifestBuildName)" />
   <Target Name="GetOfficialBuildId" Outputs="$(OfficialBuildId)" />
+  <Target Name="GetRepositoryReferences" Outputs="@(RepositoryReference)" />
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., dir.targets))/dir.targets" />
 </Project>

--- a/tools-local/generate-graphviz.proj
+++ b/tools-local/generate-graphviz.proj
@@ -1,0 +1,49 @@
+<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+
+  <Target Name="Build">
+    <ItemGroup>
+      <AllRepoProjects
+        Include="$(ProjectDir)repos\*.proj"
+        Exclude="
+          $(ProjectDir)repos\known-good.proj;
+          $(ProjectDir)repos\known-good-tests.proj" />
+    </ItemGroup>
+
+    <MSBuild
+      Projects="@(AllRepoProjects)"
+      Targets="GetRepositoryReferences">
+      <Output TaskParameter="TargetOutputs" ItemName="RepoReferences" />
+    </MSBuild>
+
+    <ItemGroup>
+      <RepoLink Include="%(RepoReferences.MSBuildSourceProjectFile)" SourceRepo="%(RepoReferences.Identity)" />
+      <RepoLink TargetRepo="%(Filename)" />
+      <RepoLink Text="&quot;%(SourceRepo)&quot; -> &quot;%(TargetRepo)&quot;" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <GraphVizFile>$(BaseIntermediatePath)graphviz.dot</GraphVizFile>
+      <GraphVizPngFile>$(BaseIntermediatePath)graphviz.png</GraphVizPngFile>
+      <GraphVizContent>digraph {
+graph [ dpi = 300 ]
+@(RepoLink -> '%(Text)')
+}</GraphVizContent>
+    </PropertyGroup>
+
+    <WriteLinesToFile
+      Lines="$(GraphVizContent)"
+      File="$(GraphVizFile)"
+      Overwrite="True" />
+
+    <Message Importance="High" Text="$(MSBuildProjectName) -> $(GraphVizFile)" />
+
+    <Exec
+      Condition="'$(GraphVizDir)' != ''"
+      Command="$([MSBuild]::NormalizePath('$(GraphVizDir)', 'dot')) $(GraphVizFile) -Tpng:cairo -o $(GraphVizPngFile)" />
+
+    <Message Condition="'$(GraphVizDir)' != ''" Importance="High" Text="$(MSBuildProjectName) -> $(GraphVizPngFile)" />
+  </Target>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))/dir.targets" />
+</Project>

--- a/tools-local/generate-graphviz/generate-graphviz.proj
+++ b/tools-local/generate-graphviz/generate-graphviz.proj
@@ -26,7 +26,7 @@
       <GraphVizFile>$(BaseIntermediatePath)graphviz.dot</GraphVizFile>
       <GraphVizPngFile>$(BaseIntermediatePath)graphviz.png</GraphVizPngFile>
       <GraphVizContent>digraph {
-graph [ dpi = 300 ]
+graph [ dpi = 150 ]
 @(RepoLink -> '%(Text)')
 }</GraphVizContent>
     </PropertyGroup>


### PR DESCRIPTION
I wrote this quick project while investigating putting source-build into Arcade (https://github.com/dotnet/source-build/issues/1466) and into the Microsoft official builds, to look for leaves and any chunky areas. I ran it with this command line on Windows:

```
.\eng\common\build.ps1 -build -projects C:\git\source-build\tools-local\generate-graphviz.proj /bl /p:TargetRid=win-x64 /p:GraphVizDir=C:\tools\graphviz\2.38\bin
```

Produces output like this:

![graphviz](https://user-images.githubusercontent.com/12819531/74563652-e0669600-4f32-11ea-9bb3-dd04e7aa3b75.png)

(You can also use a tool like http://webgraphviz.com/ with the `graphviz.dot` output.)

Doesn't run during builds.