### PR TITLE
Update to latest version of SBRP

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,9 +5,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>6eec4404c2df5bfa46e5da52383c881c5cca3a9f</Sha>
     </Dependency>
-    <Dependency Name="Private.SourceBuild.ReferencePackages" Version="1.0.0-beta.20217.1">
+    <Dependency Name="Private.SourceBuild.ReferencePackages" Version="1.0.0-beta.20521.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>639aeb4d76c8b1a6226bf7c4edb34fbdae30e6e1</Sha>
+      <Sha>41a1020889e74f2bb62319b623f02f94d9ababf7</Sha>
     </Dependency>
   </ToolsetDependencies>
   <ProductDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>
-    <PrivateSourceBuildReferencePackagesPackageVersion>1.0.0-beta.20476.1</PrivateSourceBuildReferencePackagesPackageVersion>
+    <PrivateSourceBuildReferencePackagesPackageVersion>1.0.0-beta.20521.1</PrivateSourceBuildReferencePackagesPackageVersion>
     <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-5.0.100-bootstrap.12</PrivateSourceBuiltArtifactsPackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Update reference to source-build-reference-packages to pick up latest packages from https://github.com/dotnet/source-build-reference-packages/pull/170.