### PR TITLE
WIP: Add a test to compare two SDK and show file diff

### DIFF
--- a/scripts/compare-builds.sh
+++ b/scripts/compare-builds.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# Tests to compare 2 SDK builds - generally a Microsoft-built SDK and
+# a source-build SDK. This should help us find issues/surprises before
+# we ship out a source-built SDK.
+#
+# See --help for more details, including usage
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# Filter out some directories that are special and source-build only:
+# - reference-packages/
+# - source-built-artifacts/
+paths_to_ignore_regex='\.\/reference-packages|\./source-built-artifacts'
+
+function usage() {
+    echo ""
+    echo "usage: $0 SDK1_TARBALL SDK2_TARBALL"
+    echo ""
+    echo "Compare 2 SDK builds to spot differences and potential regressions or other bugs."
+}
+
+function print_sdk_contents() {
+    sdk=$1
+    if [ -d "$sdk" ]; then
+        pushd "$sdk" >/dev/null
+        # We use two find invocation so we can add a / to the directories to match the file listing from tar
+        (find . -type d -print | sed -e 's|$|/|'; find . '!' -type d -print) \
+            | sort -u \
+            | grep -v -E "$paths_to_ignore_regex"
+        popd >/dev/null
+    else
+        if [[ "$sdk" =~ .*tar\.gz ]]; then
+            tar tf "$sdk" | sort -u | grep -v -E "$paths_to_ignore_regex"
+        else
+            echo "error: Unknown file type ${sdk}"
+            exit 1
+        fi
+    fi
+}
+
+function cleanup() {
+    if [ -d "$workdir" ]; then
+        rm -rf "$workdir"
+    fi
+}
+
+positional_args=()
+while :; do
+    if [ $# -le 0 ]; then
+        break
+    fi
+    lowerI="$(echo "$1" | awk '{print tolower($0)}')"
+    case $lowerI in
+        "-?"|-h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            positional_args+=("$1")
+            ;;
+    esac
+
+    shift
+done
+
+sdk1=${positional_args[0]:-}
+if [[ -z ${sdk1} ]]; then
+    echo "error: missing argument."
+    usage
+    exit 1
+fi
+sdk1=$(readlink -f "$sdk1")
+
+sdk2=${positional_args[1]:-}
+if [[ -z ${sdk2} ]]; then
+    echo "error: missing argument."
+    usage
+    exit 1
+fi
+sdk2=$(readlink -f "$sdk2")
+
+workdir=$(mktemp -d)
+file1="${workdir}/sdk-at-$(echo "$sdk1" | sed -e 's|/|-|g')"
+file2="${workdir}/sdk-at-$(echo "$sdk2" | sed -e 's|/|-|g')"
+
+print_sdk_contents "$sdk1" > "$file1"
+print_sdk_contents "$sdk2" > "$file2"
+
+echo "--- $sdk1"
+echo "+++ $sdk2"
+
+trap cleanup EXIT
+
+# The files noare not part of any repository. We could use plain `diff` here,
+# but it's not available on some platforms.
+git diff --no-index "$file1" "$file2" | tail -n +3

--- a/scripts/fetch-microsoft-sdk.sh
+++ b/scripts/fetch-microsoft-sdk.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Download a .NET Core SDK published by Microsoft.
+#
+# See --help for more details, including usage
+
+set -euo pipefail
+IFS=$'\n\t'
+
+function usage() {
+    echo ""
+    echo "usage: $0 SDK_VERSION [output-location]"
+    echo ""
+    echo "Download a particular .NET Core SDK built by Microsoft based on exact version match."
+}
+
+positional_args=()
+while :; do
+    if [ $# -le 0 ]; then
+        break
+    fi
+    lowerI="$(echo "$1" | awk '{print tolower($0)}')"
+    case $lowerI in
+        "-?"|-h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            positional_args+=("$1")
+            ;;
+    esac
+
+    shift
+done
+
+sdk_version=${positional_args[0]:-}
+if [[ -z ${sdk_version} ]]; then
+    echo "error: missing argument."
+    usage
+    exit 1
+fi
+
+output_location=${positional_args[1]:-dotnet-microsoft-built-sdk-${sdk_version}.tar.gz}
+
+install_script_url=https://dot.net/v1/dotnet-install.sh
+install_script_dir=$(mktemp -d)
+install_script=${install_script_dir}/dotnet-install.sh
+
+# Use curl if available, otherwise use wget
+if command -v curl > /dev/null; then
+    curl "${install_script_url}" -sSL --retry 10 --create-dirs -o "${install_script}"
+else
+    wget -q -O "${install_script}" "${install_script_url}"
+fi
+
+chmod +x "${install_script}"
+url=$("${install_script_dir}/dotnet-install.sh" --dry-run --version "${sdk_version}" | grep https | sed -E 's|.*(https://.*tar.gz)$|\1|' | head -1)
+echo "${url}"
+
+# Use curl if available, otherwise use wget
+if command -v curl > /dev/null; then
+    curl "${url}" -sSL --retry 10 --create-dirs -o "${output_location}"
+else
+    wget -q -O "${output_location}" "${url}"
+fi
+
+rm "${install_script}"
+rmdir "${install_script_dir}"

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 SCRIPT_ROOT="$(cd -P "$( dirname "$0" )" && pwd)"
-TARBALL_PREFIX=dotnet-sdk-
 VERSION_PREFIX=3.1
 # See https://github.com/dotnet/source-build/issues/579, this version
 # needs to be compatible with the runtime produced from source-build
@@ -61,9 +60,9 @@ while :; do
         break
     fi
 
-    lowerI="$(echo $1 | awk '{print tolower($0)}')"
+    lowerI="$(echo "$1" | awk '{print tolower($0)}')"
     case $lowerI in
-        -?|-h|--help)
+        "-?"|-h|--help)
             usage
             exit 0
             ;;
