### PR TITLE
Add dotnet/cssparser repo and build it from source

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -109,5 +109,9 @@
       <Uri>https://github.com/aspnet/common</Uri>
       <Sha>6e37cdfe96ac8b06a923242120169fafacd720e6</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Css.Parser" Version="1.0.0-20200708.1">
+      <Uri>https://github.com/dotnet/cssparser</Uri>
+      <Sha>d6d86bcd8c162b1ae22ef00955ff748d028dd0ee</Sha>
+    </Dependency>
   </ProductDependencies>
 </Dependencies>

--- a/repos/aspnetcore.proj
+++ b/repos/aspnetcore.proj
@@ -43,6 +43,7 @@
 
   <ItemGroup>
     <RepositoryReference Include="arcade" />
+    <RepositoryReference Include="cssparser" />
     <RepositoryReference Include="runtime" />
     <RepositoryReference Include="msbuild" />
     <RepositoryReference Include="roslyn" />

--- a/repos/cssparser.proj
+++ b/repos/cssparser.proj
@@ -1,0 +1,37 @@
+<Project>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <PackagesOutput>$(ProjectDirectory)/src/Microsoft.Css.Parser/bin/$(Configuration)/</PackagesOutput>
+    <RepoApiImplemented>false</RepoApiImplemented>
+    <DeterministicBuildOptOut>true</DeterministicBuildOptOut>
+  </PropertyGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+  <Target Name="RepoBuild">
+    <PropertyGroup>
+      <BuildCommandArgs>$(ProjectDirectory)/src/Microsoft.Css.Parser/Microsoft.Css.Parser.csproj</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /p:Configuration=$(Configuration)</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /v:$(LogVerbosity)</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) $(RedirectRepoOutputToLog)</BuildCommandArgs>
+    </PropertyGroup>
+
+    <Exec Command="$(DotnetToolCommand) restore /bl:restore.binlog $(BuildCommandArgs)  "
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+
+    <Exec Command="$(DotnetToolCommand) build /bl:build.binlog $(BuildCommandArgs)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+
+    <Exec Command="$(DotnetToolCommand) pack /bl:pack.binlog $(BuildCommandArgs)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+  </Target>
+
+</Project>

--- a/repos/known-good.proj
+++ b/repos/known-good.proj
@@ -34,6 +34,7 @@
         <RepositoryReference Include="application-insights" />
         <RepositoryReference Include="aspnet-xdt" />
         <RepositoryReference Include="command-line-api" />
+        <RepositoryReference Include="cssparser" />
         <RepositoryReference Include="netcorecli-fsc" />
         <RepositoryReference Include="newtonsoft-json" />
         <RepositoryReference Include="newtonsoft-json901" />


### PR DESCRIPTION
This repo produces the Microsoft.Css.Parser nuget package which is used by aspnetcore.

dotnet/cssparser is licensed under MIT. It does not use arcade, so the build project is based off of application-insights.proj.

After this fix, a local tarball build results in the removal of this line from the annotated prebuilt xml:

    <AnnotatedUsage Id="Microsoft.Css.Parser"
        Version="1.0.0-20200708.1"
        File="src/aspnetcore.a4938d07a5127ffad8466ddf703a6b5b21f4b0c9/artifacts/obj/Microsoft.AspNetCore.Razor.Tools/project.assets.json"
        IsDirectDependency="true"
        IsAutoReferenced="true"
        Project="src/aspnetcore.a4938d07a5127ffad8466ddf703a6b5b21f4b0c9/"/>