### PR TITLE
Don't build the portable runtime by default

### DIFF
--- a/.vsts.pipelines/builds/matrix.yml
+++ b/.vsts.pipelines/builds/matrix.yml
@@ -54,9 +54,9 @@ jobs:
     job: fedora30
     imageName: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-30-38e0f29-20191126135223
     matrix:
-      Production: { buildPortableRuntime: true }
+      Production: { alwaysBuildPortableRuntime: true }
       Online: { type: Online }
-      Offline: { type: Offline, buildPortableRuntime: true }
+      Offline: { type: Offline, alwaysBuildPortableRuntime: true }
       Offline Portable: { type: Offline Portable }
 
 - template: ../jobs/ci-linux.yml

--- a/.vsts.pipelines/builds/matrix.yml
+++ b/.vsts.pipelines/builds/matrix.yml
@@ -54,9 +54,9 @@ jobs:
     job: fedora30
     imageName: mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-30-38e0f29-20191126135223
     matrix:
-      Production: {}
+      Production: { buildPortableRuntime: true }
       Online: { type: Online }
-      Offline: { type: Offline }
+      Offline: { type: Offline, buildPortableRuntime: true }
       Offline Portable: { type: Offline Portable }
 
 - template: ../jobs/ci-linux.yml

--- a/.vsts.pipelines/jobs/ci-linux.yml
+++ b/.vsts.pipelines/jobs/ci-linux.yml
@@ -8,6 +8,7 @@ parameters:
   reportPrebuiltLeaks: false
   generatePrebuiltBurndown: false
   runUnitTests: false
+  buildPortableRuntime: false
 
 jobs:
 - job: ${{ parameters.job }}
@@ -61,6 +62,10 @@ jobs:
   - script: |
       set -ex
       df -h
+      portableRuntimeArg=
+      if [ "$(buildPortableRuntime)" = "true" ]; then
+        portableRuntimeArg="/p:BuildPortableRuntime=true"
+      fi
       if [ "$(sb.tarball)" != "true" ]; then
         failOnBaselineError=true
       fi
@@ -71,7 +76,8 @@ jobs:
         /p:ArchiveDownloadedPackages=$(sb.tarball) \
         /p:FailOnPrebuiltBaselineError=$failOnBaselineError \
         /p:ProdConBlobFeedUrlPrefix=$(prodConBlobFeedUrlPrefix) \
-        /p:AzDoPat=$(System.AccessToken)
+        /p:AzDoPat=$(System.AccessToken) \
+        $portableRuntimeArg
       du -h $(rootDirectory) | sort -h | tail -n 50
     displayName: Build source-build
     timeoutInMinutes: 180
@@ -195,6 +201,10 @@ jobs:
   - script: |
       set -ex
       df -h
+      portableRuntimeArg=
+      if [ "$(buildPortableRuntime)" = "true" ]; then
+        portableRuntimeArg="/p:BuildPortableRuntime=true"
+      fi
       networkArg=
       if [ "$(sb.tarballOffline)" = "true" ]; then
         networkArg="--network=none"
@@ -208,7 +218,8 @@ jobs:
         /p:PortableBuild=$(sb.portable) \
         /p:UseSystemLibunwind=$(systemLibunwind) \
         /p:FailOnPrebuiltBaselineError=true \
-        $poisonArg
+        $poisonArg \
+        $portableRuntimeArg
       du -h $(rootDirectory) | sort -h | tail -n 50
     displayName: Build tarball
     timeoutInMinutes: 150

--- a/.vsts.pipelines/jobs/ci-linux.yml
+++ b/.vsts.pipelines/jobs/ci-linux.yml
@@ -8,7 +8,7 @@ parameters:
   reportPrebuiltLeaks: false
   generatePrebuiltBurndown: false
   runUnitTests: false
-  buildPortableRuntime: false
+  alwaysBuildPortableRuntime: false
 
 jobs:
 - job: ${{ parameters.job }}
@@ -63,7 +63,7 @@ jobs:
       set -ex
       df -h
       portableRuntimeArg=
-      if [ "$(buildPortableRuntime)" = "true" ]; then
+      if [ "$(alwaysBuildPortableRuntime)" = "true" ]; then
         portableRuntimeArg="/p:BuildPortableRuntime=true"
       fi
       if [ "$(sb.tarball)" != "true" ]; then
@@ -202,7 +202,7 @@ jobs:
       set -ex
       df -h
       portableRuntimeArg=
-      if [ "$(buildPortableRuntime)" = "true" ]; then
+      if [ "$(alwaysBuildPortableRuntime)" = "true" ]; then
         portableRuntimeArg="/p:BuildPortableRuntime=true"
       fi
       networkArg=