@@ -363,7 +362,7 @@ export NUGET_PACKAGES="$restoredPackagesDir"
 SOURCE_BUILT_PKGS_PATH="$SCRIPT_ROOT/artifacts/obj/x64/$configuration/blob-feed/packages/"
 export DOTNET_ROOT="$dotnetDir"
 # OSX also requires DOTNET_ROOT to be on the PATH
-if [ `uname` == 'Darwin' ]; then
+if [ "$(uname)" == 'Darwin' ]; then
     export PATH="$dotnetDir:$PATH"
 fi
 
@@ -403,5 +402,9 @@ if [ "$excludeOnlineTests" == "false" ]; then
     copyRestoredPackages
     echo "ONLINE RESTORE SOURCE - ALL TESTS PASSED!"
 fi
+
+fullSdkVersion="$($dotnetDir/dotnet --version)"
+"$SCRIPT_ROOT/scripts/fetch-microsoft-sdk.sh" "$fullSdkVersion" "microsoft-built-dotnet-sdk-${fullSdkVersion}.tar.gz"
+"$SCRIPT_ROOT/scripts/compare-builds.sh" "$dotnetDir" "microsoft-built-dotnet-sdk-${fullSdkVersion}.tar.gz" || true
 
 echo "ALL TESTS PASSED!"


### PR DESCRIPTION
This should let us catch surprises in releases.

Here's the current output of this script when comparing my local `/usr/lib64/dotnet` (source-build, 3.1.103) with `~/local/dotnet-sdk-3.1.103` (Microsoft's build, downloaded from dot.net):

https://gist.github.com/omajid/9111a9310d452b3594b770d4ca8a3d87

A couple of questions:

0. Does this seem useful?

1. Do we want to run this manually at release time? Is there a release-checklist I should edit?

2. Is the output useful in its current form? Should I be filtering out more or fewer things?

3. Do we want to hook this into CI? And somehow flag any changes to the expected diff? If that's the case, how do we want to handle file version differences?