### PR TITLE
Release checklist updates post 3.1.106/2.1.516

### DIFF
--- a/.github/ISSUE_TEMPLATE/releases/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/releases/release_checklist.md
@@ -86,6 +86,8 @@
 1.  - [ ] [Internal] Send the tarball to partners. Include info about how certain we are that this will be the final Microsoft build.
       - Never overwrite a tarball. At least change the blob storage virtual dir to represent a new build. This can help avoid timing issues and make it more obvious if stale links were accidentally re-sent rather than new ones.
 1.  - [ ] SYNC POINT: Wait for Microsoft build release.
+      - Wait for dotnet/announcements post. <kbd>Watch</kbd> the repo to get emails so you don't have to poll.
+        - Example: <https://github.com/dotnet/announcements/issues/160>.
 1.  - [ ] [Internal] [3.1] In a dev branch on your GitHub fork of source-build, clean up.
       - [ ] [Internal] [3.1] Convert internal URIs to public in `eng/Version.Details.xml`.
         - `https://dev.azure.com/dnceng/internal/_git/<org>-<repo>` => `https://github.com/<org>/<repo>`

--- a/.github/ISSUE_TEMPLATE/releases/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/releases/release_checklist.md
@@ -15,10 +15,10 @@
 -->
 # {runtime-version} / {sdk-version}
 
-1.  - [ ] Create a doc to take ongoing notes on problems with the process, workarounds, and fixes.
+1.  - [ ] Create a page at ".NET Core A&D" OneNote -> "Servicing" section -> "{Month} {YYYY}" to take ongoing notes on problems with the process, workarounds, and fixes.
       - This is useful to make sure context is available to review later. It may end up blank if the release goes very smoothly.
