### PR TITLE
Add persistent support/tarball/smoke-testNuGet.Config

### DIFF
--- a/support/tarball/smoke-testNuGet.Config
+++ b/support/tarball/smoke-testNuGet.Config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
+    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
+    <add key="source-built-packages" value="SOURCE_BUILT_PACKAGES" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="ProdCon" value="PRODUCT_CONTRUCTION_PACKAGES" />
+    <add key="smoke-test feed" value="SMOKE_TEST_PACKAGE_FEED" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
This file was added at the beginning of the 3.1.106 release process (https://github.com/dotnet/source-build/pull/1663) and removed at the end, to deal with authed sources. The removal was intended as a way to keep `/smoke-testNuGet.config` and `/support/tarball/smoke-testNuGet.config` in sync over time (we'd create a new copy from the main one when we need it), but the release process is simpler if we just keep both copies even when they're identical. We don't expect significant drift with these files in the servicing branch anyway.

https://github.com/dotnet/source-build/issues/1669 tracks a better approach that will let us remove this file altogether.