### PR TITLE
roslyn: remove RichCodeNav.EnvVarDump on source-build

### DIFF
--- a/patches/roslyn/0008-remove-RichCodeNav.EnvVarDump-on-source-build.patch
+++ b/patches/roslyn/0008-remove-RichCodeNav.EnvVarDump-on-source-build.patch
@@ -1,0 +1,25 @@
+From 25257a04d8b3299be86cc41e4db1f0de4823024b Mon Sep 17 00:00:00 2001
+From: Tom Deseyn <tom.deseyn@gmail.com>
+Date: Mon, 19 Oct 2020 09:33:59 +0200
+Subject: [PATCH] roslyn: remove RichCodeNav.EnvVarDump on source-build
+
+---
+ eng/targets/Settings.props | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/eng/targets/Settings.props b/eng/targets/Settings.props
+index c3ddc1bc17b..0cbd7e8c40e 100644
+--- a/eng/targets/Settings.props
++++ b/eng/targets/Settings.props
+@@ -131,7 +131,7 @@
+   <!-- 
+      Code indexing targets to help generating LSIF from indexing builds.
+   -->
+-  <ItemGroup>
++  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
+     <PackageReference Include="RichCodeNav.EnvVarDump" Version="$(RichCodeNavEnvVarDumpVersion)" PrivateAssets="all" />
+   </ItemGroup>
+ 
+-- 
+2.26.2
+


### PR DESCRIPTION
should eliminate RichCodeNav.EnvVarDump

@crummel ptal

cc @omajid