--- a/patches/vstest/0007-Disable-warnAsError-for-source-build.patch
+++ b/patches/vstest/0007-Disable-warnAsError-for-source-build.patch
@@ -1,4 +1,4 @@
-From 48c9b6640c268beaa71778cebf8097655e2ac8cd Mon Sep 17 00:00:00 2001
+From 156d6c62f8bd5273d6873a9cd075148e00e3a899 Mon Sep 17 00:00:00 2001
 From: Chris Rummel <crummel@microsoft.com>
 Date: Thu, 19 Mar 2020 09:37:25 -0500
 Subject: [PATCH 7/7] Disable warnAsError for source-build
@@ -8,7 +8,7 @@ Subject: [PATCH 7/7] Disable warnAsError for source-build
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/scripts/build.sh b/scripts/build.sh
-index 39a04ada..53a475d4 100755
+index 39a04ada..a4ace03a 100755
 --- a/scripts/build.sh
 +++ b/scripts/build.sh
 @@ -249,7 +249,7 @@ function invoke_build()
@@ -16,7 +16,8 @@ index 39a04ada..53a475d4 100755
              $dotnet build $TPB_Solution --configuration $TPB_Configuration -v:minimal -p:Version=$TPB_Version -p:CIBuild=$TPB_CIBuild -p:LocalizedBuild=$TPB_LocalizedBuild || failed=true
          else
 -            $dotnet build $TPB_Build_From_Source_Solution /bl:build.binlog --configuration $TPB_Configuration -v:minimal -p:Version=$TPB_Version -p:CIBuild=$TPB_CIBuild -p:LocalizedBuild=$TPB_LocalizedBuild -p:DotNetBuildFromSource=true || failed=true
-+            $dotnet build $TPB_Build_From_Source_Solution /bl:build.binlog --configuration $TPB_Configuration -v:minimal -p:Version=$TPB_Version -p:CIBuild=$TPB_CIBuild -p:LocalizedBuild=$TPB_LocalizedBuild -p:DotNetBuildFromSource=true -p:TreatWarningsAsErrors=false || failed=true
+<<<<<<< HEAD
++            $dotnet build $TPB_Build_From_Source_Solution /bl:build.binlog --configuration $TPB_Configuration -v:minimal -warnaserror:0 -p:Version=$TPB_Version -p:CIBuild=$TPB_CIBuild -p:LocalizedBuild=$TPB_LocalizedBuild -p:DotNetBuildFromSource=true || failed=true
         fi
      else
          find . -name "$PROJECT_NAME_PATTERNS" | xargs -L 1 $dotnet build --configuration $TPB_Configuration -v:minimal -p:Version=$TPB_Version -p:CIBuild=$TPB_CIBuild -p:LocalizedBuild=$TPB_LocalizedBuild

--- a/patches/vstest/0007-Disable-warnAsError-for-source-build.patch
+++ b/patches/vstest/0007-Disable-warnAsError-for-source-build.patch
@@ -1,4 +1,4 @@
-From 156d6c62f8bd5273d6873a9cd075148e00e3a899 Mon Sep 17 00:00:00 2001
+From 48c9b6640c268beaa71778cebf8097655e2ac8cd Mon Sep 17 00:00:00 2001
 From: Chris Rummel <crummel@microsoft.com>
 Date: Thu, 19 Mar 2020 09:37:25 -0500
 Subject: [PATCH 7/7] Disable warnAsError for source-build
@@ -8,7 +8,7 @@ Subject: [PATCH 7/7] Disable warnAsError for source-build
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/scripts/build.sh b/scripts/build.sh
-index 39a04ada..a4ace03a 100755
+index 39a04ada..53a475d4 100755
 --- a/scripts/build.sh
 +++ b/scripts/build.sh
 @@ -249,7 +249,7 @@ function invoke_build()
@@ -16,8 +16,7 @@ index 39a04ada..a4ace03a 100755
              $dotnet build $TPB_Solution --configuration $TPB_Configuration -v:minimal -p:Version=$TPB_Version -p:CIBuild=$TPB_CIBuild -p:LocalizedBuild=$TPB_LocalizedBuild || failed=true
          else
 -            $dotnet build $TPB_Build_From_Source_Solution /bl:build.binlog --configuration $TPB_Configuration -v:minimal -p:Version=$TPB_Version -p:CIBuild=$TPB_CIBuild -p:LocalizedBuild=$TPB_LocalizedBuild -p:DotNetBuildFromSource=true || failed=true
