### PR TITLE
Run "git init" when .git doesn't exist to help GitHub source zip/tar.gz builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,6 +31,16 @@ if [ -z "${HOME:-}" ]; then
     mkdir "$HOME"
 fi
 
+# If .git doesn't exist at the repo root, create it. It's required for the build to work. The very
+# prominent source tar.gz and zip files created by GitHub don't include it, so it's worth having a
+# fallback here. See https://github.com/dotnet/source-build/issues/1646 for details.
+if [ ! -e "$scriptroot/.git" ]; then
+  (
+    cd "$scriptroot"
+    git init
+  )
+fi
+
 if grep -q '\(/docker/\|/docker-\)' "/proc/1/cgroup"; then
     export DotNetRunningInDocker=1
 fi


### PR DESCRIPTION
For https://github.com/dotnet/source-build/issues/1646

Download links with this change:
https://github.com/dagood/source-build/archive/49195585d0de06e9a06b8fb005c460035363b2af.zip
https://github.com/dagood/source-build/archive/49195585d0de06e9a06b8fb005c460035363b2af.tar.gz