### PR TITLE
Fix building on arm64

### DIFF
--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/PublishCoreSetupBinaries.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/PublishCoreSetupBinaries.cs
@@ -35,6 +35,7 @@ namespace Microsoft.DotNet.Build.Tasks
         // This is a list of bad stuff we should remove that's never part of a version number.  If adding to it, it
         // should include the delimiter immediately before the RID, arch, or extension.
         protected string[] BadAtoms = new[] { "-x64", ".x64",
+                                              "-arm64", ".arm64",
                                               ".tar", ".gz",
                                               "-rhel.7", "-rhel.8", "-rhel.9",
                                               ".rhel.7", ".rhel.8", ".rhel.9",


### PR DESCRIPTION
./build.sh was failing to build on arm64 because we were placing the runtime tarball at:

./artifacts/obj/arm64/Release/blobs/Runtime/$VERSION-arm64/dotnet-runtime-$VERSION-$RID.tar.gz

And the extra -arm64 in `$VERSION-arm64` under the Runtime directory was screwing up the build.

Adding -arm64/.arm64 in the expression list makes things work.

The fix was suggested by @dagood.