### PR TITLE
Add prepare artifacts job; fixup AzDO fetch script

### DIFF
--- a/.vsts.pipelines/builds/matrix.yml
+++ b/.vsts.pipelines/builds/matrix.yml
@@ -72,3 +72,14 @@ jobs:
     scriptPrefix: ./
     scriptSuffix: .sh
     setupMac: true
+
+- template: ../jobs/prepare-artifacts.yml
+  parameters:
+    # Gather from all jobs that have offline in the matrix. This also defines dependencies.
+    gatherJobs:
+    - job: centos71
+    - job: centos8
+    - job: debian9
+      artifactName: Tarball debian9 Online
+    - job: fedora30
+    gatherPortableJob: centos71

--- a/.vsts.pipelines/builds/matrix.yml
+++ b/.vsts.pipelines/builds/matrix.yml
@@ -73,13 +73,15 @@ jobs:
     scriptSuffix: .sh
     setupMac: true
 
-- template: ../jobs/prepare-artifacts.yml
-  parameters:
-    # Gather from all jobs that have offline in the matrix. This also defines dependencies.
-    gatherJobs:
-    - job: centos71
-    - job: centos8
-    - job: debian9
-      artifactName: Tarball debian9 Online
-    - job: fedora30
-    gatherPortableJob: centos71
+# Prepare artifacts in all situations but public PR validation.
+- ${{ if not(and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'))) }}:
+  - template: ../jobs/prepare-artifacts.yml
+    parameters:
+      # Gather from all jobs that have offline in the matrix. This also defines dependencies.
+      gatherJobs:
+      - job: centos71
+      - job: centos8
+      - job: debian9
+        artifactName: Tarball debian9 Online
+      - job: fedora30
+      gatherPortableJob: centos71

--- a/.vsts.pipelines/jobs/prepare-artifacts.yml
+++ b/.vsts.pipelines/jobs/prepare-artifacts.yml
@@ -1,0 +1,84 @@
+parameters:
+  gatherJobs: []
+  gatherPortableJob: ''
+
+  # downloadBuildConfig by default uses the current build, but can be changed to point at an
+  # existing/previous build by passing properties like these, instead:
+  #
+  #   buildType: specific
+  #   buildVersionToDownload: specific
+  #   project: 'public'
+  #   definition: 'source-build-CI'
+  #   buildId: 741400
+  #
+  # By defining this in one place, it's easier to set this up if necessary. This may be useful
+  # because the build takes a long time relative to prepare-artifacts, and we may want to tweak
+  # prepare-artifacts in case it fails due to a bug in the future. ...It's also nice to have the
+  # properties listed in this comment even if we don't use them here, because it's hard to figure
+  # them out from the docs alone--it'll be a nice reference.
+  downloadBuildConfig:
+    buildType: current
+
+jobs:
+- job: PrepareArtifacts
+  pool:
+    vmImage: 'ubuntu-18.04'
+  dependsOn:
+  - ${{ each gather in parameters.gatherJobs }}:
+    - ${{ gather.job }}
+  timeoutInMinutes: 300
+  workspace:
+    clean: all
+  variables:
+    artifactStageDir: '$(Build.SourcesDirectory)/artifacts/stage'
+    nonportableSourceBuiltStageDir: '$(artifactStageDir)/nonportableSourceBuilt'
+    portableSourceBuiltStageDir: '$(artifactStageDir)/portableSourceBuilt'
+    allSourceBuiltStageDir: '$(artifactStageDir)/allSourceBuilt'
+    outputTarballFile: '$(artifactStageDir)/Private.SourceBuilt.Artifacts.$(Build.BuildId).tar.gz'
+  steps:
+  - ${{ each gather in parameters.gatherJobs }}:
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download ${{ gather.job }} nonportable'
+      inputs:
+        ${{ insert }}: ${{ parameters.downloadBuildConfig }}
+        downloadType: single
+        artifactName: ${{ coalesce(gather.artifactName, format('Tarball {0} Offline', gather.job)) }}
+        downloadPath: $(nonportableSourceBuiltStageDir)
+        allowPartiallySucceededBuilds: true
+
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download ${{ parameters.gatherPortableJob }} portable'
+    inputs:
+      ${{ insert }}: ${{ parameters.downloadBuildConfig }}
+      downloadType: single
+      artifactName: 'Tarball ${{ parameters.gatherPortableJob }} Offline Portable'
+      downloadPath: $(portableSourceBuiltStageDir)
+      allowPartiallySucceededBuilds: true
+
+  - script: |
+      find "$(artifactStageDir)" -type f -exec du -h {} \;
+    displayName: Show downloaded artifacts
+
+  - script: |
+      set -xeuo pipefail
+      mkdir -p "$(allSourceBuiltStageDir)"
+
+      # Extract all source-built assets into a single place. Overlap and overwrites are expected.
+      # What matters is the portable ones are copied last and ultimately win.
+      find \
+        "$(nonportableSourceBuiltStageDir)" \
+        "$(portableSourceBuiltStageDir)" \
+        -iname 'Private.SourceBuilt.Artifacts.*.tar.gz' \
+        -exec tar -xf {} -C "$(allSourceBuiltStageDir)" \;
+
+      # Intentionally don't create a top-level directory. Matches earlier versions of this artifact.
+      cd "$(allSourceBuiltStageDir)"
+      tar --numeric-owner -czf "$(outputTarballFile)" *
+    displayName: Create source-built artifacts tar.gz
+
+  - publish: '$(outputTarballFile)'
+    artifact: Private.SourceBuilt.Artifacts
+
+  - script: |
+      tar -tf "$(outputTarballFile)" | sort
+    displayName: Show tarball contents

--- a/scripts/fetch-azdo-artifact-tarball.sh
+++ b/scripts/fetch-azdo-artifact-tarball.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+# Library. Source this script or copy-paste it into a shell to import its functions.
 
-# Logic is encapsulated to make this function easy to copy-paste to a machine that doesn't have a
-# clone of this repository. This may be common when downloading a tarball.
+# Set up AzDO authentication if not already done in this environment, download a file, and extract
+# it to the current dir. Logic is encapsulated to make this function easy to copy-paste to a machine
+# that doesn't have a clone of this repository, which is common when downloading a tarball onto a
+# fresh machine to validate it.
+#
+# Usage: download_tarball <url>
+#   url: the URL to download. Wrap it in single quotes to avoid issues with special chars.
 download_tarball() {
+  [ "${azdo_build_pat:-}" ] || read -p 'AzDO dnceng PAT with build read permission: ' -s azdo_build_pat
   (
     set -euo pipefail
     url=$1
     temp_name=${temp_name:-tarball.tar.gz}
-
-    [ "$azdo_build_pat" ] || read -p 'AzDO dnceng PAT with build read permission: ' -s azdo_build_pat
 
     echo; echo 'Starting download...'
 
@@ -30,5 +34,3 @@ download_tarball() {
     echo 'Complete!'
   )
 }
-
-download_tarball "$@"

--- a/scripts/fetch-azdo-artifact-tarball.sh
+++ b/scripts/fetch-azdo-artifact-tarball.sh
@@ -23,6 +23,7 @@ download_tarball() {
       echo "Extracted using tar -xf"
     # Fall back to 'gunzip' as an intermediate to avoid problems found
     # decompressing archives with 'tar' when downloaded directly from AzDO.
+    # AzDO seems to double-compress the tar.gz: https://superuser.com/a/841876
     elif gunzip -d < "$temp_name" | tar -zx; then
       echo "Extracted using gunzip"
     else


### PR DESCRIPTION
Add a simple prepare-artifacts job to take over manual work preparing previously-source-built tarballs.

Fix up the AzDO fetch script: simplify and document for the scenario it's actually used for: downloading onto fresh machines for manual testing.

---

I worked on this to avoid manual steps for 3.1.106, and polished it a little more for this PR for next time.

Fixes https://github.com/dotnet/source-build/issues/1676