### PR TITLE
[master] Download only Private.SourceBuilt artifacts

### DIFF
--- a/.vsts.pipelines/jobs/prepare-artifacts.yml
+++ b/.vsts.pipelines/jobs/prepare-artifacts.yml
@@ -43,6 +43,7 @@ jobs:
         ${{ insert }}: ${{ parameters.downloadBuildConfig }}
         downloadType: single
         artifactName: ${{ coalesce(gather.artifactName, format('Tarball {0} Offline', gather.job)) }}
+        itemPattern: '**/Private.SourceBuilt.Artifacts.*.tar.gz'
         downloadPath: $(nonportableSourceBuiltStageDir)
         allowPartiallySucceededBuilds: true
 
@@ -52,6 +53,7 @@ jobs:
       ${{ insert }}: ${{ parameters.downloadBuildConfig }}
       downloadType: single
       artifactName: 'Tarball ${{ parameters.gatherPortableJob }} Offline Portable'
+      itemPattern: '**/Private.SourceBuilt.Artifacts.*.tar.gz'
       downloadPath: $(portableSourceBuiltStageDir)
       allowPartiallySucceededBuilds: true
 


### PR DESCRIPTION
Update prepare-artifacts.yml to only update Private.SourceBuilt.Artifacts.*.tar.gz rather than all artifacts in the tarball folder.