-<<<<<<< HEAD
-+            $dotnet build $TPB_Build_From_Source_Solution /bl:build.binlog --configuration $TPB_Configuration -v:minimal -warnaserror:0 -p:Version=$TPB_Version -p:CIBuild=$TPB_CIBuild -p:LocalizedBuild=$TPB_LocalizedBuild -p:DotNetBuildFromSource=true || failed=true
++            $dotnet build $TPB_Build_From_Source_Solution /bl:build.binlog --configuration $TPB_Configuration -v:minimal -p:Version=$TPB_Version -p:CIBuild=$TPB_CIBuild -p:LocalizedBuild=$TPB_LocalizedBuild -p:DotNetBuildFromSource=true -p:TreatWarningsAsErrors=false || failed=true
         fi
      else
          find . -name "$PROJECT_NAME_PATTERNS" | xargs -L 1 $dotnet build --configuration $TPB_Configuration -v:minimal -p:Version=$TPB_Version -p:CIBuild=$TPB_CIBuild -p:LocalizedBuild=$TPB_LocalizedBuild

--- a/repos/core-setup.proj
+++ b/repos/core-setup.proj
@@ -9,7 +9,7 @@
     <RepositoryReference Include="newtonsoft-json901" />
     <RepositoryReference Include="roslyn" />
     <RepositoryReference Include="standard" />
-    <RepositoryReference Include="core-setup-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(BuildPortableRuntime)' == 'true'" />
+    <RepositoryReference Include="core-setup-portable" Condition="'$(TargetOS)' == 'Linux' and '$(BuildPortableRuntime)' == 'true'" />
   </ItemGroup>
 
   <Import Project="core-setup.common.targets" />

--- a/repos/core-setup.proj
+++ b/repos/core-setup.proj
@@ -9,7 +9,7 @@
     <RepositoryReference Include="newtonsoft-json901" />
     <RepositoryReference Include="roslyn" />
     <RepositoryReference Include="standard" />
-    <RepositoryReference Include="core-setup-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(SkipPortableRuntimeBuild)' != 'true'" />
+    <RepositoryReference Include="core-setup-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(BuildPortableRuntime)' == 'true'" />
   </ItemGroup>
 
   <Import Project="core-setup.common.targets" />

--- a/repos/coreclr-portable.proj
+++ b/repos/coreclr-portable.proj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <SourceDirectory>coreclr</SourceDirectory>
     <PortableBuild>true</PortableBuild>
-    <BuildingPortableRuntime>true</BuildingPortableRuntime>
-    <UseSystemLibraries>false</UseSystemLibraries>
+    <UseSystemLibunwind>false</UseSystemLibunwind>
   </PropertyGroup>
 
   <Import Project="coreclr.common.props" />

--- a/repos/coreclr.common.props
+++ b/repos/coreclr.common.props
@@ -2,6 +2,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
+    <UseSystemLibunwind Condition="'$(UseSytemLibunwind)' == ''">true</UseSystemLibunwind>
     <BuildArguments>$(Platform) $(Configuration) skiptests</BuildArguments>
     <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) -ignoreWarnings</BuildArguments>
     <BuildArguments>$(BuildArguments) -skipmanagedtools</BuildArguments>

--- a/repos/coreclr.proj
+++ b/repos/coreclr.proj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <RepositoryReference Include="linker" />
     <RepositoryReference Include="roslyn" />
-    <RepositoryReference Include="coreclr-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(SkipPortableRuntimeBuild)' != 'true'" />
+    <RepositoryReference Include="coreclr-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(BuildPortableRuntime)' == 'true'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/coreclr.proj
+++ b/repos/coreclr.proj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <RepositoryReference Include="linker" />
     <RepositoryReference Include="roslyn" />
-    <RepositoryReference Include="coreclr-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(BuildPortableRuntime)' == 'true'" />
+    <RepositoryReference Include="coreclr-portable" Condition="'$(TargetOS)' == 'Linux' and '$(BuildPortableRuntime)' == 'true'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/corefx.proj
+++ b/repos/corefx.proj
@@ -7,7 +7,7 @@
     <RepositoryReference Include="linker" />
     <RepositoryReference Include="coreclr" />
     <RepositoryReference Include="standard" />
-    <RepositoryReference Include="corefx-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(SkipPortableRuntimeBuild)' != 'true'" />
+    <RepositoryReference Include="corefx-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(BuildPortableRuntime)' == 'true'" />
   </ItemGroup>
 
   <Import Project="corefx.common.targets" />

