### PR TITLE
Add symreader to source-build for Microsoft.DiaSymReader/1.3.0

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -106,6 +106,11 @@
       <Sha>cac0690ad133c5e166ce5642dc71175791404fad</Sha>
       <RepoName>newtonsoft-json</RepoName>
     </Dependency>
+    <Dependency Name="Microsoft.DiaSymReader" Version="1.3.0">
+      <Uri>https://github.com/dotnet/symreader</Uri>
+      <Sha>f8a3ba85aed339fb8d08ca26f3876b28c32d58ee</Sha>
+      <RepoName>symreader</RepoName>
+    </Dependency>
     <!-- additional Newtonsoft version to ease out individual repo updates to use current source-build version-->
     <Dependency Name="Newtonsoft.Json" Version="9.0.1">
       <Uri>https://github.com/adaggarwal/Newtonsoft.Json</Uri>

--- a/patches/symreader/0001-Add-initial-Arcade-SDK-switchover.patch
+++ b/patches/symreader/0001-Add-initial-Arcade-SDK-switchover.patch
@@ -1,0 +1,93 @@
+From a0f63bb501b5fb756b7c5dbeb75482d70433f377 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Tue, 27 Oct 2020 12:33:06 -0500
+Subject: [PATCH] Add initial Arcade SDK switchover
+
+---
+ eng/Versions.props          | 8 --------
+ global.json                 | 4 ++--
+ nuget.config                | 9 ++++++---
+ src/Directory.Build.props   | 6 +-----
+ src/Directory.Build.targets | 2 +-
+ 5 files changed, 10 insertions(+), 19 deletions(-)
+
+diff --git a/eng/Versions.props b/eng/Versions.props
+index 3fcd73c..ab45fc9 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -20,12 +20,4 @@
+     <MicrosoftDiaSymReaderNativeVersion>1.7.0</MicrosoftDiaSymReaderNativeVersion>
+     <MicrosoftSourceLinkVersion>1.0.0-beta-63001-01</MicrosoftSourceLinkVersion>
+   </PropertyGroup>
+-
+-  <PropertyGroup>
+-    <RestoreSources>
+-      $(RestoreSources);
+-      https://dotnet.myget.org/F/symreader-native/api/v3/index.json;
+-      https://dotnet.myget.org/F/dotnet-core/api/v3/index.json
+-    </RestoreSources>
+-  </PropertyGroup>
+ </Project>
+diff --git a/global.json b/global.json
+index c7bc27d..40607ef 100644
+--- a/global.json
++++ b/global.json
+@@ -1,8 +1,8 @@
+ {
+   "sdk": {
+-    "version": "2.1.300-rtm-008866"
++    "version": "5.0.100-preview.8.20417.9"
+   },
+   "msbuild-sdks": {
+-    "RoslynTools.RepoToolset": "1.0.0-beta2-63011-08"
++    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20467.6"
+   }
+ }
+diff --git a/nuget.config b/nuget.config
+index 1b0fc7e..d9ab4c8 100644
+--- a/nuget.config
++++ b/nuget.config
+@@ -1,8 +1,11 @@
+-<?xml version="1.0" encoding="utf-8"?>
+ <configuration>
+-  <!-- Only specify feed for RepoToolset SDK (see https://github.com/Microsoft/msbuild/issues/2982) -->
++  <fallbackPackageFolders>
++    <clear />
++  </fallbackPackageFolders>
+   <packageSources>
+     <clear />
+-    <add key="roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
++    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
++    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
++    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
+   </packageSources>
+ </configuration>
+diff --git a/src/Directory.Build.props b/src/Directory.Build.props
+index b3b8f41..aaae87a 100644
+--- a/src/Directory.Build.props
++++ b/src/Directory.Build.props
+@@ -1,10 +1,6 @@
+ <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+ <Project>
+-  <PropertyGroup>
+-    <ImportNetSdkFromRepoToolset>false</ImportNetSdkFromRepoToolset>
+-  </PropertyGroup>
+-
+-  <Import Project="Sdk.props" Sdk="RoslynTools.RepoToolset" />
++  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+ 
+   <PropertyGroup>
+     <LangVersion>Latest</LangVersion>
+diff --git a/src/Directory.Build.targets b/src/Directory.Build.targets
+index 8f5b978..fd79a2d 100644
+--- a/src/Directory.Build.targets
++++ b/src/Directory.Build.targets
+@@ -1,4 +1,4 @@
+ <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+ <Project>
+-  <Import Project="Sdk.targets" Sdk="RoslynTools.RepoToolset" />
++  <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+ </Project>
+-- 
+2.25.2
+

--- a/patches/symreader/0002-Fix-license-per-Arcade-SDK-expectations.patch
+++ b/patches/symreader/0002-Fix-license-per-Arcade-SDK-expectations.patch
@@ -1,0 +1,248 @@
+From a010a22f6bb3227677c3bea29b1561f9275d7811 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Tue, 27 Oct 2020 13:21:53 -0500
+Subject: [PATCH] Fix license per Arcade SDK expectations
+
+Use Apache-2.0 license during build/pack. Put the license content inline in
+License.txt because the Arcade SDK expects it to match the actual license text.
+---
+ License.txt               | 209 ++++++++++++++++++++++++++++++++++++--
+ src/Directory.Build.props |   4 +
+ 2 files changed, 202 insertions(+), 11 deletions(-)
+
+diff --git a/License.txt b/License.txt
+index 76d8993..d645695 100644
+--- a/License.txt
++++ b/License.txt
+@@ -1,15 +1,202 @@
+-Copyright (c) .NET Foundation and Contributors
+ 
+-All rights reserved.
++                                 Apache License
++                           Version 2.0, January 2004
++                        http://www.apache.org/licenses/
+ 
+-Licensed under the Apache License, Version 2.0 (the “License”); you may not
+-use this file except in compliance with the License. You may obtain a copy of
+-the License at
++   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+ 
+-    http://www.apache.org/licenses/LICENSE-2.0
++   1. Definitions.
+ 
+-Unless required by applicable law or agreed to in writing, software
+-distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-License for the specific language governing permissions and limitations under
+-the License.
++      "License" shall mean the terms and conditions for use, reproduction,
++      and distribution as defined by Sections 1 through 9 of this document.
++
++      "Licensor" shall mean the copyright owner or entity authorized by
++      the copyright owner that is granting the License.
++
++      "Legal Entity" shall mean the union of the acting entity and all
++      other entities that control, are controlled by, or are under common
++      control with that entity. For the purposes of this definition,
++      "control" means (i) the power, direct or indirect, to cause the
++      direction or management of such entity, whether by contract or
++      otherwise, or (ii) ownership of fifty percent (50%) or more of the
++      outstanding shares, or (iii) beneficial ownership of such entity.
++
++      "You" (or "Your") shall mean an individual or Legal Entity
++      exercising permissions granted by this License.
++
++      "Source" form shall mean the preferred form for making modifications,
++      including but not limited to software source code, documentation
++      source, and configuration files.
++
++      "Object" form shall mean any form resulting from mechanical
++      transformation or translation of a Source form, including but
++      not limited to compiled object code, generated documentation,
++      and conversions to other media types.
++
++      "Work" shall mean the work of authorship, whether in Source or
++      Object form, made available under the License, as indicated by a
++      copyright notice that is included in or attached to the work
++      (an example is provided in the Appendix below).
++
++      "Derivative Works" shall mean any work, whether in Source or Object
++      form, that is based on (or derived from) the Work and for which the
++      editorial revisions, annotations, elaborations, or other modifications
++      represent, as a whole, an original work of authorship. For the purposes
++      of this License, Derivative Works shall not include works that remain
++      separable from, or merely link (or bind by name) to the interfaces of,
++      the Work and Derivative Works thereof.
++
++      "Contribution" shall mean any work of authorship, including
++      the original version of the Work and any modifications or additions
++      to that Work or Derivative Works thereof, that is intentionally
++      submitted to Licensor for inclusion in the Work by the copyright owner
++      or by an individual or Legal Entity authorized to submit on behalf of
++      the copyright owner. For the purposes of this definition, "submitted"
++      means any form of electronic, verbal, or written communication sent
++      to the Licensor or its representatives, including but not limited to
++      communication on electronic mailing lists, source code control systems,
++      and issue tracking systems that are managed by, or on behalf of, the
++      Licensor for the purpose of discussing and improving the Work, but
++      excluding communication that is conspicuously marked or otherwise
++      designated in writing by the copyright owner as "Not a Contribution."
++
++      "Contributor" shall mean Licensor and any individual or Legal Entity
++      on behalf of whom a Contribution has been received by Licensor and
++      subsequently incorporated within the Work.
++
++   2. Grant of Copyright License. Subject to the terms and conditions of
++      this License, each Contributor hereby grants to You a perpetual,
++      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
++      copyright license to reproduce, prepare Derivative Works of,
++      publicly display, publicly perform, sublicense, and distribute the
++      Work and such Derivative Works in Source or Object form.
++
++   3. Grant of Patent License. Subject to the terms and conditions of
++      this License, each Contributor hereby grants to You a perpetual,
++      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
++      (except as stated in this section) patent license to make, have made,
++      use, offer to sell, sell, import, and otherwise transfer the Work,
++      where such license applies only to those patent claims licensable
++      by such Contributor that are necessarily infringed by their
++      Contribution(s) alone or by combination of their Contribution(s)
++      with the Work to which such Contribution(s) was submitted. If You
++      institute patent litigation against any entity (including a
++      cross-claim or counterclaim in a lawsuit) alleging that the Work
++      or a Contribution incorporated within the Work constitutes direct
++      or contributory patent infringement, then any patent licenses
++      granted to You under this License for that Work shall terminate
++      as of the date such litigation is filed.
++
++   4. Redistribution. You may reproduce and distribute copies of the
++      Work or Derivative Works thereof in any medium, with or without
++      modifications, and in Source or Object form, provided that You
++      meet the following conditions:
++
++      (a) You must give any other recipients of the Work or
++          Derivative Works a copy of this License; and
++
++      (b) You must cause any modified files to carry prominent notices
++          stating that You changed the files; and
++
++      (c) You must retain, in the Source form of any Derivative Works
++          that You distribute, all copyright, patent, trademark, and
++          attribution notices from the Source form of the Work,
++          excluding those notices that do not pertain to any part of
++          the Derivative Works; and
++
++      (d) If the Work includes a "NOTICE" text file as part of its
++          distribution, then any Derivative Works that You distribute must
++          include a readable copy of the attribution notices contained
++          within such NOTICE file, excluding those notices that do not
++          pertain to any part of the Derivative Works, in at least one
++          of the following places: within a NOTICE text file distributed
++          as part of the Derivative Works; within the Source form or
++          documentation, if provided along with the Derivative Works; or,
++          within a display generated by the Derivative Works, if and
++          wherever such third-party notices normally appear. The contents
++          of the NOTICE file are for informational purposes only and
++          do not modify the License. You may add Your own attribution
++          notices within Derivative Works that You distribute, alongside
++          or as an addendum to the NOTICE text from the Work, provided
++          that such additional attribution notices cannot be construed
++          as modifying the License.
++
++      You may add Your own copyright statement to Your modifications and
++      may provide additional or different license terms and conditions
++      for use, reproduction, or distribution of Your modifications, or
++      for any such Derivative Works as a whole, provided Your use,
++      reproduction, and distribution of the Work otherwise complies with
++      the conditions stated in this License.
++
++   5. Submission of Contributions. Unless You explicitly state otherwise,
++      any Contribution intentionally submitted for inclusion in the Work
++      by You to the Licensor shall be under the terms and conditions of
++      this License, without any additional terms or conditions.
++      Notwithstanding the above, nothing herein shall supersede or modify
++      the terms of any separate license agreement you may have executed
++      with Licensor regarding such Contributions.
++
++   6. Trademarks. This License does not grant permission to use the trade
++      names, trademarks, service marks, or product names of the Licensor,
++      except as required for reasonable and customary use in describing the
++      origin of the Work and reproducing the content of the NOTICE file.
++
++   7. Disclaimer of Warranty. Unless required by applicable law or
++      agreed to in writing, Licensor provides the Work (and each
++      Contributor provides its Contributions) on an "AS IS" BASIS,
++      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
++      implied, including, without limitation, any warranties or conditions
++      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
++      PARTICULAR PURPOSE. You are solely responsible for determining the
++      appropriateness of using or redistributing the Work and assume any
++      risks associated with Your exercise of permissions under this License.
++
++   8. Limitation of Liability. In no event and under no legal theory,
++      whether in tort (including negligence), contract, or otherwise,
++      unless required by applicable law (such as deliberate and grossly
++      negligent acts) or agreed to in writing, shall any Contributor be
++      liable to You for damages, including any direct, indirect, special,
++      incidental, or consequential damages of any character arising as a
++      result of this License or out of the use or inability to use the
++      Work (including but not limited to damages for loss of goodwill,
++      work stoppage, computer failure or malfunction, or any and all
++      other commercial damages or losses), even if such Contributor
++      has been advised of the possibility of such damages.
++
++   9. Accepting Warranty or Additional Liability. While redistributing
++      the Work or Derivative Works thereof, You may choose to offer,
++      and charge a fee for, acceptance of support, warranty, indemnity,
++      or other liability obligations and/or rights consistent with this
++      License. However, in accepting such obligations, You may act only
++      on Your own behalf and on Your sole responsibility, not on behalf
++      of any other Contributor, and only if You agree to indemnify,
++      defend, and hold each Contributor harmless for any liability
++      incurred by, or claims asserted against, such Contributor by reason
++      of your accepting any such warranty or additional liability.
++
++   END OF TERMS AND CONDITIONS
++
++   APPENDIX: How to apply the Apache License to your work.
++
++      To apply the Apache License to your work, attach the following
++      boilerplate notice, with the fields enclosed by brackets "[]"
++      replaced with your own identifying information. (Don't include
++      the brackets!)  The text should be enclosed in the appropriate
++      comment syntax for the file format. We also recommend that a
++      file or class name and description of purpose be included on the
++      same "printed page" as the copyright notice for easier
++      identification within third-party archives.
++
++   Copyright [yyyy] [name of copyright owner]
++
++   Licensed under the Apache License, Version 2.0 (the "License");
++   you may not use this file except in compliance with the License.
++   You may obtain a copy of the License at
++
++       http://www.apache.org/licenses/LICENSE-2.0
++
++   Unless required by applicable law or agreed to in writing, software
++   distributed under the License is distributed on an "AS IS" BASIS,
++   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++   See the License for the specific language governing permissions and
++   limitations under the License.
+diff --git a/src/Directory.Build.props b/src/Directory.Build.props
+index aaae87a..fc3e188 100644
+--- a/src/Directory.Build.props
++++ b/src/Directory.Build.props
+@@ -2,6 +2,10 @@
+ <Project>
+   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+ 
++  <PropertyGroup>
++    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
++  </PropertyGroup>
++
+   <PropertyGroup>
+     <LangVersion>Latest</LangVersion>
+   </PropertyGroup>
+-- 
+2.25.2
+

--- a/repos/runtime.proj
+++ b/repos/runtime.proj
@@ -4,6 +4,7 @@
   <!-- Repository References -->
   <ItemGroup>
       <RepositoryReference Include="arcade" />
+      <RepositoryReference Include="symreader" />
       <RepositoryReference Include="linker" />
       <RepositoryReference Include="newtonsoft-json" />
       <RepositoryReference Include="newtonsoft-json901" />

--- a/repos/symreader.proj
+++ b/repos/symreader.proj
@@ -1,0 +1,47 @@
+<Project>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
+    <NuGetConfigFile>$(ProjectDirectory)nuget.config</NuGetConfigFile>
+    <PackagesOutput>$(ProjectDirectory)/artifacts/packages/$(Configuration)/Shipping</PackagesOutput>
+    <RepoApiImplemented>false</RepoApiImplemented>
+    <DeterministicBuildOptOut>true</DeterministicBuildOptOut>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <RepositoryReference Include="arcade" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <UseSourceBuiltSdkOverride Include="@(ArcadeSdkOverride)" />
+  </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+  <Target Name="RepoBuild">
+    <PropertyGroup>
+      <BuildCommandArgs>$(ProjectDirectory)/src//Microsoft.DiaSymReader//Microsoft.DiaSymReader.csproj</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /p:Configuration=$(Configuration)</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /v:$(LogVerbosity)</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) $(RedirectRepoOutputToLog)</BuildCommandArgs>
+    </PropertyGroup>
+
+    <Exec Command="$(DotnetToolCommand) restore /bl:restore.binlog $(BuildCommandArgs)  "
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+
+    <Exec Command="$(DotnetToolCommand) build /bl:build.binlog $(BuildCommandArgs)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+
+    <Exec Command="$(DotnetToolCommand) pack /bl:pack.binlog $(BuildCommandArgs)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+  </Target>
+
+</Project>

--- a/tools-local/prebuilt-baseline-offline.xml
+++ b/tools-local/prebuilt-baseline-offline.xml
@@ -240,6 +240,7 @@
     <Usage Id="Microsoft.NETCore.Targets" Version="2.0.0" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" IsDirectDependency="true" IsAutoReferenced="true" />
+    <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net20" Version="1.0.0-preview.2" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net40" Version="1.0.0" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.0" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net46" Version="1.0.0" />

--- a/tools-local/prebuilt-baseline-online.xml
+++ b/tools-local/prebuilt-baseline-online.xml
@@ -209,6 +209,7 @@
     <Usage Id="Microsoft.NETCore.Targets" Version="2.1.0" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" IsDirectDependency="true" IsAutoReferenced="true" />
+    <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net20" Version="1.0.0-preview.2" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net40" Version="1.0.0" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.0" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net46" Version="1.0.0" />


### PR DESCRIPTION
Add the symreader repo back to the build to build the `Microsoft.DiaSymReader/1.3.0` dependency from source.

This is an old package with 2.1 era infra that I upgraded, from repo toolset to arcade.

For https://github.com/dotnet/source-build/issues/1812.