### PR TITLE
More complete release scripts, fix checklist ordering and reference to scripts

### DIFF
--- a/.github/ISSUE_TEMPLATE/releases/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/releases/release_checklist.md
@@ -83,12 +83,6 @@
       - Note: The PR is internal for internal builds and on GitHub for non-internal builds.
       - [Non-Internal] Merge the PR when green and accepted.
       - [Internal] Don't merge the PR.
-      - [ ] Download the artifacts from the green PR validation build.
-        - Download the tarball and smoke-test prereqs from each job.
-          - We may require only a subset for certain releases: refer to the previous release email thread corresponding to 2.1 vs. 3.1 build.
-        - Rename tarball and smoke-test prereqs to human-friendly names. Refer to previous release email for naming pattern.
-          - Can use <https://github.com/dagood/terminal-setup/blob/master/bash-util/rename-inner-targz> to do this.
-1.  - [ ] Upload tarballs and smoke-test prereqs to blob storage.
 1.  - [ ] Coordinate with team and complete manual distributed smoke-testing. Suggested assignment below, but it's flexible.  Send email with direct links to artifacts from green PR.
       - [2.1]
         - [ ] RHEL7 and RHEL8 VMs - crummel
@@ -103,6 +97,13 @@
         - [ ] CentOS 7 - dagood
         - [ ] CentOS 8 - dseefeld
         - [ ] Debian - dagood
+1.  - [ ] Download the artifacts from the green PR validation build onto a machine with Bash.
+      - We may require only a subset of the artifacts for certain releases: refer to the previous release email thread corresponding to 2.1 vs. 3.1 build.
+      - Can use <https://github.com/dotnet/source-build/blob/release/3.1/scripts/fetch-azdo-artifact-tarball.sh> as a library.
+        - E.g. download the tarballs with `download_tarball`, and fix them up with `fix_azdo_tarball` if necessary.
+1.  - [ ] Rename tarball and smoke-test prereqs to human-friendly names. (Can use `rename_tarball_inner_dir`.)
+      - Refer to previous release's email threads for naming pattern.
+1.  - [ ] Upload tarballs and smoke-test prereqs to blob storage.
 1.  - [ ] [Internal] Send the tarball to partners. Include info about how certain we are that this will be the final Microsoft build.
       - Never overwrite a tarball. At least change the blob storage virtual dir to represent a new build. This can help avoid timing issues and make it more obvious if stale links were accidentally re-sent rather than new ones.
 1.  - [ ] SYNC POINT: Wait for Microsoft build release.

--- a/scripts/fetch-azdo-artifact-tarball.sh
+++ b/scripts/fetch-azdo-artifact-tarball.sh
@@ -7,31 +7,168 @@
 # that doesn't have a clone of this repository, which is common when downloading a tarball onto a
 # fresh machine to validate it.
 #
+# If env var 'azdo_build_pat' isn't detected, prompts to set it. The prompt is intended to help a
+# little bit by keeping the PAT off 'history' while also making multiple calls to the function
+# convenient. Be aware that the PAT is put into the current shell's env.
+#
 # Usage: download_tarball <url>
 #   url: the URL to download. Wrap it in single quotes to avoid issues with special chars.