--- a/repos/corefx.proj
+++ b/repos/corefx.proj
@@ -7,7 +7,7 @@
     <RepositoryReference Include="linker" />
     <RepositoryReference Include="coreclr" />
     <RepositoryReference Include="standard" />
-    <RepositoryReference Include="corefx-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(BuildPortableRuntime)' == 'true'" />
+    <RepositoryReference Include="corefx-portable" Condition="'$(TargetOS)' == 'Linux' and '$(BuildPortableRuntime)' == 'true'" />
   </ItemGroup>
 
   <Import Project="corefx.common.targets" />

--- a/repos/known-good.proj
+++ b/repos/known-good.proj
@@ -46,21 +46,21 @@
         <RepositoryReference Include="msbuild" />
         <RepositoryReference Include="nuget-client" />
         <RepositoryReference Include="websdk" />
-        <RepositoryReference Include="coreclr" />
-        <RepositoryReference Include="coreclr-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(BuildPortableRuntime)' == 'true'" />
+        <RepositoryReference Include="coreclr" Condition="'$(BuildNonPortableRuntime)' == 'true'" />
+        <RepositoryReference Include="coreclr-portable" Condition="$(TargetOS)' == 'Linux' and '$(BuildPortableRuntime)' == 'true'" />
 
         <RepositoryReference Include="templating" />
 
         <!-- Tier 3 -->
 
         <RepositoryReference Include="aspnet-extensions" />
-        <RepositoryReference Include="corefx" />
-        <RepositoryReference Include="corefx-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(BuildPortableRuntime)' == 'true'" />
+        <RepositoryReference Include="corefx" Condition="'$(BuildNonPortableRuntime)' == 'true'" />
+        <RepositoryReference Include="corefx-portable" Condition="'$(TargetOS)' == 'Linux' and '$(BuildPortableRuntime)' == 'true'" />
 
         <!-- Tier 4 -->
 
-        <RepositoryReference Include="core-setup" />
-        <RepositoryReference Include="core-setup-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(BuildPortableRuntime)' == 'true'" />
+        <RepositoryReference Include="core-setup" Condition="'$(BuildNonPortableRuntime)' == 'true'" />
+        <RepositoryReference Include="core-setup-portable" Condition="'$(TargetOS)' == 'Linux' and '$(BuildPortableRuntime)' == 'true'" />
 
         <!-- Tier 5 -->
 

--- a/repos/known-good.proj
+++ b/repos/known-good.proj
@@ -47,7 +47,7 @@
         <RepositoryReference Include="nuget-client" />
         <RepositoryReference Include="websdk" />
         <RepositoryReference Include="coreclr" />
-        <RepositoryReference Include="coreclr-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(SkipPortableRuntimeBuild)' != 'true'" />
+        <RepositoryReference Include="coreclr-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(BuildPortableRuntime)' == 'true'" />
 
         <RepositoryReference Include="templating" />
 
@@ -55,12 +55,12 @@
 
         <RepositoryReference Include="aspnet-extensions" />
         <RepositoryReference Include="corefx" />
-        <RepositoryReference Include="corefx-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(SkipPortableRuntimeBuild)' != 'true'" />
+        <RepositoryReference Include="corefx-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(BuildPortableRuntime)' == 'true'" />
 
         <!-- Tier 4 -->
 
         <RepositoryReference Include="core-setup" />
-        <RepositoryReference Include="core-setup-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(SkipPortableRuntimeBuild)' != 'true'" />
+        <RepositoryReference Include="core-setup-portable" Condition="'$(PortableBuild)' != 'true' and '$(TargetOS)' == 'Linux' and '$(BuildPortableRuntime)' == 'true'" />
 
         <!-- Tier 5 -->
 

--- a/repos/known-good.proj
+++ b/repos/known-good.proj
@@ -47,7 +47,7 @@
         <RepositoryReference Include="nuget-client" />
         <RepositoryReference Include="websdk" />
         <RepositoryReference Include="coreclr" Condition="'$(BuildNonPortableRuntime)' == 'true'" />
-        <RepositoryReference Include="coreclr-portable" Condition="$(TargetOS)' == 'Linux' and '$(BuildPortableRuntime)' == 'true'" />
+        <RepositoryReference Include="coreclr-portable" Condition="'$(TargetOS)' == 'Linux' and '$(BuildPortableRuntime)' == 'true'" />
 
         <RepositoryReference Include="templating" />
 


### PR DESCRIPTION
Per https://github.com/dotnet/source-build/issues/1529, we believe this is the more common case.  Users who wish to generate a tarball on banana-linux and build from the tarball on apple-linux can still re-enable this behavior.