### PR TITLE
Download only Private.SourceBuilt artifacts

### DIFF
--- a/.vsts.pipelines/stages/prepare-artifacts.yml
+++ b/.vsts.pipelines/stages/prepare-artifacts.yml
@@ -45,6 +45,7 @@ stages:
           ${{ insert }}: ${{ parameters.downloadBuildConfig }}
           downloadType: single
           artifactName: ${{ coalesce(gather.artifactName, format('Tarball {0}', gather.job)) }}
+          itemPattern: '**/Private.SourceBuilt.Artifacts.*.tar.gz'
           downloadPath: $(nonportableSourceBuiltStageDir)
           allowPartiallySucceededBuilds: true
 
@@ -54,6 +55,7 @@ stages:
         ${{ insert }}: ${{ parameters.downloadBuildConfig }}
         downloadType: single
         artifactName: 'Tarball ${{ parameters.gatherPortableJob }}'
+        itemPattern: '**/Private.SourceBuilt.Artifacts.*.tar.gz'
         downloadPath: $(portableSourceBuiltStageDir)
         allowPartiallySucceededBuilds: true
 


### PR DESCRIPTION
Update prepare-artifacts.yml to only update Private.SourceBuilt.Artifacts.*.tar.gz rather than all artifacts in the tarball folder.  The job is failing because the agent is running out of disk space.  