### PR TITLE
[release/3.1] Fix macOS PAT flow for internal non-authenticated builds

### DIFF
--- a/.vsts.pipelines/jobs/ci-linux.yml
+++ b/.vsts.pipelines/jobs/ci-linux.yml
@@ -44,6 +44,10 @@ jobs:
     ${{ if not(and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'))) }}:
       SetInternalPackageFeedPatDockerArg: ''
     ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      # In the internal build, we have one definition that provides dn-bot-dnceng-artifact-feeds-rw,
+      # and another that doesn't (to be more like a public build). For the definition that doesn't
+      # define dn-bot-dnceng-artifact-feeds-rw, this line relies on the subshell to fail when it
+      # tries to find a command by that name and set internalPackageFeedPat to nothing.
       SetInternalPackageFeedPatDockerArg: >-
         -e internalPackageFeedPat=$(dn-bot-dnceng-artifact-feeds-rw)
 

--- a/.vsts.pipelines/jobs/ci-local.yml
+++ b/.vsts.pipelines/jobs/ci-local.yml
@@ -36,9 +36,13 @@ jobs:
     type: Production
 
     ${{ if not(and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'))) }}:
-      InternalPackageFeedPatEnv: ''
+      SetInternalPackageFeedPatBashCommand: ''
     ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      InternalPackageFeedPatEnv: $(dn-bot-dnceng-artifact-feeds-rw)
+      # In the internal build, we have one definition that provides dn-bot-dnceng-artifact-feeds-rw,
+      # and another that doesn't (to be more like a public build). For the definition that doesn't
+      # define dn-bot-dnceng-artifact-feeds-rw, this line relies on the subshell to fail when it
+      # tries to find a command by that name and set internalPackageFeedPat to nothing.
+      SetInternalPackageFeedPatBashCommand: 'export internalPackageFeedPat=$(dn-bot-dnceng-artifact-feeds-rw)'
 
   steps:
   - checkout: self
@@ -68,9 +72,11 @@ jobs:
   - template: ../steps/check-space-powershell.yml
 
   # Build source-build.
-  - script: ${{ format('{0}build{1} $(args.build)', parameters.scriptPrefix, parameters.scriptSuffix) }}
-    env:
-      internalPackageFeedPat: $(InternalPackageFeedPatEnv)
+  - script: |
+      set -x
+      $(SetInternalPackageFeedPatBashCommand)
+      set -e
+      ${{ format('{0}build{1} $(args.build)', parameters.scriptPrefix, parameters.scriptSuffix) }}
     displayName: Build source-build
     timeoutInMinutes: 150
 
@@ -78,9 +84,11 @@ jobs:
 
   # Run smoke tests.
   - ${{ if ne(parameters.skipSmokeTest, true) }}:
-    - bash: ${{ format('{0}build{1} $(args.smokeTest)', parameters.scriptPrefix, parameters.scriptSuffix) }}
-      env:
-        internalPackageFeedPat: $(InternalPackageFeedPatEnv)
+    - bash: |
+        set -x
+        $(SetInternalPackageFeedPatBashCommand)
+        set -e
+        ${{ format('{0}build{1} $(args.smokeTest)', parameters.scriptPrefix, parameters.scriptSuffix) }}
       displayName: Run smoke-test
 
   # Gather artifacts. Uses git bash on Windows.


### PR DESCRIPTION
I wanted to take previously source-built artifacts from https://dev.azure.com/dnceng/internal/_build/results?buildId=807228&view=results, but the macOS leg failed due to auth issues. The auth json looks like this, literally, and gets a 401:

```json
...
{
  "endpoint":"https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal-transport/nuget/v3/index.json",
  "username":"optional",
  "password":"$(dn-bot-dnceng-artifact-feeds-rw)"
}
...
```

This is because `dn-bot-dnceng-artifact-feeds-rw` is not defined in that particular build definition. AzDO leaves the entire variable substitution expression when it doesn't match any varaible, then we pass it in directly:

```yaml
    InternalPackageFeedPatEnv: $(dn-bot-dnceng-artifact-feeds-rw)
...
    - bash: ...
      env:
        internalPackageFeedPat: $(InternalPackageFeedPatEnv)
```

On Linux, we actually inject this value into a shell script rather than using the task `env` setting. This means that bash is evaluating it, so the `$()` syntax means it's a subshell. The subshell fails to find a command `dn-bot-dnceng-artifact-feeds-rw` and gives no output. This assigns an empty string value to the PAT variable, which disables auth:

```
-e internalPackageFeedPat=$(dn-bot-dnceng-artifact-feeds-rw)
```

This is convoluted and probably only worked by coincidence in the first place, but it's trivial to change the macOS side to match the Linux side, and that's a very localized fix, so I figure it's reasonable to just do that. I added a comment to the yaml to explain what's going on here for the future.

I have a build running with this change here: https://dev.azure.com/dnceng/internal/_build/results?buildId=807484&view=results