### PR TITLE
Add doc describing arcade-powred source-build CI onboarding and eng/ config

### DIFF
--- a/Documentation/planning/arcade-powered-source-build/onboarding/README.md
+++ b/Documentation/planning/arcade-powered-source-build/onboarding/README.md
@@ -1,0 +1,11 @@
+# Onboarding to arcade-powered source-build
+
+Onboarding to arcade-powered source-build takes a few steps:
+
+1. [Local onboarding: basic configuration in `eng/`.](local-onboarding.md)
+   * Implemented by source-build team.
+2. [CI onboarding: adding PR validation and official build jobs.](ci-onboarding.md)
+   * Implemented by repo source-build champion.
+
+See [arcade-powered source-build](..) for more general information about the
+arcade-powered source-build plan.

--- a/Documentation/planning/arcade-powered-source-build/onboarding/ci-onboarding.md
+++ b/Documentation/planning/arcade-powered-source-build/onboarding/ci-onboarding.md
@@ -1,0 +1,116 @@
+# CI onboarding
+
+Source-build needs to run during official builds to create source-build
+[intermediate nupkg]s for the downstream repos that will consume them.
+Source-build should also run in PR validation builds, to prevent regression in
+the source-build flow and (when enabled) catch unintended prebuilt usage.
+
+The source-build job implementation is provided in the ordinary Arcade jobs
+template for easy consumption, but more detailed templates are also available in
+case the Arcade jobs template isn't suitable for certain repos.
+
+See <https://github.com/dotnet/arcade/tree/master/eng/common/templates> for
+current implementation of the templates. The `parameters:` inline comments in
+those files should be the most up to date docs and maintained with higher
+priority than this doc.
+
+## `eng/common/templates/jobs/jobs.yml` opt-in switch
+
+This is the simplest way to onboard. So far we think this should only require a
+two line change if the repo already uses the arcade
+`eng/common/templates/jobs/jobs.yml` template and it's managed-only.
+("Managed-only" meaning it doesn't produce any NuGet packages that are specific
+to certain RIDs, like `Microsoft.NETCore.App.Runtime.linux-x64`.)
+
+To opt in:
+* Set `runSourceBuild: true`
+* If the repo is managed-only, set:
+  ```yaml
+  sourceBuildParameters:
+    includeDefaultManagedPlatform: true
+  ```
+* If the repo is not managed-only, set `platforms:` to a list of objects.
+
+A managed-only repo using this implementation should look something like
+[this source-build-reference-packages implementation:](https://github.com/dotnet/source-build-reference-packages/blob/0ee4e822dad9cc624b67f7486c2902fcbee05312/azure-pipelines/builds/ci.yml#L16-L31)
+
+```yaml
+stages:
+- stage: build
+  displayName: Build
+  jobs:
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enablePublishUsingPipelines: true
+      enablePublishBuildArtifacts: true
+      enablePublishBuildAssets: true
+      artifacts:
+        publish:
+          artifacts: true
+          manifests: true
+      runSourceBuild: true
+      sourceBuildParameters:
+        includeDefaultManagedPlatform: true
+```
+
+A non-managed-only repo would instead specify `sourceBuildParameters` like this:
+
+```yaml
+sourceBuildParameters:
+  platforms:
+  - name: 'Centos71_Portable'
+    container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343'
+  - name: 'MacOS_Portable'
+    pool: { vmImage: 'macOS-10.14' }
+  - name: 'Centos71'
+    nonPortable: true
+    container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343'
+  - name: 'Centos8'
+    nonPortable: true
+    container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-8-daa5116-20200325130212'
+  - name: 'Debian9'
+    nonPortable: true
+    container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-20200918130533-047508b'
+  - name: 'Fedora30'
+    nonPortable: true
+    container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-30-38e0f29-20191126135223'
+  - name: 'Fedora32'
+    nonPortable: true
+    container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-32-20200512010618-163ed2a'
+  - name: 'MacOS'
+    nonPortable: true
+    pool: { vmImage: 'macOS-10.14' }
+  - name: 'Ubuntu1804'
+    nonPortable: true
+    container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20200918145614-047508b'
+```
+
+## `eng/common/templates/jobs/source-build.yml`
+
+This is one level deeper than `eng/common/templates/jobs/jobs.yml`. It is a
+`jobs` template that produces just the set of source-build jobs.
+
+This template defines the platform used for `includeDefaultManagedPlatform`.
+
+## `eng/common/templates/job/source-build.yml`
+
+This template defines a single `job` that runs source-build on a specified
+platform.
+
+## `eng/common/templates/steps/source-build.yml`
+
+This template defines the `steps` for a single source-build job. This is the
+most granular template, and may be useful if some repo-specific preamble or
+cleanup steps are required, or if the repo already has job matrix templates and
+this just fits in nicely.
+
+
+# Official build publishing
+
+Publishing [intermediate nupkg]s in the official build is handled by the
+standard Arcade publish infrastructure, which should already be set up in the
+repo. The source-build steps handle uploading the [intermediate nupkg] to the
+pipeline in the correct way for Arcade to detect and publish.
+
+
+[intermediate nupkg]: https://github.com/dotnet/source-build/blob/release/3.1/Documentation/planning/arcade-powered-source-build/intermediate-nupkg.md

--- a/Documentation/planning/arcade-powered-source-build/onboarding/local-onboarding.md
+++ b/Documentation/planning/arcade-powered-source-build/onboarding/local-onboarding.md
@@ -1,0 +1,116 @@
+# Local onboarding
+
+Local onboarding involves setting up files in `eng/` that determine the behavior
+of source-build in the repo.
+
+
+## Source-build configuration overview
+
+### `eng/SourceBuild.props`
+
+```xml
+<Project>
+
+  <PropertyGroup>
+    <GitHubRepositoryName>this-repo</GitHubRepositoryName>
+    <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
+  </PropertyGroup>
+
+</Project>
+```
+
+This file contains basic configuration used to restore the correct dependencies
+(managed-only or not) and produce the right name for the repo's [intermediate
+nupkg].
+
+* `this-repo` should be the same as the repo's name on GitHub, without the
+  GitHub organization name.
+* `SourceBuildManagedOnly` defaults to false if omitted. `true` means that the
+  repo doesn't produce any RID-specific artifacts like
+  `Microsoft.NETCore.App.Runtime.linux-x64`, only managed code.
+
+These two properties determine the name of the [intermediate nupkg]:
+`Microsoft.SourceBuild.Intermediate.$(GitHubRepositoryName)[.$(RidSuffix)]`.
+
+It's possible more configuration will be required for specific repos.
+`eng/SourceBuild.props`, similar to `eng/Build.props`, is a place to add extra
+MSBuild code that can change the way source-build behaves.
+
+### `eng/SourceBuildPrebuiltBaseline.xml`
+
+```xml
+<UsageData>
+  <IgnorePatterns>
+    <UsagePattern IdentityGlob="*/*" />
+  </IgnorePatterns>
+</UsageData>
+```
+
+This defines which prebuilt NuGet packages are allowed to be used during the
+build. Initially, all package IDs and versions are permitted (`*/*`).
+
+The `*/*` glob means "any nupkg id, any version". It will be replaced with more
+specific rules at a later phase of the implementation plan. The goal is to make
+it specific, so when a PR introduces an unexpected prebuilt, PR validation will
+fail and let us resolve the source-buildability issue before the PR gets merged.
+
+### `eng/Version.Details.xml`
+
+```xml
+...
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-alpha.1.20468.7" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>a820ca1c4f9cb5892331e2624d3999c39161fe2a</Sha>
+      <SourceBuild RepoName="runtime" />
+    </Dependency>
+...
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="5.0.0-alpha.1.20473.1">
+      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
+      <Sha>def2e2c6dc5064319250e2868a041a3dc07f9579</Sha>
+      <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
+    </Dependency>
+...
+```
+
+Dependency changes may include adding `SourceBuild` to existing dependency
+elements, and adding a new `source-build-reference-packages` element.
+
+`SourceBuild` causes the source-build targets in the Arcade SDK to download
+[intermediate nupkg]s from the upstream repo's official build, rather than using
+prebuilt binaries to fulfill the dependencies. Note that `RepoName` is used to
+calculate the ID of the [intermediate nupkg]: the `Dependency` `Name` is
+ignored by source-build.
+
+`ManagedOnly` determines whether a RID suffix is necessary on the [intermediate
+nupkg] ID. For example, running source-build on `dotnet/installer` with
+`linux-x64` with the above example configuration will restore:
+
+* `Microsoft.SourceBuild.Intermediate.runtime.linux-x64`
+  * `.linux-x64` because `ManagedOnly` is not `true`.
+* `Microsoft.SourceBuild.Intermediate.source-build-reference-packages`
+  * Ends with the `RepoName` without a suffix because `ManagedOnly="true"`.
+
+
+# Trying it out locally
+
+Running source-build locally is done by passing `/p:ArcadeBuildFromSource=true`
+at the end of the usual arcade-based build command for the repo. For example:
+
+```
+./build.sh -c Release --restore --build --pack /p:ArcadeBuildFromSource=true
+```
+
+> Note: [source-build is not supported on
+> Windows](https://github.com/dotnet/source-build/issues/1190), only Linux and
+> macOS.
+
+After running the build, source-build artifacts will be in
+`artifacts/source-build`, and the [intermediate nupkg] will be something like
+`artifacts/packages/*/Microsoft.SourceBuild.Intermediate.*.nupkg`.
+
+It isn't strictly necessary to try it out locally to proceed with CI onboarding.
+The source-build contributor who submits the initial configuration PR to the
+repo will have tested out the build locally themselves.
+
+
+[intermediate nupkg]: https://github.com/dotnet/source-build/blob/release/3.1/Documentation/planning/arcade-powered-source-build/intermediate-nupkg.md


### PR DESCRIPTION
Rendered: https://github.com/dagood/source-build/tree/apsb-ci-doc/Documentation/planning/arcade-powered-source-build/onboarding