### PR TITLE
[release/3.1] Add flexible baseline patterns: avoid updating online baseline with each release

### DIFF
--- a/tools-local/prebuilt-baseline-online.xml
+++ b/tools-local/prebuilt-baseline-online.xml
@@ -1,52 +1,17 @@
 <UsageData>
   <CreatedByRid>centos.7-x64</CreatedByRid>
-  <ProjectDirectories>
-    <Dir>artifacts/src/ApplicationInsights-dotnet.53b80940842204f78708a538628288ff5d741a1d/</Dir>
-    <Dir>artifacts/src/arcade.15f00efd583eab4372b2e9ca25bd80ace5b119ad/</Dir>
-    <Dir>artifacts/src/extensions.1774c15ac24c65513fa9fc1f4fbb69be9a2a4e25/</Dir>
-    <Dir>artifacts/src/xdt.c01a538851a8ab1a1fbeb2e6243f391fff7587b4/</Dir>
-    <Dir>artifacts/src/aspnetcore-tooling.02423c0c6c445b12abea9fee03ebdb2e18b4a2dd/</Dir>
-    <Dir>artifacts/src/aspnetcore.c75b3f7a2fb9fe21fd96c93c070fdfa88a2fbe97/</Dir>
-    <Dir>artifacts/src/cli.781686b7534a8203e3944c2b111df5a279d9c43e/</Dir>
-    <Dir>artifacts/src/cliCommandLineParser.0e89c2116ad28e404ba56c14d1c3f938caa25a01/</Dir>
-    <Dir>artifacts/src/common.6e37cdfe96ac8b06a923242120169fafacd720e6/</Dir>
-    <Dir>artifacts/src/installer.c423b556b530ff8a168386d63821acb6dfc6ee5d/</Dir>
-    <Dir>artifacts/src/core-setup.9c1330deddc14e8c564e30402d6a644c43110778/</Dir>
-    <Dir>artifacts/src/core-setup.9c1330deddc14e8c564e30402d6a644c43110778/</Dir>
-    <Dir>artifacts/src/coreclr.f897710bc4efe6a046068fde0acf641667a8fff5/</Dir>
-    <Dir>artifacts/src/coreclr.f897710bc4efe6a046068fde0acf641667a8fff5/</Dir>
-    <Dir>artifacts/src/corefx.d6302a72f8eafa326d7572a02acf8f3021ebb9e8/</Dir>
-    <Dir>artifacts/src/corefx.d6302a72f8eafa326d7572a02acf8f3021ebb9e8/</Dir>
-    <Dir>artifacts/src/fsharp.dc86ab5d2c46e9a7c49290e7e2270ab1eeb0c61e/</Dir>
-    <Dir>artifacts/src/known-good-tests./</Dir>
-    <Dir>artifacts/src/known-good./</Dir>
-    <Dir>artifacts/src/linker.1127689f262d52ea8ff68ef03d706fa62b3b40a1/</Dir>
-    <Dir>artifacts/src/msbuild.e901037fe1815eae17424f860412d0b967d09461/</Dir>
-    <Dir>src/netcorecli-fsc/</Dir>
-    <Dir>artifacts/src/Newtonsoft.Json.cac0690ad133c5e166ce5642dc71175791404fad/</Dir>
-    <Dir>artifacts/src/Newtonsoft.Json.e43dae94c26f0c30e9095327a3a9eac87193923d/</Dir>
-    <Dir>artifacts/src/NuGet.Client.6f8eb3a2e1db6b458451b9cfd2a4f5557769b041/</Dir>
-    <Dir>src/package-source-build/</Dir>
-    <Dir>artifacts/src/roslyn.d8180a5ecafb92adcfbfe8cf9199eb23be1a1ccf/</Dir>
-    <Dir>artifacts/src/sdk.82e2b68c9ef7f28307114c4ab4d43c11e6f7cd52/</Dir>
-    <Dir>artifacts/src/sourcelink.f175b06862f889474b689a57527e489101c774cc/</Dir>
-    <Dir>artifacts/src/standard.a5b5f2e1e369972c8ff1e2183979fab6099f52ef/</Dir>
-    <Dir>artifacts/src/templating.10dad0fa67c3cd3db542c29d591de026ed45147b/</Dir>
-    <Dir>artifacts/src/toolset.d04a69c978e9099d743ce68c667fafe9a1a7d59e/</Dir>
-    <Dir>artifacts/src/vstest.55e7e45431c9c05656c999b902686e7402664573/</Dir>
-    <Dir>artifacts/src/websdk.3478a1379fe3765b28eb3f7cb889fb45233fb09c/</Dir>
-    <Dir>artifacts/src/xliff-tasks.173ee3bd61c9549557eefa3cfb718bdef157cb87/</Dir>
-    <Dir>Tools/</Dir>
-    <Dir>tools-local/tasks/</Dir>
-    <Dir>artifacts/obj/</Dir>
-    <Dir></Dir>
-  </ProjectDirectories>
+  <IgnorePatterns>
+    <UsagePattern IdentityGlob="Microsoft.AspNetCore.App.Ref/3.*" />
+    <UsagePattern IdentityGlob="Microsoft.DotNet.Web.ItemTemplates/3.1.*" />
+    <UsagePattern IdentityGlob="Microsoft.DotNet.Web.ProjectTemplates.3.1/3.1.*" />
+    <UsagePattern IdentityGlob="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.1/3.1.*" />
+    <UsagePattern IdentityGlob="Microsoft.Dotnet.WinForms.ProjectTemplates/3.1.*" />
+    <UsagePattern IdentityGlob="Microsoft.DotNet.Wpf.ProjectTemplates/3.1.*" />
+  </IgnorePatterns>
   <Usages>
     <Usage Id="MicroBuild.Core" Version="0.2.0" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="MicroBuild.Core" Version="0.3.0" IsDirectDependency="true" />
     <Usage Id="MicroBuild.Core.Sentinel" Version="1.0.0" IsDirectDependency="true" IsAutoReferenced="true" />
