### PR TITLE
Fix a couple CI issues leftover from preview8

### DIFF
--- a/patches/installer/0005-Don-t-do-this-in-source-build-aspnetcore-targeting-p.patch
+++ b/patches/installer/0005-Don-t-do-this-in-source-build-aspnetcore-targeting-p.patch
@@ -1,0 +1,35 @@
+From 5f34f12928157f5ed1c351dc217bf4bf5b62befe Mon Sep 17 00:00:00 2001
+From: Chris Rummel <crummel@microsoft.com>
+Date: Mon, 14 Sep 2020 09:47:04 -0500
+Subject: [PATCH 5/5] Don't do this in source-build -
+ aspnetcore-targeting-pack.tar.gz not available.
+
+---
+ src/redist/targets/GeneratePKG.targets | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/redist/targets/GeneratePKG.targets b/src/redist/targets/GeneratePKG.targets
+index 82e55b18c..c78dc7b55 100644
+--- a/src/redist/targets/GeneratePKG.targets
++++ b/src/redist/targets/GeneratePKG.targets
+@@ -128,7 +128,7 @@
+             Inputs="@(GenerateSdkPkgInputs)"
+             Outputs="$(SdkPKGInstallerFile)"
+             DependsOnTargets="GenerateLayout;SetupPkgInputsOutputs"
+-            Condition=" '$(OSName)' == 'osx' ">
++            Condition=" '$(OSName)' == 'osx' and '$(DotNetBuildFromSource)' != 'true' ">
+ 
+       <ItemGroup>
+         <TemplateFiles Include="$(RedistLayoutPath)templates/**/*" />
+@@ -172,7 +172,7 @@
+             Inputs="@(GenerateSdkProductArchiveInputs)"
+             Outputs="$(CombinedFrameworkSdkHostPKGInstallerFile)"
+             DependsOnTargets="GenerateSdkPkg"
+-            Condition=" '$(OSName)' == 'osx' ">
++            Condition=" '$(OSName)' == 'osx' and '$(DotNetBuildFromSource)' != 'true' ">
+       <ItemGroup>
+         <PkgComponentsSourceFiles Include="$(SdkPKGInstallerFile);
+                                 $(DownloadsFolder)$(DownloadedSharedFrameworkInstallerFileName);
+-- 
+2.18.0
+

--- a/patches/runtime/0018-Don-t-include-extra-PackageIcon-Arcade-does-this-alr.patch
+++ b/patches/runtime/0018-Don-t-include-extra-PackageIcon-Arcade-does-this-alr.patch
@@ -1,0 +1,26 @@
+From 4905e9ebb7a674b23594fe4b979b8120de2dc748 Mon Sep 17 00:00:00 2001
+From: Chris Rummel <crummel@microsoft.com>
+Date: Fri, 11 Sep 2020 10:31:18 -0500
+Subject: [PATCH 18/18] Don't include extra PackageIcon - Arcade does this
+ already.
+
+---
+ .../netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj      | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj b/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj
+index e9fc92b2acb..08933b13365 100644
+--- a/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj
++++ b/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj
+@@ -38,7 +38,7 @@
+           DependsOnTargets="ConvertItems"
+           BeforeTargets="GetPackageFiles">
+     <ItemGroup>
+-      <RuntimeFile Include="@(File->HasMetadata('TargetPath'))" Exclude="$(PackageIconFullPath)" />
++      <RuntimeFile Include="@(File->HasMetadata('TargetPath'))" />
+       <File Remove="@(RuntimeFile)" />
+     </ItemGroup>
+ 
+-- 
+2.18.0
+

--- a/tools-local/prebuilt-baseline-online.xml
+++ b/tools-local/prebuilt-baseline-online.xml
@@ -31,6 +31,12 @@
     <Dir></Dir>
   </ProjectDirectories>
   <Usages>
+    <!-- OSX-only prebuilts.  please do not remove these when updating this baseline, except for updating versions when necessary -->
+    <Usage Id="Microsoft.AspNetCore.App.Runtime.linux-x64" Version="5.0.0-preview.8.20414.8" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="4.8.1-servicing.19605.5" IsDirectDependency="true" />
+    <Usage Id="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-preview.8.20410.2" IsDirectDependency="true" />
+    <Usage Id="Microsoft.NETCore.App.Host.linux-x64" Version="5.0.0-preview.8.20407.11" IsDirectDependency="true" />
+    <!-- End OSX-only prebuilts -->
     <Usage Id="dotnet-deb-tool" Version="2.0.0" IsDirectDependency="true" />
     <Usage Id="Humanizer.Core" Version="2.2.0" />
     <Usage Id="MicroBuild.Core" Version="0.2.0" IsDirectDependency="true" IsAutoReferenced="true" />


### PR DESCRIPTION
Portable build: Patch runtime to not include extra package icon in nupkgs.
OSX: Patch installer to not generate extra packages that require the aspnetcore-targeting-pack.tar.gz that aren't produced in source-build.  I checked and neither 3.1 nor 5.0 preview4 produced these, so this is a new requirement and the OSX build passes smoke-tests locally without it.