### PR TITLE
Add dotnet/diagnostics to source-build

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -96,6 +96,10 @@
       <Uri>https://github.com/dotnet/installer</Uri>
       <Sha>473d1b592e8c281f03dcc4024c04c7c188e99c03</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Diagnostics.NETCore.Client" Version="0.2.0-preview.20419.2">
+      <Uri>https://github.com/dotnet/diagnostics</Uri>
+      <Sha>47296ca69bb66180c132f3b16667f904dfc7c6c7</Sha>
+    </Dependency>
     <!-- external dependencies, not handled by Maestro/Arcade -->
     <Dependency Name="Newtonsoft.Json" Version="12.0.2">
       <Uri>https://github.com/adaggarwal/Newtonsoft.Json</Uri>

--- a/patches/diagnostics/0001-Dont-build-analyzers-for-source-build.patch
+++ b/patches/diagnostics/0001-Dont-build-analyzers-for-source-build.patch
@@ -1,0 +1,28 @@
+From 76a2a98998151ca6db805f3f032cf169f2ec5ef9 Mon Sep 17 00:00:00 2001
+From: Omair Majid <omajid@redhat.com>
+Date: Thu, 22 Oct 2020 19:07:08 -0400
+Subject: [PATCH] Dont build analyzers for source-build
+
+---
+ eng/Analyzers.props | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/eng/Analyzers.props b/eng/Analyzers.props
+index 438ae20b..97d83e0a 100644
+--- a/eng/Analyzers.props
++++ b/eng/Analyzers.props
+@@ -1,9 +1,9 @@
+ <Project>
+-  <PropertyGroup>
++  <PropertyGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
+     <CodeAnalysisRuleset>$(MSBuildThisFileDirectory)CodeAnalysis.ruleset</CodeAnalysisRuleset>
+     <EnableAnalyzers>true</EnableAnalyzers>
+   </PropertyGroup>
+-  <ItemGroup>
++  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
+     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0-beta3.final" PrivateAssets="all" />
+   </ItemGroup>
+ </Project>
+-- 
+2.26.2
+

--- a/repos/diagnostics.proj
+++ b/repos/diagnostics.proj
@@ -1,0 +1,43 @@
+<Project>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
+    <NuGetConfigFile>$(ProjectDirectory)NuGet.config</NuGetConfigFile>
+    <PackagesOutput>$(ProjectDirectory)/artifacts/packages/$(Configuration)/Shipping</PackagesOutput>
+    <RepoApiImplemented>false</RepoApiImplemented>
+    <DeterministicBuildOptOut>true</DeterministicBuildOptOut>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
+  </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+  <Target Name="RepoBuild">
+    <PropertyGroup>
+      <BuildCommandArgs>$(ProjectDirectory)/src/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /p:Configuration=$(Configuration)</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /v:$(LogVerbosity)</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) $(RedirectRepoOutputToLog)</BuildCommandArgs>
+    </PropertyGroup>
+
+    <Exec Command="$(DotnetToolCommand) restore /bl:restore.binlog $(BuildCommandArgs)  "
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+
+    <Exec Command="$(DotnetToolCommand) build /bl:build.binlog $(BuildCommandArgs)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+
+    <Exec Command="$(DotnetToolCommand) pack /bl:pack.binlog $(BuildCommandArgs)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+  </Target>
+
+</Project>

--- a/repos/vstest.proj
+++ b/repos/vstest.proj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <EnvironmentVariables Include="DotNetPackageVersionPropsPath=$(PackageVersionPropsPath)" />
+    <RepositoryReference Include="diagnostics" />
     <RepositoryReference Include="runtime" />
     <RepositoryReference Include="newtonsoft-json" />
   </ItemGroup>


### PR DESCRIPTION
This produces the Microsoft.Diagnostics.NETCore.Client package that's
shipped as part of the Microsoft SDK too.

Adding this also adds some additional dependencies:

    <AnnotatedUsage Id="Microsoft.NETCore.DotNetAppHost" Version="2.1.0" File="src/diagnostics.b6de9d322756aed892dafa0aed0053caa7db4fa6/artifacts/obj/Microsoft.Diagnostics.NETCore.Client/project.assets.json" Project="src/diagnostics.b6de9d322756aed892dafa0aed0053caa7db4fa6/" SourceBuildPackageIdCreator="runtime MicrosoftNETCoreDotNetAppHostPackageVersion/5.0.0-preview.8.20407.11" />
    <AnnotatedUsage Id="Microsoft.NETCore.DotNetHostPolicy" Version="2.1.0" File="src/diagnostics.b6de9d322756aed892dafa0aed0053caa7db4fa6/artifacts/obj/Microsoft.Diagnostics.NETCore.Client/project.assets.json" Project="src/diagnostics.b6de9d322756aed892dafa0aed0053caa7db4fa6/" SourceBuildPackageIdCreator="runtime MicrosoftNETCoreDotNetHostPolicyPackageVersion/5.0.0-preview.8.20407.11" />
    <AnnotatedUsage Id="Microsoft.NETCore.DotNetHostResolver" Version="2.1.0" File="src/diagnostics.b6de9d322756aed892dafa0aed0053caa7db4fa6/artifacts/obj/Microsoft.Diagnostics.NETCore.Client/project.assets.json" Project="src/diagnostics.b6de9d322756aed892dafa0aed0053caa7db4fa6/" SourceBuildPackageIdCreator="runtime MicrosoftNETCoreDotNetHostResolverPackageVersion/5.0.0-preview.8.20407.11" />
    <AnnotatedUsage Id="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" File="src/diagnostics.b6de9d322756aed892dafa0aed0053caa7db4fa6/artifacts/obj/Microsoft.Diagnostics.NETCore.Client/project.assets.json" IsDirectDependency="true" IsAutoReferenced="true" Project="src/diagnostics.b6de9d322756aed892dafa0aed0053caa7db4fa6/" />

But all of these Package+Version usages are already present in the file.