-    <Usage Id="Microsoft.AspNetCore.App.Ref" Version="3.0.1" />
-    <Usage Id="Microsoft.AspNetCore.App.Ref" Version="3.1.8" />
     <Usage Id="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
     <Usage Id="Microsoft.Build" Version="15.7.179" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build.CentralPackageVersions" Version="2.0.1" />
@@ -81,19 +46,15 @@
     <Usage Id="Microsoft.DotNet.Web.ItemTemplates" Version="2.1.14" />
     <Usage Id="Microsoft.DotNet.Web.ItemTemplates" Version="2.2.8" />
     <Usage Id="Microsoft.DotNet.Web.ItemTemplates" Version="3.0.1" />
-    <Usage Id="Microsoft.DotNet.Web.ItemTemplates" Version="3.1.8" />
     <Usage Id="Microsoft.DotNet.Web.ProjectTemplates.2.1" Version="2.1.14" />
     <Usage Id="Microsoft.DotNet.Web.ProjectTemplates.2.2" Version="2.2.8" />
     <Usage Id="Microsoft.DotNet.Web.ProjectTemplates.3.0" Version="3.0.1" />
-    <Usage Id="Microsoft.DotNet.Web.ProjectTemplates.3.1" Version="3.1.8" />
     <Usage Id="Microsoft.DotNet.Web.Spa.ProjectTemplates.2.1" Version="2.1.14" />
     <Usage Id="Microsoft.DotNet.Web.Spa.ProjectTemplates.2.2" Version="2.2.8" />
     <Usage Id="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.0" Version="3.0.1" />
-    <Usage Id="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.1" Version="3.1.8" />
     <Usage Id="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="4.8.0-rc2.19462.10" />
     <Usage Id="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="4.8.1-servicing.20412.5" />
     <Usage Id="Microsoft.DotNet.Wpf.ProjectTemplates" Version="3.0.0" />
-    <Usage Id="Microsoft.DotNet.Wpf.ProjectTemplates" Version="3.1.8-servicing.20412.3" />
     <Usage Id="Microsoft.Extensions.DependencyModel" Version="2.1.0" IsDirectDependency="true" />
     <Usage Id="Microsoft.NETCore.App" Version="2.0.0" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="Microsoft.NETCore.App" Version="2.1.0" IsDirectDependency="true" IsAutoReferenced="true" />

