### PR TITLE
Update SBRP reference to 1.0.0-beta.20466.1

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,9 +5,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>ff5d4b6c8dbdaeacb6e6159d3f8185118dffd915</Sha>
     </Dependency>
-    <Dependency Name="Private.SourceBuild.ReferencePackages" Version="1.0.0-beta.20217.1">
+    <Dependency Name="Private.SourceBuild.ReferencePackages" Version="1.0.0-beta.20466.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>639aeb4d76c8b1a6226bf7c4edb34fbdae30e6e1</Sha>
+      <Sha>d7a126090ef990e8d313340ff1caf8d7f4f904bc</Sha>
     </Dependency>
   </ToolsetDependencies>
   <ProductDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>
-    <PrivateSourceBuildReferencePackagesPackageVersion>1.0.0-beta.10000.2</PrivateSourceBuildReferencePackagesPackageVersion>
+    <PrivateSourceBuildReferencePackagesPackageVersion>1.0.0-beta.20466.1</PrivateSourceBuildReferencePackagesPackageVersion>
     <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-5.0.100-bootstrap.9</PrivateSourceBuiltArtifactsPackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Update SBRP reference to pickup recent changes and eliminate some prebuilts.