### PR TITLE
Repo consolidation updates for aspnetcore

### DIFF
--- a/Documentation/planning/arcade-powered-source-build/implementation-plan.md
+++ b/Documentation/planning/arcade-powered-source-build/implementation-plan.md
@@ -23,9 +23,7 @@ To get each repo building with the new source-build 5.0 plan, [Arcade-Powered So
 | 2 | msbuild | [Ben Villalobos](https://github.com/BenVillalobos) | ✔️ | 4 | | | | | |
 | 2 | NuGet.Client | [Fernando Aguilar Reyes](https://github.com/dominoFire) | ✔️ | 8 | | | | | |
 | 2 | templating | [Jose Aguilar](https://github.com/donJoseLuis) | ✔️ | ✔️ | | | | | |
-| 3 | extensions | [John Luo](https://github.com/JunTaoLuo) | ⏱ | 1 | | | | | |
-| 3 | aspnetcore-tooling | [John Luo](https://github.com/JunTaoLuo) | ⏱ | 3 | | | | | |
-| 3 | aspnetcore | [John Luo](https://github.com/JunTaoLuo) | ⏱ | 11 | | | | | |
+| 3 | aspnetcore | [John Luo](https://github.com/JunTaoLuo) | ⏱ | 14 | | | | | |
 | 3 | websdk | [Vijay Ramakrishnan](https://github.com/vijayrkn) | ⏱ | 1 | | | | | |
 | 4 | sdk | [Sarah Oslund](https://github.com/sfoslund) |  | 2 + 3(cli) + 3(toolset) | | | | | |
 | 4 | vstest | [Sarabjot Singh](https://github.com/singhsarab) |  | 6 | | | | | |


### PR DESCRIPTION
@dseefeld Here are the changes in the docs to reflect what's going on in aspnetcore in 5.0.

extensions consolidation occurred in preview2 and portions moved to dotnet/runtime and dotnet/aspnetcore according to the docs https://github.com/aspnet/Announcements/issues/411
aspnetcore-tooling consolidation occurred in preview6 and moved to dotnet/aspnetcore