### PR TITLE
Fix 'elf.h' file not found on macOS 10.15

### DIFF
--- a/patches/coreclr/0005-Fix-bad-configure-tests.patch
+++ b/patches/coreclr/0005-Fix-bad-configure-tests.patch
@@ -1,0 +1,65 @@
+From 8dc136685608bb1cbaadc2fe9b21f870f6f4fe4e Mon Sep 17 00:00:00 2001
+From: Jan Vorlicek <janvorli@microsoft.com>
+Date: Fri, 25 Sep 2020 12:57:57 -0700
+Subject: [PATCH] Fix bad configure tests
+
+There was an extra -c in the CMAKE_REQUIRED_FLAGS set for testing
+HAVE_UNW_GET_ACCESSORS and HAVE_UNW_GET_SAVE_LOC that was breaking
+build of coreclr under homebrew. The option was somehow making
+these checks behave on ARM Linux, eveb though it is not clear to
+me why, as it was just causing this option to be passed to the
+compiler twice at different positions of the command line of
+the cmake tests.
+This change fixes it by using check_symbol_exists instead of
+check_c_source_compiles, since just removing the duplicite -c
+was resulting in the check failing on ARM / ARM64 Linux due
+to a missing symbol from libunwind during linking.
+---
+ src/coreclr/src/pal/src/configure.cmake | 26 ++-----------------------
+ 1 file changed, 2 insertions(+), 24 deletions(-)
+
+diff --git a/src/pal/src/configure.cmake b/src/pal/src/configure.cmake
+index 893f88c44f3d..0a2a4411aa96 100644
+--- a/src/pal/src/configure.cmake
++++ b/src/pal/src/configure.cmake
+@@ -1049,8 +1049,6 @@ if(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
+   list(INSERT CMAKE_REQUIRED_INCLUDES 0 ${CMAKE_CURRENT_SOURCE_DIR}/libunwind/include ${CMAKE_CURRENT_BINARY_DIR}/libunwind/include)
+ endif()
+ 
+-set(CMAKE_REQUIRED_FLAGS "-c -Werror=implicit-function-declaration")
+-
+ check_c_source_compiles("
+ #include <libunwind.h>
+ #include <ucontext.h>
+@@ -1062,29 +1060,9 @@ int main(int argc, char **argv)
+         return 0;
+ }" UNWIND_CONTEXT_IS_UCONTEXT_T)
+ 
+-check_c_source_compiles("
+-#include <libunwind.h>
+-
+-int main(int argc, char **argv) {
+-  unw_cursor_t cursor;
+-  unw_save_loc_t saveLoc;
+-  int reg = UNW_REG_IP;
+-  unw_get_save_loc(&cursor, reg, &saveLoc);
+-
+-  return 0;
+-}" HAVE_UNW_GET_SAVE_LOC)
+-
+-check_c_source_compiles("
+-#include <libunwind.h>
+-
+-int main(int argc, char **argv) {
+-  unw_addr_space_t as;
+-  unw_get_accessors(as);
+-
+-  return 0;
+-}" HAVE_UNW_GET_ACCESSORS)
++check_symbol_exists(unw_get_save_loc libunwind.h HAVE_UNW_GET_SAVE_LOC)
++check_symbol_exists(unw_get_accessors libunwind.h HAVE_UNW_GET_ACCESSORS)
+ 
+-set(CMAKE_REQUIRED_FLAGS)
+ if(NOT CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
+   list(REMOVE_AT CMAKE_REQUIRED_INCLUDES 0 1)
+ endif()


### PR DESCRIPTION
See: #1744

This is a backport of the fix that was merged into runtime for master: https://github.com/dotnet/runtime/pull/42756