### PR TITLE
Update 'release/3.1' => 'pre-arcade' SBRP branch in bootstrap CI

### DIFF
--- a/.vsts.pipelines/jobs/ci-linux_bootstrap.yml
+++ b/.vsts.pipelines/jobs/ci-linux_bootstrap.yml
@@ -50,7 +50,7 @@ jobs:
       set -ex
       df -h
       $(docker.run) $(docker.bst.map) $(docker.bst.work) $(imageName) bash -c '
-      git clone --single-branch --branch release/3.1 --depth 1 https://github.com/dotnet/source-build-reference-packages'
+      git clone --single-branch --branch pre-arcade --depth 1 https://github.com/dotnet/source-build-reference-packages'
       du -h $(rootDirectory) | sort -h | tail -n 50
     displayName: clone source-build-reference-packages
     condition: always()


### PR DESCRIPTION
See https://github.com/dotnet/source-build-reference-packages/pull/137

Removing this branch reference is tracked by https://github.com/dotnet/source-build/issues/1498