-      - The common location is ".NET Core A&D" OneNote -> "Servicing" section -> "{Month} {YYYY}".
-        - There are other notes on servicing in this OneNote. It may be useful to review if something goes wrong to see if it's been fixed before.
+      - There are other notes on servicing in this OneNote. It may be useful to review if something goes wrong to see if it's been fixed before.
+      - [Non-Internal] File GitHub issues as you encounter problems, and link to them from the notes. Provide info in the issue rather than in the notes.
 1.  - [ ] [Internal] Ensure internal/release/X.Y branch is up to date with mirrored release/X.Y branch.
 1.  - [ ] Update to new version.
       - [2.1] [/Documentation/servicing/update-2.1.md](https://github.com/dotnet/source-build/tree/release/3.1/Documentation/servicing/update-2.1.md)

--- a/.github/ISSUE_TEMPLATE/releases/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/releases/release_checklist.md
@@ -97,7 +97,7 @@
 1.  - [ ] [Internal] Add source-build team as reviewers.
 1.  - [ ] [Internal] When CI is green and two reviewers approve, merge.
       - Avoid squash/rebase: nice to preserve commit hashes. However, there are no known dependencies on *source-build* commits being preserved.
-1.  - [ ] Create and push tags. [/Documentation/servicing/tagging.md](https://github.com/dotnet/source-build/tree/release/3.1/Documentation/servicing/tagging.md)
+1.  - [ ] Create and push tags on the post-merge commit. [/Documentation/servicing/tagging.md](https://github.com/dotnet/source-build/tree/release/3.1/Documentation/servicing/tagging.md)
 1.  - [ ] Notify distro maintainers and partners about the release tags
 1.  - [ ] [3.1] Download Private.SourceBuilt.Artifacts.XX.tar.gz files from offline CI legs.
 1.  - [ ] [3.1] Merge Private.SourceBuilt.Artifacts.XX.tar.gz files.

--- a/.github/ISSUE_TEMPLATE/releases/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/releases/release_checklist.md
@@ -78,11 +78,26 @@
       - Note: The PR is internal for internal builds and on GitHub for non-internal builds.
       - [Non-Internal] Merge the PR when green and accepted.
       - [Internal] Don't merge the PR.
-      - [ ] [Internal] Download the artifacts from the green PR validation build. This saves a lot of time getting the tarball to partners.
+      - [ ] Download the artifacts from the green PR validation build.
         - Download the tarball and smoke-test prereqs from each job.
           - We may require only a subset for certain releases: refer to the previous release email thread corresponding to 2.1 vs. 3.1 build.
         - Rename tarball and smoke-test prereqs to human-friendly names. Refer to previous release email for naming pattern.
           - Can use <https://github.com/dagood/terminal-setup/blob/master/bash-util/rename-inner-targz> to do this.
+1.  - [ ] Upload tarballs and smoke-test prereqs to blob storage.
+1.  - [ ] Coordinate with team and complete manual distributed smoke-testing. Suggested assignment below, but it's flexible.
+      - [2.1]
+        - [ ] RHEL7 and RHEL8 VMs - crummel
+        - [ ] RHEL docker - dleeapho
+        - [ ] Fedora30 - dseefeld
+        - [ ] Fedora31 - dagood
+        - [ ] Debian9 - crummel
+      - [3.1]
+        - [ ] RHEL 7 & 8 VM - crummel
+        - [ ] RHEL Docker - dleeapho
+        - [ ] Fedora30 - dseefeld
+        - [ ] CentOS 7 - dagood
+        - [ ] CentOS 8 - dseefeld
+        - [ ] Debian - dagood
 1.  - [ ] [Internal] Send the tarball to partners. Include info about how certain we are that this will be the final Microsoft build.
       - Never overwrite a tarball. At least change the blob storage virtual dir to represent a new build. This can help avoid timing issues and make it more obvious if stale links were accidentally re-sent rather than new ones.
 1.  - [ ] SYNC POINT: Wait for Microsoft build release.

--- a/.github/ISSUE_TEMPLATE/releases/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/releases/release_checklist.md
@@ -32,10 +32,10 @@
           - Ensure auth details are **not** included in this file.
         - [ ] Verify/update the ASP.NET versions (`MicrosoftAspNetCoreAllPackageVersion` and `MicrosoftAspNetCoreAppPackageVersion`) in dependencies.props.
         - [ ] Verify/update the `OfficialBuildId`s in updated repos (usually coreclr, corefx, core-setup).
-        - [ ] Update the `DotnetCLIVersion.txt` SDK version to N-1.
+        - [ ] Update the `DotnetCLIVersion.txt` SDK version to N-1: the latest released "2.1.XYY" SDK version, where "2.1.X" matches the SDK we're building.
       - [3.1]
         - [ ] Verify that the `PrivateSourceBuiltArtifactsPackageVersion` in `eng/Versions.props` matches N-1 release artifacts.
-        - [ ] Update the `global.json` SDK version to N-1.
+        - [ ] Update the `global.json` SDK version to N-1: the latest released "3.1.XYY" SDK version, where "3.1.X" matches the SDK we're building.
 1.  - [ ] Regenerate patches as necessary.
       - Run `./build.sh /t:CloneOnly /t:ApplyPatches` to minimally clone and attempt patch application to see what, if anything, needs to be regenerated.
       - ASP.NET will always need to be regenerated because it contains a version number that needs to be updated.

--- a/.github/ISSUE_TEMPLATE/releases/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/releases/release_checklist.md
@@ -126,6 +126,7 @@
 1.  - [ ] [3.1] Merge Private.SourceBuilt.Artifacts.XX.tar.gz files.
       - Make sure the centos7 portable offline one is the one that ends up in `coreclr-tooling`.
 1.  - [ ] [3.1] Upload merged Private.SourceBuilt.Artifacts.XX.tar.gz file to dotnetcli account source-built-artifacts blob container.
+      - Never overwrite a tarball. Use a sub-patch version if one already exists, e.g. `0.1.0-3.1.105.1`.
 1.  - [ ] If there's a respin (for any reason: source-build infra fixes or upstream repo problems):
       - Go back in this process checklist as far as necessary.
       - When tagging, make sure to create a new tag. A sub-patch version tag for SDK and runtime must be generated. E.g - v2.1.300.1-SDK

--- a/.github/ISSUE_TEMPLATE/releases/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/releases/release_checklist.md
@@ -1,49 +1,109 @@
 # .NET Core Release Checklist
 
-## Release Versions
+<!--
+  To start the checklist for a new release:
+  - If it's an internal release, open a new issue in dotnet/core-eng (private repo).
+    - Otherwise, open a new issue in dotnet/source-build.
+  - Paste one copy of the below checklist per release. (Once for 2.1, again for 3.1, if both are being serviced)
+  - Delete lines that only apply to other releases. (E.g. delete [2.1] if doing a 3.1 release.)
+  - Delete lines starting with [Internal] if running a non-internal release.
+  - Delete lines starting with [Non-Internal] if running an internal release.
+-->
 
-_The set of .NET Core versions that are being released as a unit._
+<!--
+  Enter the version tracked by this checklist.
+-->
+# {runtime-version} / {sdk-version}
 
-* 2.1.X: <runtime/SDK>
-* 3.1.X: <runtime/SDK>
-
-1. - [ ] Update target branch to new version.
-   - For 2.x:
-     - [ ] If releasing 2.x, run auto-update (refer to docs).
-   - For 3.x:
-     - [ ] if maestro auto-PR is active, then verify SHA1s in version.Details with manifest versions in VSU share dir (refer docs), make sure that we match the versions
-     - [ ] if auto-PR updates are unavailable, checkout a local branch for the pertinent version and run darc updates(refer docs). 
-       - [ ] Push this local branch upstream and start the release PR for the N version that is to be released.
-1. - [ ] Version updates and confirmations
-   - For 2.x:
-       - [ ] Verify that `source-build/ProdConFeed.txt` contains the latest feed required for the release. For info on latest feed (refer OneNote).
-       - [ ] Verify/update the ASP.NET versions (`MicrosoftAspNetCoreAllPackageVersion` and `MicrosoftAspNetCoreAppPackageVersion`) in dependencies.props.
-       - [ ] Verify/update the `OfficialBuildId`s in updated repos (usually coreclr, corefx, core-setup).
-   - For 3.x:
-       - [ ] Verify that the `PrivateSourceBuiltArtifactsPackageVersion` in `eng/Versions.props` match N-1 release artifacts.
-1. - [ ] Build locally/in-CI and get to a clean build
-1. - [ ] Complete prebuilt and poison audit. Review the baseline changes to find out if there are any new prebuilts.
-1. - [ ] Verify the the packs included in the SDK are from source-build-reference-packages, not source-build, and have XML documentation comments. 
-1. - [ ] Remove new prebuilts, if any. Ideally any new prebuilts that show up in offline builds have to be removed. In some cases, new prebuilts show up in Production builds but gets purged in offline builds automatically as they are not packaged(they may not be needed for the actual build).
-1. - [ ] If significant delays are anticipated, notify the distro maintainer with PR link mentioning that a PR is ready, but we're waiting on the final validation. Do not tag the release until we have the final validation for the Microsoft build.
-1. - [ ] Re-validate the SHA1s in Versions file with the manifest in VSU share dir
-1. - [ ] Tag runtime version (e.g. "v2.1.0-runtime") with an annotated (preferably signed) tag including runtime and SDK versions, e.g. "Release for 2.1.0 runtime and 2.1.300 SDK."
-      - `git tag -s v<X.X.X-runtime/SDK> <SHA1>` . E.g - $ git tag -s v2.1.0-runtime c7012bcc8
-1. - [ ] Tag SDK version (e.g. "v2.1.300-SDK") with the same annotation, also preferably signed
-1. - [ ] Push these tags to GitHub
-      - `git push <remote> v2.1.0-runtime && git push <remote> v2.1.300-SDK`
-            
-        Do not use "git push --tags" unless you have a fresh repo with no other tags - this will push all your tags.
-1. - [ ] If there's a respin, retag the with the new changes. A sub-patch version tag for SDK and runtime would have to be generated. E.g - v2.1.300.1-SDK
-1. - [ ] Notify the distro maintainer/s about the release tags
-1. - [ ] Download the tarball from CI
-1. - [ ] Upload the tarball to Azure blob feed for source-build
-
-            <Source-build-blob-feed-container>/redhat/<branch_version>/<SDK_version>/dotnet-<sdk_version>-<RID>.tar.gz
-
-1. - [ ] Similarly, download Private.SourceBuilt.Artifacts.XX.tar.gz from CI and upload it to source-built-artifacts blob container
-1. - [ ] Write a post-mortem for the release
-
-### Additional notes
-
-See the .NET Core A&D OneNote -> Tarball section -> Source-build release checklist.
+1.  - [ ] Create a doc to take ongoing notes on problems with the process, workarounds, and fixes.
+      - This is useful to make sure context is available to review later. It may end up blank if the release goes very smoothly.
+      - The common location is ".NET Core A&D" OneNote -> "Servicing" section -> "{Month} {YYYY}".
+        - There are other notes on servicing in this OneNote. It may be useful to review if something goes wrong to see if it's been fixed before.
+1.  - [ ] [Internal] Ensure internal/release/X.Y branch is up to date with mirrored release/X.Y branch.
+1.  - [ ] Update to new version.
+      - [2.1] [/Documentation/servicing/update-2.1.md](https://github.com/dotnet/source-build/tree/release/3.1/Documentation/servicing/update-2.1.md)
+      - [3.1] [/Documentation/servicing/update-3.1.md](https://github.com/dotnet/source-build/tree/release/3.1/Documentation/servicing/update-3.1.md)
+      - Start a new working branch and PR for WIP so others can easily look if needed and CI starts running.
+        - [Internal] For internal builds, use <https://dev.azure.com/dnceng/internal/_git/dotnet-source-build>, branch name `internal/release/<SDK-version>-<month name><YYYY>`.
+1.  - [ ] Version update cleanup and confirmations
+      - [2.1]
+        - [ ] Verify that `source-build/ProdConFeed.txt` contains the latest feed required for the release.
+          - Build number should match ProdCon build number.
+          - Ensure auth details are **not** included in this file.
+        - [ ] Verify/update the ASP.NET versions (`MicrosoftAspNetCoreAllPackageVersion` and `MicrosoftAspNetCoreAppPackageVersion`) in dependencies.props.
+        - [ ] Verify/update the `OfficialBuildId`s in updated repos (usually coreclr, corefx, core-setup).
+        - [ ] Update the `DotnetCLIVersion.txt` SDK version to N-1.
+      - [3.1]
+        - [ ] Verify that the `PrivateSourceBuiltArtifactsPackageVersion` in `eng/Versions.props` matches N-1 release artifacts.
+        - [ ] Update the `global.json` SDK version to N-1.
+1.  - [ ] Regenerate patches as necessary.
+      - Run `./build.sh /t:CloneOnly /t:ApplyPatches` to minimally clone and attempt patch application to see what, if anything, needs to be regenerated.
+      - ASP.NET will always need to be regenerated because it contains a version number that needs to be updated.
+1.  - [ ] [2.1] Fetch internal git data for submodules.
+      1.  Run `git submodule update --init --recursive` and see errors due to missing commits.
+      1.  Run `fetch-vsts-commits.sh` with a PAT to automatically fetch internal refs.
+          * If some refs are still missing on unusual repos, those repos may need to be set up in `fetch-vsts-commits.sh`.
+1.  - [ ] Start building locally (for quick diagnosis) and in CI (for super clean build) and iterate towards a green build.
+      - [Internal] [3.1] Set environment variable `internalPackageFeedPat` to dnceng internal PAT with package read and code read access.
+        - E.g. run `export internalPackageFeedPat;read internalPackageFeedPat` and paste the PAT. This sets up your running shell for an authenticated build. Passing `/p:` isn't sufficient.
+      - [Internal] [3.1] Also pass arg `/p:AzDoPat=$internalPackageFeedPat` for darc clone in particular.
+      - [Internal] [2.1] Pass auth arg `/p:ProdConBlobFeedUrlPrefix=<url up to and not including 'orchestrated-release-2-1/' from feed.txt>`
+      - [Internal] [2.1] When running smoke-test locally, also pass `/p:ProdConBlobFeedUrlPrefix=<...>`
+        - The smoke-test command looks like `./build.sh /t:RunSmokeTest /p:Configuration=Release /p:ProdConBlobFeedUrlPrefix=***`.
+      - Update baseline from the CI job, using the `centos71 Offline` artifacts.
+        - `Logs centos71 Offline/source-build/logs/artifacts/prebuilt-report/generated-new-baseline.xml`
+          - => `tools-local/prebuilt-baseline-online.xml`
+        - `Logs centos71 Offline/tarball/logs/artifacts/prebuilt-report/generated-new-baseline.xml`
+          - => `tools-local/prebuilt-baseline-offline.xml`
+1.  - [ ] Review prebuilt baseline diff and iterate builds to drive to zero.
+      - Find an explanation for each change in each (online/offline) baseline.
+        - If possible, figure out the cause and fix.
+          - Discuss with repo or code owner if the fix is a new patch.
+          - This may require adding packages to dotnet/source-build-reference-packages.
+        - If the baseline change is due to the change in patch version, make sure there's an issue tracking fixing the instability, or start tracking it.
+        - If in doubt, talk to the team. Someone might have already encountered a similar diff in the past.
+1.  - [ ] Complete manual validation steps
+      - [ ] Ask for confirmation on poison report.
+        - Confirm with team how to check this for a specific build/release.
+      - [ ] Verify the packs included in the SDK are from source-build-reference-packages, not source-build.
+        - E.g. in `testing-smoke/builtCli`, run `find . -iname System.IO.Pipelines.dll -exec sha256sum {} \; | sort` and look at file origin based on checksum of the file in the SDK.
+      - [ ] Verify the packs included in the SDK have XML documentation comments. 
+      - [ ] Re-validate the SHA1s in Versions file with the manifest in VSU share dir.
+      - [ ] [3.1] Review the file list diff between Microsoft-built SDK and source-built SDK in smoke-test output.
+        - [Internal] [3.1] For internal builds, smoke-test fails to acquire the Microsoft-built SDK. Manually acquire the Microsoft-built SDK from the build email you should have received, then run `scripts/compare-builds.sh` yourself to get the output to review.
+          - [#1631](https://github.com/dotnet/source-build/issues/1631) tracks a fix.
+        - Use <https://gist.github.com/omajid/9111a9310d452b3594b770d4ca8a3d87> as a loose baseline.
+          - [#1630](https://github.com/dotnet/source-build/issues/1630) tracks a checked-in baseline.
+1.  - [ ] Add team members as reviewers to the PR. Get acceptance.
+      - Note: The PR is internal for internal builds and on GitHub for non-internal builds.
+      - [Non-Internal] Merge the PR when green and accepted.
+      - [Internal] Don't merge the PR.
+      - [ ] [Internal] Download the artifacts from the green PR validation build. This saves a lot of time getting the tarball to partners.
+        - Download the tarball and smoke-test prereqs from each job.
+          - We may require only a subset for certain releases: refer to the previous release email thread corresponding to 2.1 vs. 3.1 build.
+        - Rename tarball and smoke-test prereqs to human-friendly names. Refer to previous release email for naming pattern.
+          - Can use <https://github.com/dagood/terminal-setup/blob/master/bash-util/rename-inner-targz> to do this.
+1.  - [ ] [Internal] Send the tarball to partners. Include info about how certain we are that this will be the final Microsoft build.
+      - Never overwrite a tarball. At least change the blob storage virtual dir to represent a new build. This can help avoid timing issues and make it more obvious if stale links were accidentally re-sent rather than new ones.
+1.  - [ ] SYNC POINT: Wait for Microsoft build release.
+1.  - [ ] [Internal] [3.1] In a dev branch on your GitHub fork of source-build, clean up.
+      - [ ] [Internal] [3.1] Convert internal URIs to public in `eng/Version.Details.xml`.
+        - `https://dev.azure.com/dnceng/internal/_git/<org>-<repo>` => `https://github.com/<org>/<repo>`
+      - [ ] [Internal] [3.1] Remove internal package feeds from source-build.
+        - `/NuGet.Config`
+        - `/smoke-testNuGet.Config`
+        - Do not remove from subrepos. The build infra removes these sources automatically while modifying each subrepo nuget.config file.
+1.  - [ ] [Internal] Push the servicing branch to your GitHub fork and submit a source-build PR.
+1.  - [ ] [Internal] Add source-build team as reviewers.
+1.  - [ ] [Internal] When CI is green and two reviewers approve, merge.
+      - Avoid squash/rebase: nice to preserve commit hashes. However, there are no known dependencies on *source-build* commits being preserved.
+1.  - [ ] Create and push tags. [/Documentation/servicing/tagging.md](https://github.com/dotnet/source-build/tree/release/3.1/Documentation/servicing/tagging.md)
+1.  - [ ] Notify distro maintainers and partners about the release tags
+1.  - [ ] [3.1] Download Private.SourceBuilt.Artifacts.XX.tar.gz files from offline CI legs.
+1.  - [ ] [3.1] Merge Private.SourceBuilt.Artifacts.XX.tar.gz files.
+      - Make sure the centos7 portable offline one is the one that ends up in `coreclr-tooling`.
+1.  - [ ] [3.1] Upload merged Private.SourceBuilt.Artifacts.XX.tar.gz file to dotnetcli account source-built-artifacts blob container.
+1.  - [ ] If there's a respin (for any reason: source-build infra fixes or upstream repo problems):
+      - Go back in this process checklist as far as necessary.
+      - When tagging, make sure to create a new tag. A sub-patch version tag for SDK and runtime must be generated. E.g - v2.1.300.1-SDK
+1.  - [ ] Clean up retrospective notes if necessary.

--- a/.github/ISSUE_TEMPLATE/releases/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/releases/release_checklist.md
@@ -98,6 +98,12 @@
 1.  - [ ] [Internal] When CI is green and two reviewers approve, merge.
       - Avoid squash/rebase: nice to preserve commit hashes. However, there are no known dependencies on *source-build* commits being preserved.
 1.  - [ ] Create and push tags on the post-merge commit. [/Documentation/servicing/tagging.md](https://github.com/dotnet/source-build/tree/release/3.1/Documentation/servicing/tagging.md)
+1.  - [ ] Create a GitHub release on the tag with SDK versioning.
+      - Go to <https://github.com/dotnet/source-build/tags>
+      - Expand the SDK-versioned tag's message and copy it
+      - Click <kbd>...</kbd> on the right on the SDK-versioned tag and press "Create release"
+      - Paste into the release title
+      - Click submit.
 1.  - [ ] Notify distro maintainers and partners about the release tags
 1.  - [ ] [3.1] Download Private.SourceBuilt.Artifacts.XX.tar.gz files from offline CI legs.
 1.  - [ ] [3.1] Merge Private.SourceBuilt.Artifacts.XX.tar.gz files.

--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,6 @@ artifacts
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/
-[Rr]elease/
-[Rr]eleases/
 x64/
 x86/
 build/

--- a/Documentation/servicing/tagging.md
+++ b/Documentation/servicing/tagging.md
@@ -1,0 +1,38 @@
+# Tagging a release
+
+Set up a signing key if you haven't already:
+- Generating a key: <https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key>
+- Adding to GitHub: <https://docs.github.com/en/github/authenticating-to-github/adding-a-new-gpg-key-to-your-github-account>
+
+## Create tags
+Create annotated and signed tags with a shared message that includes both the runtime and SDK versions, e.g. "Release for 2.1.0 runtime and 2.1.300 SDK."
+
+You can paste this and fill in the prompts to do this:
+
+```sh
+read -p 'Runtime version (X.Y.Z): ' runtimeVersion; \
+read -p 'SDK version (X.Y.BZZ): ' sdkVersion; \
+read -p 'Commit: ' commit; \
+message="Release for $runtimeVersion runtime and $sdkVersion SDK."; \
+git tag -s "v${runtimeVersion}-runtime" $commit -m "$message"; \
+git tag -s "v${sdkVersion}-SDK" $commit -m "$message"; \
+echo "$message"
+```
+
+## Review the tags
+Look at tag info to spot any oddities. Double-check the versions and signing validity.
+
+```sh
+git tag -v "v${runtimeVersion}-runtime"; \
+git tag -v "v${sdkVersion}-SDK"
+```
+
+## Push the tags
+Run fully-specified pushes:
+
+```sh
+git push 'git@github.com:dotnet/source-build' "v${runtimeVersion}-runtime" && \
+git push 'git@github.com:dotnet/source-build' "v${sdkVersion}-SDK"
+```
+
+**Do not use "git push --tags"**. Unless you have a fresh repo with no other tags, this will push all your tags. This risks messing up existing tags on the remote.

--- a/Documentation/servicing/tagging.md
+++ b/Documentation/servicing/tagging.md
@@ -5,7 +5,7 @@ Set up a signing key if you haven't already:
 - Adding to GitHub: <https://docs.github.com/en/github/authenticating-to-github/adding-a-new-gpg-key-to-your-github-account>
 
 ## Create tags
-Create annotated and signed tags with a shared message that includes both the runtime and SDK versions, e.g. "Release for 2.1.0 runtime and 2.1.300 SDK."
+Create annotated and signed tags with a shared message that includes both the runtime and SDK versions, e.g. `Source-build 2.1.0 runtime and 2.1.300 SDK`.
 
 You can paste this and fill in the prompts to do this:
 
@@ -13,7 +13,7 @@ You can paste this and fill in the prompts to do this:
 read -p 'Runtime version (X.Y.Z): ' runtimeVersion; \
 read -p 'SDK version (X.Y.BZZ): ' sdkVersion; \
 read -p 'Commit: ' commit; \
-message="Release for $runtimeVersion runtime and $sdkVersion SDK."; \
+message="Source-build ${runtimeVersion} runtime and ${sdkVersion} SDK"; \
 git tag -s "v${runtimeVersion}-runtime" $commit -m "$message"; \
 git tag -s "v${sdkVersion}-SDK" $commit -m "$message"; \
 echo "$message"

--- a/Documentation/servicing/update-2.1.md
+++ b/Documentation/servicing/update-2.1.md
@@ -1,0 +1,54 @@
+# Running 2.1 auto-update
+
+## Internal: Running 2.1 auto-update using build definition
+
+1.  Open https://dev.azure.com/dnceng/internal/_build/index?definitionId=248
+1.  Find the ProdCon build number, in the format `YYYYMMDD-##`.
+    * This is the date of the first time this build spun. If the date seems old, this is probably because it's been respun.
+1.  Press "Queue new build"
+1.  Set the `pb.manifest.build` variable to the `YYYYMMDD-##` build number.
+1.  Press "Queue"
+1.  Open the build and wait for it to complete.
+1.  Find the auto-update PR at <https://dev.azure.com/dnceng/internal/_git/dotnet-source-build/pullrequests?_a=active>.
+
+## Public: Running 2.1 auto-update from dotnet/versions
+
+This is how to update using a public ProdCon manifest, like <https://github.com/dotnet/versions/tree/master/build-info/dotnet/product/cli/release/2.1.6>.
+
+Always look for full-versioned dirs. The 2.1 and 2.2 directories are prerelease/daily builds. If you can, wait until you hear internally that a build is done to make sure the update isn't a waste of time or picking the wrong build. Then:
+
+1.  Branch off the latest 2.1/2.2 commit in GitHub.
+1.  Make sure your submodules are pristine. (`git submodule update --init --recursive`)
+1.  Edit dependencies.props to set the updater to update from the dotnet/versions directory path: `<BasePath>build-info/dotnet/product/cli/release/2.1.6</BasePath>` in the following context:
+    ```xml
+    <DependencyInfo Include="ProdCon" Condition="'$(UpdateFromManifestFile)' == ''">
+      <DependencyType>Orchestrated build</DependencyType>
+      <BasePath>build-info/dotnet/product/cli/release/2.1.6</BasePath>
+      <CurrentRef>$(ProdConCurrentRef)</CurrentRef>
+      <VersionsRepoOwner>dotnet</VersionsRepoOwner>
+      <VersionsRepo>versions</VersionsRepo>
+    </DependencyInfo>
+    <DependencyInfo Include="ProdCon" Condition="'$(UpdateFromManifestFile)' != ''">
+      <DependencyType>Orchestrated build file</DependencyType>
+      <Path>$(UpdateFromManifestFile)</Path>
+    </DependencyInfo>
+    ```
+1.  Change the versions for ASP.NET in dependencies.props to match the latest release:
+    ```xml
+    <MicrosoftAspNetCoreAllPackageVersion>2.1.16</MicrosoftAspNetCoreAllPackageVersion>
+    <MicrosoftAspNetCoreAppPackageVersion>2.1.16</MicrosoftAspNetCoreAppPackageVersion>
+    ```
+1.  Run:
+    ```
+    .\build.cmd /t:InitBuild /p:SkipPatches=true
+    ```
+    * This sets up necessary tooling but avoids patching, since patches can prevent submodule checkouts.
+1.  Run:
+    ```
+    .\build.cmd /t:UpdateDependencies /p:UpdateFromManifestFile=$(manifestFile) /clp:v=n
+    ```
+    * Warnings about "Unable to find a desired hash for …" are normal.
+      * It just means that repo wasn't in the manifest for this particular ProdCon build.
+    * Errors are not normal.
+1.  Commit all changes, submit a PR.
+    * Example: https://github.com/dotnet/source-build/pull/840

--- a/Documentation/servicing/update-3.1.md
+++ b/Documentation/servicing/update-3.1.md
@@ -1,0 +1,25 @@
+# Running 3.1 auto-update
+
+## Run update manually
+
+1.  If you haven't already, set up `darc`.
+    * Run `eng/common/darc-init.sh`
+    * Run `darc authenticate`
+1.  Get the build id from the internal build assets.
+    1.  For example, in the build directory from email, copy "...\CORE_BUILDS\3.1.X\3.1.201\3.1.201-servicing-015034\manifest.json" locally and open it.
+    1.  Find the build for dotnet/core-sdk or dotnet/installer, grab its `barBuildId`.
+1.  Run `darc update-dependenices --id <barBuildId> --verbose` in source-build repo root.
+    * See https://github.com/dotnet/core-eng/issues/10155 for discussion about using channel vs. build ID.
+    * If darc fails on XliffTasks, comment out its `/eng/Version.Details.xml` entry temporarily and try again.
+1.  If authenticated feeds were added to `/NuGet.config`, copy them into `/smoke-testNuGet.config`.
+1.  Commit changes.
+1.  Verify the final state of the repos in `/eng/Version.Details.xml` matches `manifest.json`.
+
+## Look for an automatic Maestro++ PR
+
+There might be an auto-PR. Check:
+
+* Public: <https://github.com/dotnet/source-build/pulls/app%2Fdotnet-maestro>
+* Internal: <https://dev.azure.com/dnceng/internal/_git/dotnet-source-build/pullrequests?_a=active>
+
+*Do not use an auto-update PR*: we can't be sure it's accurate to the exact build Microsoft plans to ship (there may have been an unplanned build since then), and there may also be more general problems updating from a channel. Run the update manually, instead. More info at <https://github.com/dotnet/core-eng/issues/10155>.


### PR DESCRIPTION
Update the release checklist based on my experience with 3.1.106/2.1.516 servicing. I split out some details into docs with absolute links to keep it manageable but still capture everything that seems important without referring to internal docs.

Fixes https://github.com/dotnet/source-build/issues/1632, "Add Microsoft SDK vs. source-built SDK file list diff smoke-test review to release checklist"