### PR TITLE
[release/3.1] Fix prepare-artifacts portable dependency

### DIFF
--- a/.vsts.pipelines/stages/prepare-artifacts.yml
+++ b/.vsts.pipelines/stages/prepare-artifacts.yml
@@ -24,6 +24,7 @@ stages:
   dependsOn:
   - ${{ each gather in parameters.gatherJobs }}:
     - ${{ gather.job }}
+  - ${{ parameters.gatherPortableJob }}
   jobs:
   - job: PrepareArtifacts
     pool:


### PR DESCRIPTION
Prepare Artifacts downloads artifacts from a portable job, but doesn't have a stage dependency on it. The timing's been working out by chance so far but we should fix this.