### PR TITLE
Re-enable packaging source-build

### DIFF
--- a/repos/known-good.proj
+++ b/repos/known-good.proj
@@ -64,7 +64,7 @@
 
         <!-- Package source-build artifacts -->
 
-        <!-- RepositoryReference Include="package-source-build" /-->
+        <RepositoryReference Include="package-source-build" />
 
       </ItemGroup>
     </Otherwise>


### PR DESCRIPTION
Re-enable package-source-build project to generate previously source-built tarball.