### PR TITLE
[master] Only set download timeout in CI

### DIFF
--- a/.vsts.pipelines/jobs/ci-linux.yml
+++ b/.vsts.pipelines/jobs/ci-linux.yml
@@ -32,6 +32,9 @@ jobs:
     stagingDirectory: $(rootDirectory)/sb/staging
     systemLibunwind: ${{ parameters.systemLibunwind }}
     tarballName: tarball_$(Build.BuildId)
+    tarballDownloadArgs: >-
+      /p:DownloadSourceBuildReferencePackagesTimeoutSeconds=600
+      /p:DownloadSourceBuiltArtifactsTimeoutSeconds=1500
     SOURCE_BUILD_SKIP_SUBMODULE_CHECK: true
     # Default type, can be overridden by matrix legs.
     type: ${{ coalesce(parameters.type, 'Production') }}
@@ -67,6 +70,7 @@ jobs:
         /p:ArchiveDownloadedPackages=$(sb.tarball) \
         /p:FailOnPrebuiltBaselineError=$failOnBaselineError \
         /p:ProdConBlobFeedUrlPrefix=$(prodConBlobFeedUrlPrefix) \
+        $(tarballDownloadArgs) \
         /p:AzDoPat=$(System.AccessToken)
       du -h $(rootDirectory) | sort -h | tail -n 50
     displayName: Build source-build

--- a/.vsts.pipelines/jobs/ci-local.yml
+++ b/.vsts.pipelines/jobs/ci-local.yml
@@ -34,6 +34,9 @@ jobs:
     artifactName: ${{ format('{0} $(type)', parameters.job) }}
     failOnPrebuiltBaselineError: ${{ parameters.failOnPrebuiltBaselineError }}
     logsDirectory: $(Build.ArtifactStagingDirectory)/logs
+    tarballDownloadArgs: >-
+      /p:SkipDownloadingReferencePackages=true
+      /p:SkipDownloadingPreviouslySourceBuiltPackages=true
     SOURCE_BUILD_SKIP_SUBMODULE_CHECK: true
     # Default type, can be overridden by matrix legs.
     type: Production
@@ -66,7 +69,9 @@ jobs:
   - template: ../steps/check-space-powershell.yml
 
   # Build source-build.
-  - script: ${{ format('{0}build{1} $(args.build)', parameters.scriptPrefix, parameters.scriptSuffix) }}
+  - script: |
+      ${{ format('{0}build{1} $(args.build)', parameters.scriptPrefix, parameters.scriptSuffix) }} \
+        $(tarballDownloadArgs)
     displayName: Build source-build
     timeoutInMinutes: 150
 

--- a/.vsts.pipelines/jobs/ci-local.yml
+++ b/.vsts.pipelines/jobs/ci-local.yml
@@ -19,13 +19,14 @@ jobs:
   pool: ${{ parameters.pool }}
   timeoutInMinutes: 240
   variables:
-    args.build: >
+    args.build: >-
       /p:Configuration=$(sb.configuration)
-      /p:BuildPortableRuntime=$(sb.portable) \
-      /p:BuildPortableSdk=$(sb.portable) \
+      /p:BuildPortableRuntime=$(sb.portable)
+      /p:BuildPortableSdk=$(sb.portable)
       /p:FailOnPrebuiltBaselineError=$(failOnPrebuiltBaselineError)
       /p:ProdConBlobFeedUrlPrefix=$(prodConBlobFeedUrlPrefix)
       /p:AzDoPat=$(System.AccessToken)
+      $(tarballDownloadArgs)
     args.smokeTest: >
       --run-smoke-test
       /p:Configuration=$(sb.configuration)
@@ -70,8 +71,7 @@ jobs:
 
   # Build source-build.
   - script: |
-      ${{ format('{0}build{1} $(args.build)', parameters.scriptPrefix, parameters.scriptSuffix) }} \
-        $(tarballDownloadArgs)
+      ${{ format('{0}build{1} $(args.build)', parameters.scriptPrefix, parameters.scriptSuffix) }}
     displayName: Build source-build
     timeoutInMinutes: 150
 

--- a/build.proj
+++ b/build.proj
@@ -59,7 +59,7 @@
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(CompletedSemaphorePath)DownloadSourceBuildReferencePackages.complete" >
     <PropertyGroup Condition="'$(DownloadSourceBuildReferencePackagesTimeoutSeconds)' == ''">
-      <DownloadSourceBuildReferencePackagesTimeoutSeconds>600</DownloadSourceBuildReferencePackagesTimeoutSeconds>
+      <DownloadSourceBuildReferencePackagesTimeoutSeconds>N/A</DownloadSourceBuildReferencePackagesTimeoutSeconds>
     </PropertyGroup>
 
     <DownloadFileSB
@@ -76,7 +76,7 @@
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(CompletedSemaphorePath)DownloadSourceBuiltArtifacts.complete" >
     <PropertyGroup Condition="'$(DownloadSourceBuiltArtifactsTimeoutSeconds)' == ''">
-      <DownloadSourceBuiltArtifactsTimeoutSeconds>1500</DownloadSourceBuiltArtifactsTimeoutSeconds>
+      <DownloadSourceBuiltArtifactsTimeoutSeconds>N/A</DownloadSourceBuiltArtifactsTimeoutSeconds>
     </PropertyGroup>
 
     <DownloadFileSB


### PR DESCRIPTION
Also remove unnecessary download in ci-local.

For https://github.com/dotnet/source-build/issues/1658

(cherry picked from https://github.com/dotnet/source-build/pull/1799)

> Conflicts:
>	.vsts.pipelines/jobs/ci-local.yml

(It looks like we missed porting auth setup to `master` at some point.)