--- a/tools-local/tasks/Directory.Build.props
+++ b/tools-local/tasks/Directory.Build.props
@@ -35,9 +35,7 @@
       Include="$(SdkReferenceDir)NuGet.*.dll"
       Exclude="$(SdkReferenceDir)NuGet.CommandLine.XPlat.dll" />
 
-    <SdkAssemblyReference
-      Include="@(SdkAssembly -> '%(FileName)')"
-      HintPath="$(SdkReferenceDir)%(Identity).dll" />
+    <SdkAssemblyReference Include="@(SdkAssembly -> '%(FullPath)')" />
   </ItemGroup>
 
 </Project>

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/UsageData.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/UsageData.cs
@@ -13,6 +13,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
         public string CreatedByRid { get; set; }
         public string[] ProjectDirectories { get; set; }
         public PackageIdentity[] NeverRestoredTarballPrebuilts { get; set; }
+        public UsagePattern[] IgnorePatterns { get; set; }
         public Usage[] Usages { get; set; }
 
         public XElement ToXml() => new XElement(
@@ -29,6 +30,10 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
                 NeverRestoredTarballPrebuilts
                     .OrderBy(id => id)
                     .Select(id => id.ToXElement())),
+            IgnorePatterns?.Any() != true ? null : new XElement(
+                nameof(IgnorePatterns),
+                IgnorePatterns
+                    .Select(p => p.ToXml())),
             Usages?.Any() != true ? null : new XElement(
                 nameof(Usages),
                 Usages
@@ -40,16 +45,20 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
         {
             CreatedByRid = xml.Element(nameof(CreatedByRid))
                 ?.Value,
-            ProjectDirectories = xml.Element(nameof(ProjectDirectories)) == null ? new string[] { } :
-                xml.Element(nameof(ProjectDirectories)).Elements()
+            ProjectDirectories =
+                (xml.Element(nameof(ProjectDirectories))?.Elements()).NullAsEmpty()
                 .Select(x => x.Value)
                 .ToArray(),
-            NeverRestoredTarballPrebuilts = xml.Element(nameof(NeverRestoredTarballPrebuilts)) == null ? new PackageIdentity[] { } :
-                xml.Element(nameof(NeverRestoredTarballPrebuilts)).Elements()
+            NeverRestoredTarballPrebuilts =
+                (xml.Element(nameof(NeverRestoredTarballPrebuilts))?.Elements()).NullAsEmpty()
                 .Select(XmlParsingHelpers.ParsePackageIdentity)
                 .ToArray(),
-            Usages = xml.Element(nameof(Usages)) == null ? new Usage[] { } :
-                xml.Element(nameof(Usages)).Elements()
+            IgnorePatterns =
+                (xml.Element(nameof(IgnorePatterns))?.Elements()).NullAsEmpty()
+                .Select(UsagePattern.Parse)
+                .ToArray(),
+            Usages =
+                (xml.Element(nameof(Usages))?.Elements()).NullAsEmpty()
                 .Select(Usage.Parse)
                 .ToArray()
         };

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/UsagePattern.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/UsagePattern.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
+{
+    public class UsagePattern
+    {
+        public string IdentityRegex { get; set; }
+
+        public string IdentityGlob { get; set; }
+
+        public XElement ToXml() => new XElement(
+            nameof(UsagePattern),
+            IdentityRegex.ToXAttributeIfNotNull(nameof(IdentityRegex)),
+            IdentityGlob.ToXAttributeIfNotNull(nameof(IdentityGlob)));
+
+        public static UsagePattern Parse(XElement xml) => new UsagePattern
+        {
+            IdentityRegex = xml.Attribute(nameof(IdentityRegex))?.Value,
+            IdentityGlob = xml.Attribute(nameof(IdentityGlob))?.Value
+        };
+
+        public Regex CreateRegex()
+        {
+            if (!string.IsNullOrEmpty(IdentityRegex))
+            {
+                return new Regex(IdentityRegex, RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            }
+
+            if (!string.IsNullOrEmpty(IdentityGlob))
+            {
+                // Escape regex characters like '.', but handle '*' as regex '.*'.
+                string regex = Regex.Escape(IdentityGlob).Replace("\\*", ".*");
+
+                return new Regex(
+                    $"^{regex}$",
+                    RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            }
+
+            return new Regex("");
+        }
+    }
+}

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/UsageValidationData.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/UsageValidationData.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
+{
+    public class UsageValidationData
+    {
+        /// <summary>
+        /// A human-readable report of new and removed prebuilts.
+        /// </summary>
+        public XElement Report { get; set; }
+
+        /// <summary>
+        /// The actual usage data from the build. Can be used as a baseline in future runs.
+        /// </summary>
+        public UsageData ActualUsageData { get; set; }
+    }
+}

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/ValidateUsageAgainstBaseline.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/ValidateUsageAgainstBaseline.cs
@@ -18,19 +18,8 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
         [Required]
         public string DataFile { get; set; }
 
-        /// <summary>
-        /// The prebuilt baseline: an XML file that lists allowed prebuilt usage.
-        /// </summary>
-        public string BaselineDataFile { get; set; }
-
-        /// <summary>
-        /// A hint path used in error messages to tell the user where to update the prebuilt
-        /// baseline data if a baseline validation error occurs. If there is no baseline data file
-        /// at all yet, the error indicates that one should be created at this location if the
-        /// prebuilt usage should be permitted.
-        /// </summary>
         [Required]
-        public string BaselineDataUpdateHintFile { get; set; }
+        public string BaselineDataFile { get; set; }
 
         [Required]
         public string OutputBaselineFile { get; set; }
@@ -44,9 +33,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
         {
             var used = UsageData.Parse(XElement.Parse(File.ReadAllText(DataFile)));
 
-            string baselineText = string.IsNullOrEmpty(BaselineDataFile)
-                ? "<UsageData />"
-                : File.ReadAllText(BaselineDataFile);
+            string baselineText = File.ReadAllText(BaselineDataFile);
 
             var baseline = UsageData.Parse(XElement.Parse(baselineText));
 
@@ -142,23 +129,10 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
 
             if (tellUserToUpdateBaseline)
             {
-                string baselineNotFoundWarning = "";
-                if (string.IsNullOrEmpty(BaselineDataFile))
-                {
-                    baselineNotFoundWarning =
-                        $"not expected, because no baseline file exists at '{BaselineDataUpdateHintFile}'";
-                }
-                else
-                {
-                    baselineNotFoundWarning =
-                        $"different from the baseline found at '{BaselineDataFile}'";
-                }
-
-                Log.LogMessage(
-                    MessageImportance.High,
-                    $"Prebuilt usages are {baselineNotFoundWarning}. If it's acceptable to " +
-                    "update the baseline, copy the contents of the automatically generated " +
-                    $"baseline '{OutputBaselineFile}'.");
+                Log.LogWarning(
+                    "Prebuilt usages are different from the baseline found at " +
+                    $"'{BaselineDataFile}'. If it's acceptable to update the baseline, copy the " +
+                    $"contents of the automatically generated baseline '{OutputBaselineFile}'.");
             }
 
             return new UsageValidationData

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/WriteUsageReports.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/WriteUsageReports.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using Microsoft.DotNet.Build.Tasks;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/WriteUsageReports.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/WriteUsageReports.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using Microsoft.DotNet.Build.Tasks;
 using System;
 using System.Collections.Generic;
 using System.IO;


### PR DESCRIPTION
This ports the flexible baseline feature from https://github.com/dotnet/arcade/pull/6155 back to dotnet/source-build. This makes servicing updates a bit more sustainable by removing the need to *always* update the online baseline even if the changes are expected and predictable. See https://github.com/dotnet/source-build/issues/1726.

I reverted some changes because dotnet/source-build works a little differently. E.g. here, warnings are allowed, and we always know where the baseline is located.

Also, yet another tweak to make VS work for editing the task project. The `*` wildcard wasn't evaluating properly with the last attempt because it was put directly into item metadata--now it's simpler.