### PR TITLE
[3.1] Only set download timeout in CI

### DIFF
--- a/.vsts.pipelines/jobs/ci-linux.yml
+++ b/.vsts.pipelines/jobs/ci-linux.yml
@@ -32,6 +32,9 @@ jobs:
     stagingDirectory: $(rootDirectory)/sb/staging
     systemLibunwind: ${{ parameters.systemLibunwind }}
     tarballName: tarball_$(Build.BuildId)
+    tarballDownloadArgs: >-
+      /p:DownloadSourceBuildReferencePackagesTimeoutSeconds=600
+      /p:DownloadSourceBuiltArtifactsTimeoutSeconds=1500
     SOURCE_BUILD_SKIP_SUBMODULE_CHECK: true
     # Default type, can be overridden by matrix legs.
     type: ${{ coalesce(parameters.type, 'Production') }}
@@ -76,6 +79,7 @@ jobs:
         /p:ArchiveDownloadedPackages=$(sb.tarball) \
         /p:FailOnPrebuiltBaselineError=$failOnBaselineError \
         /p:ProdConBlobFeedUrlPrefix=$(prodConBlobFeedUrlPrefix) \
+        $(tarballDownloadArgs) \
         /p:AzDoPat=$(System.AccessToken)
       du -h $(rootDirectory) | sort -h | tail -n 50
     displayName: Build source-build

--- a/.vsts.pipelines/jobs/ci-local.yml
+++ b/.vsts.pipelines/jobs/ci-local.yml
@@ -31,6 +31,9 @@ jobs:
     artifactName: ${{ format('{0} $(type)', parameters.job) }}
     failOnPrebuiltBaselineError: ${{ parameters.failOnPrebuiltBaselineError }}
     logsDirectory: $(Build.ArtifactStagingDirectory)/logs
+    tarballDownloadArgs: >-
+      /p:SkipDownloadingReferencePackages=true
+      /p:SkipDownloadingPreviouslySourceBuiltPackages=true
     SOURCE_BUILD_SKIP_SUBMODULE_CHECK: true
     # Default type, can be overridden by matrix legs.
     type: Production
@@ -76,7 +79,8 @@ jobs:
       set -x
       $(SetInternalPackageFeedPatBashCommand)
       set -e
-      ${{ format('{0}build{1} $(args.build)', parameters.scriptPrefix, parameters.scriptSuffix) }}
+      ${{ format('{0}build{1} $(args.build)', parameters.scriptPrefix, parameters.scriptSuffix) }} \
+        $(tarballDownloadArgs)
     displayName: Build source-build
     timeoutInMinutes: 150
 

--- a/.vsts.pipelines/jobs/ci-local.yml
+++ b/.vsts.pipelines/jobs/ci-local.yml
@@ -17,12 +17,13 @@ jobs:
   pool: ${{ parameters.pool }}
   timeoutInMinutes: 240
   variables:
-    args.build: >
+    args.build: >-
       /p:Configuration=$(sb.configuration)
       /p:PortableBuild=$(sb.portable)
       /p:FailOnPrebuiltBaselineError=$(failOnPrebuiltBaselineError)
       /p:ProdConBlobFeedUrlPrefix=$(prodConBlobFeedUrlPrefix)
       /p:AzDoPat=$(System.AccessToken)
+      $(tarballDownloadArgs)
     args.smokeTest: >
       --run-smoke-test
       /p:Configuration=$(sb.configuration)
@@ -79,8 +80,7 @@ jobs:
       set -x
       $(SetInternalPackageFeedPatBashCommand)
       set -e
-      ${{ format('{0}build{1} $(args.build)', parameters.scriptPrefix, parameters.scriptSuffix) }} \
-        $(tarballDownloadArgs)
+      ${{ format('{0}build{1} $(args.build)', parameters.scriptPrefix, parameters.scriptSuffix) }}
     displayName: Build source-build
     timeoutInMinutes: 150
 

--- a/build.proj
+++ b/build.proj
@@ -156,7 +156,7 @@
           Inputs="$(MSBuildProjectFullPath)" 
           Outputs="$(CompletedSemaphorePath)DownloadSourceBuildReferencePackages.complete" >
     <PropertyGroup Condition="'$(DownloadSourceBuildReferencePackagesTimeoutSeconds)' == ''">
-      <DownloadSourceBuildReferencePackagesTimeoutSeconds>600</DownloadSourceBuildReferencePackagesTimeoutSeconds>
+      <DownloadSourceBuildReferencePackagesTimeoutSeconds>N/A</DownloadSourceBuildReferencePackagesTimeoutSeconds>
     </PropertyGroup>
 
     <DownloadFileSB 
@@ -173,7 +173,7 @@
           Inputs="$(MSBuildProjectFullPath)" 
           Outputs="$(CompletedSemaphorePath)DownloadSourceBuiltArtifacts.complete" >
     <PropertyGroup Condition="'$(DownloadSourceBuiltArtifactsTimeoutSeconds)' == ''">
-      <DownloadSourceBuiltArtifactsTimeoutSeconds>1500</DownloadSourceBuiltArtifactsTimeoutSeconds>
+      <DownloadSourceBuiltArtifactsTimeoutSeconds>N/A</DownloadSourceBuiltArtifactsTimeoutSeconds>
     </PropertyGroup>
 
     <DownloadFileSB 


### PR DESCRIPTION
Also remove unnecessary download in ci-local. (Not building tarball.)

For https://github.com/dotnet/source-build/issues/1658