+#
+# Usage: name=<targz-path> download_tarball <url>
+#   Downloads the tarball to a specific name/location.
 download_tarball() {
   [ "${azdo_build_pat:-}" ] || read -p 'AzDO dnceng PAT with build read permission: ' -s azdo_build_pat
   (
     set -euo pipefail
     url=$1
-    temp_name=${temp_name:-tarball.tar.gz}
+    name=${name:-tarball.tar.gz}
 
     echo; echo 'Starting download...'
 
-    curl -o "$temp_name" -u "intentionally_blank:$azdo_build_pat" "$url"
-    if tar -xf "$temp_name"; then
+    # Sometimes tooling converts %-encoding back to spaces. AzDO doesn't like that (400 error), so
+    # put the % back. (Full encoding might be better, but we just have spaces to deal with so far.)
+    url=${url// /%20}
+
+    curl -fSL -o "$name" -u "intentionally_blank:$azdo_build_pat" "$url"
+
+    echo "Completed download: '$url' -> '$name'"
+  )
+}
+
+# Extract a tarball into the working directory. This includes a workaround for tarballs downloaded
+# from AzDO, which may have been double-compressed by the server.
+#
+# Usage: name=<tarball-path> extract_tarball
+extract_tarball() {
+  (
+    set -euo pipefail
+
+    if tar -xf "$name"; then
       echo "Extracted using tar -xf"
     # Fall back to 'gunzip' as an intermediate to avoid problems found
     # decompressing archives with 'tar' when downloaded directly from AzDO.
     # AzDO seems to double-compress the tar.gz: https://superuser.com/a/841876
-    elif gunzip -d < "$temp_name" | tar -zx; then
+    elif gunzip -d < "$name" | tar -zx; then
       echo "Extracted using gunzip"
     else
-      echo "Failed to extract $temp_name"
+      echo "Failed to extract $name"
       exit 1
     fi
 
-    rm "$temp_name"
-    echo 'Complete!'
+    echo "Completed extracting: $name"
   )
+}
+
+# Use download_tarball to download a tarball to a temporary file in the working dir, extract the
+# tar.gz in the working dir, and delete the temporary file.
+#
+# Usage: download_extract_tarball <url>
+#   url: the URL to download. Wrap it in single quotes to avoid issues with special chars.
+download_extract_tarball() {
+  (
+    set -euo pipefail
+
+    url=$1
+
+    date_now_for_path=$(date +%Y-%m-%d_%H%M%S)
+    export name=${name:-tarball-${date_now_for_path}.tar.gz}
+
+    download_tarball "$url"
+    extract_tarball
+
+    rm "$name"
+    echo "Completed download_extract_tarball."
+  )
+}
+
+# AzDO sometimes double-compresses tarballs unexpectedly, which can cause problems with
+# rename_inner_targz during the release process. This function extracts the tarball file with a
+# workaround and re-creates it. Uses a temporary dir in the working directory to store extracted
+# contents. The targz file must be in the working dir.
+#
+# Usage: fix_azdo_tarball <targz-file>
+fix_azdo_tarball() {
+  (
+    set -euo pipefail
+
+    tar=$1
+    tar_temp=${tar}-temp-extract
+
+    set -x
+
+    mkdir "$tar_temp"
+    (
+      cd "$tar_temp"
+      name="../$tar" extract_tarball
+      rm "../$tar"
+
+      tar --numeric-owner -zcf "../$tar" *
+    )
+    rm -rf "$tar_temp"
+  )
+}
+
+# Renames the inner top-level dir inside a tarball to something else. Creates a new tar.gz in the
+# working dir that matches the new inner top-level dir. The input tar.gz file must contain only a
+# single directory at its root. The working directory must not have any exiting files that match the
+# old inner dir name, target inner dir name, or output tarball name.
+#
+# This is only intended to be useful to manually create a nice-looking final source-build tarball to
+# upload to blob storage. We should instead have the build produce a nice name to begin with:
+# https://github.com/dotnet/source-build/issues/747
+#
+# Usage: rename_tarball_inner_dir <targz-name> <target-name>
+#   targz-name: The name of the tarball file. Includes extension.
+#   target-name:
+#     The desired name of the inner dir in the output tar.gz. The output tar.gz is named
+#     {target-name}.tar.gz in the working directory.
+rename_tarball_inner_dir() {
+  (
+    set -u
+
+    tar=$1
+    target=$2
+
+    first=$(tar -ztf "$tar" | head -1)
+    inner=${first%%/*}
+
+    abort_if_exists "$inner"
+    abort_if_exists "$target"
+    abort_if_exists "$target.tar.gz"
+
+    set -x
+
+    tar -xf "$tar"
+    mv "$inner" "$target"
+    tar --numeric-owner -zcf "$target.tar.gz" "$target"
+    rm -rf "$target"
+  )
+}
+
+# Renames the given targz so that its filename matches its top-level directory. The output tarball
+# ends up in the working dir.
+#
+# Usage: rename_targz_to_match_first_dir <targz-name>
+rename_targz_to_match_first_dir() {
+  (
+    set -u
+
+    tar=$1
+    first_file=$(tar -ztf "$tar" | head -1)
+    first_dir=${first_file%%/*}
+    tar_dest=${first_dir}.tar.gz
+
+    abort_if_exists "$tar_dest"
+
+    set -x
+    mv "$tar" "$tar_dest"
+  )
+}
+
+abort_if_exists() {
+  if [ -a "$1" ]
+  then
+    echo "Aborting: file exists: $1"
+    exit 1
+  fi
 }


### PR DESCRIPTION
The step ordering previously suggested downloading + renaming the tarballs even though they won't be used yet. This slows down the process because it takes a while, and people could be doing validation. This is just a small bug: the intent was clear before, but just a little wrong if followed step by step.

I also added some scripts to the repo that should help with the tarball munging process. I moved the inner dir renaming function over to this file from a personal repo for easier usage here. These scripts are still unpolished and just enough to get the release together.