### PR TITLE
Add DownloadFileSB timeout and progress logging

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,11 +44,8 @@
     <PackagesDir Condition="'$(NuGetPackageRoot)' != ''">$(NuGetPackageRoot)</PackagesDir>
     <PackagesDir Condition="'$(PackagesDir)' == ''">$(ProjectDir)packages/restored/</PackagesDir>
     <ArcadeBootstrapPackageDir>$(PackagesDir)ArcadeBootstrapPackage/</ArcadeBootstrapPackageDir>
-    <!-- if we're not currently building,  Visual Studio will still set this -->
-    <SDK_VERSION Condition="'$(SDK_VERSION)' == ''">$(NETCoreSdkVersion)</SDK_VERSION>
     <DotNetSdkDir>$(DotNetCliToolDir)sdk/$(SDK_VERSION)/</DotNetSdkDir>
     <DotNetSdkResolversDir>$(DotNetSdkDir)SdkResolvers/</DotNetSdkResolversDir>
-    <SdkReferenceDir>$(DotNetCliToolDir)sdk/$(SDK_VERSION)/</SdkReferenceDir>
   </PropertyGroup>
 
   <!--

--- a/build.proj
+++ b/build.proj
@@ -149,17 +149,27 @@
   <Target Name="DownloadSourceBuildReferencePackages"
           AfterTargets="Build"
           Condition="'$(OfflineBuild)' != 'true' and '$(OS)' != 'Windows_NT' and '$(SkipDownloadingReferencePackages)' != 'true'">
+    <PropertyGroup Condition="'$(DownloadSourceBuildReferencePackagesTimeoutSeconds)' == ''">
+      <DownloadSourceBuildReferencePackagesTimeoutSeconds>600</DownloadSourceBuildReferencePackagesTimeoutSeconds>
+    </PropertyGroup>
+
     <DownloadFileSB 
           SourceUrl="$(ReferencePackagesTarballUrl)$(ReferencePackagesTarballName).$(PrivateSourceBuildReferencePackagesPackageVersion).tar.gz"
-          DestinationFolder="$(ExternalTarballsDir)" />
+          DestinationFolder="$(ExternalTarballsDir)"
+          TimeoutSeconds="$(DownloadSourceBuildReferencePackagesTimeoutSeconds)" />
   </Target>
 
   <Target Name="DownloadSourceBuiltArtifacts"
           AfterTargets="Build"
           Condition="'$(OfflineBuild)' != 'true' and '$(OS)' != 'Windows_NT' and '$(SkipDownloadingPreviouslySourceBuiltPackages)' != 'true'">
+    <PropertyGroup Condition="'$(DownloadSourceBuiltArtifactsTimeoutSeconds)' == ''">
+      <DownloadSourceBuiltArtifactsTimeoutSeconds>600</DownloadSourceBuiltArtifactsTimeoutSeconds>
+    </PropertyGroup>
+
     <DownloadFileSB 
           SourceUrl="$(SourceBuiltArtifactsTarballUrl)$(SourceBuiltArtifactsTarballName).$(PrivateSourceBuiltArtifactsPackageVersion).tar.gz"
-          DestinationFolder="$(ExternalTarballsDir)" />
+          DestinationFolder="$(ExternalTarballsDir)"
+          TimeoutSeconds="$(DownloadSourceBuiltArtifactsTimeoutSeconds)" />
   </Target>
 
   <!-- After building, generate a prebuilt usage report. -->

--- a/tools-local/tasks/Directory.Build.props
+++ b/tools-local/tasks/Directory.Build.props
@@ -6,6 +6,20 @@
     <Platform>AnyCPU</Platform>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <SdkReferenceDir Condition="'$(SDK_VERSION)' != ''">$(DotNetCliToolDir)sdk/$(SDK_VERSION)/</SdkReferenceDir>
+  </PropertyGroup>
+
+  <!--
+    If building in Visual Studio and the current SDK version isn't located in the repo (e.g. due to
+    roll-forward using a global install) or SDK_VERSION isn't defined at all, try searching for any
+    version to use as a fallback. The match just needs to be good enough to develop in: there isn't
+    a scenario where we build a task in Visual Studio then try to run it.
+  -->
+  <PropertyGroup Condition="!Exists('$(SdkReferenceDir)') and '$(VisualStudioVersion)' != ''">
+    <SdkReferenceDir>$(DotNetCliToolDir)sdk\*\</SdkReferenceDir>
+  </PropertyGroup>
+
   <!--
     Use some assemblies from the SDK, instead of package references. This ensures they match what's
     found when the task is loaded by the SDK's MSBuild.


### PR DESCRIPTION
In local tests, my average download speed seems to either be `~4,621.04 kB/s` or `~19,680.66 kB/s`, not really anything in between. I suspect we might be hitting something similar in CI causing the timeouts, just extremely low download speed at some certain chance.

To adjust the timeout or turn it off, use props like:

```
/p:DownloadSourceBuildReferencePackagesTimeoutSeconds=N/A
/p:DownloadSourceBuiltArtifactsTimeoutSeconds=N/A
```

Also include a fix (and simplification) for Visual Studio sb task authoring.

The idea/reasoning for a hang-detecting extra timeout comes from https://github.com/dotnet/core-setup/pull/6168#discussion_r279428268.

Example console output:

```
  DownloadFileSB timeout set to 00:10:00
  DownloadFileSB.Downloading https://dotnetfeed.blob.core.windows.net/dotnet-core/assets/Private.SourceBuild.ReferencePackages.1.0.0-beta.20107.1.tar.gz to /src/artifacts/obj/x64/Release/external-tarballs/Private.SourceBuild.ReferencePackages.1.0.0-beta.20107.1.tar.gz
  Progress... 00:00:00.0048674, current file size 00.0% (12,288 / 124,529,886) ~ 2,524.55 kB/s
  Progress... 00:00:05.0084819, current file size 72.0% (89,604,096 / 124,529,886) ~ 17,890.47 kB/s
  DownloadFileSB.StreamCopyComplete https://dotnetfeed.blob.core.windows.net/dotnet-core/assets/Private.SourceBuild.ReferencePackages.1.0.0-beta.20107.1.tar.gz
  DownloadFileSB.Downloading Complete! Elapsed: 00:00:08.3839997
  DownloadFileSB timeout set to 00:10:00
  DownloadFileSB.Downloading https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.0.1.0-3.1.101.2.tar.gz to /src/artifacts/obj/x64/Release/external-tarballs/Private.SourceBuilt.Artifacts.0.1.0-3.1.101.2.tar.gz
  Progress... 00:00:05.0013435, current file size 84.7% (740,610,048 / 874,103,134) ~ 148,082.22 kB/s
  DownloadFileSB.StreamCopyComplete https://dotnetcli.azureedge.net/source-built-artifacts/assets/Private.SourceBuilt.Artifacts.0.1.0-3.1.101.2.tar.gz
  Progress... 00:00:10.0016683, current file size 100.0% (874,103,134 / 874,103,134) ~ 87,395.73 kB/s
  DownloadFileSB.Downloading Complete! Elapsed: 00:00:14.7599156
```