### PR TITLE
Disable macOS CI temporarily

### DIFF
--- a/.vsts.pipelines/builds/matrix.yml
+++ b/.vsts.pipelines/builds/matrix.yml
@@ -89,16 +89,17 @@ stages:
     jobParameters:
       imageName: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-source-build-20200401093015-ed32d26
 
-- template: ../stages/stage-jobs-matrix.yml
-  parameters:
-    jobTemplateName: ../jobs/ci-local.yml
-    name: osx
-    jobParameters:
-      pool:
-        name: Hosted macOS
-      scriptPrefix: ./
-      scriptSuffix: .sh
-      setupMac: true
+# Disable until CI break is fixed to avoid cognitive load while getting 5.0 prebuilts down: https://github.com/dotnet/source-build/issues/1819
+# - template: ../stages/stage-jobs-matrix.yml
+#   parameters:
+#     jobTemplateName: ../jobs/ci-local.yml
+#     name: osx
+#     jobParameters:
+#       pool:
+#         name: Hosted macOS
+#       scriptPrefix: ./
+#       scriptSuffix: .sh
+#       setupMac: true
 
 # Prepare artifacts in all situations but public PR validation.
 - ${{ if not(and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'))) }}:


### PR DESCRIPTION
This makes it easier to tell when PR validation succeeds.

(It also removes the risk of someone doing a bad PR merge if a real error is mistaken for the known macOS failure, but this isn't IMO very significant for our small team vs. a repo like dotnet/runtime where it matters much more.)

Fixing is tracked by https://github.com/dotnet/source-build/issues/1819