### PR TITLE
Update runtime nuget version to SBRP version

### DIFF
--- a/patches/runtime/0026-Update-nuget-versions-to-version-in-SBRP.patch
+++ b/patches/runtime/0026-Update-nuget-versions-to-version-in-SBRP.patch
@@ -1,0 +1,27 @@
+From a5316fa11734007708c5eace77a72a5db81632ff Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Tue, 27 Oct 2020 17:38:33 +0000
+Subject: [PATCH] Update nuget versions to version in SBRP
+
+---
+ eng/Versions.props | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/eng/Versions.props b/eng/Versions.props
+index 6fcbcfe25b7..5955f759589 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -127,8 +127,8 @@
+     <RefOnlyMicrosoftBuildFrameworkVersion>$(RefOnlyMicrosoftBuildVersion)</RefOnlyMicrosoftBuildFrameworkVersion>
+     <RefOnlyMicrosoftBuildTasksCoreVersion>$(RefOnlyMicrosoftBuildVersion)</RefOnlyMicrosoftBuildTasksCoreVersion>
+     <RefOnlyMicrosoftBuildUtilitiesCoreVersion>$(RefOnlyMicrosoftBuildVersion)</RefOnlyMicrosoftBuildUtilitiesCoreVersion>
+-    <RefOnlyNugetProjectModelVersion>4.9.4</RefOnlyNugetProjectModelVersion>
+-    <RefOnlyNugetPackagingVersion>4.9.4</RefOnlyNugetPackagingVersion>
++    <RefOnlyNugetProjectModelVersion>5.1.0</RefOnlyNugetProjectModelVersion>
++    <RefOnlyNugetPackagingVersion>5.1.0</RefOnlyNugetPackagingVersion>
+     <!-- Testing -->
+     <MicrosoftNETTestSdkVersion>16.8.0-preview-20200730-03</MicrosoftNETTestSdkVersion>
+     <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.20411.1</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
+-- 
+2.18.4
+

--- a/tools-local/prebuilt-baseline-online.xml
+++ b/tools-local/prebuilt-baseline-online.xml
@@ -8,6 +8,8 @@
     <Dir>artifacts/src/cliCommandLineParser.0e89c2116ad28e404ba56c14d1c3f938caa25a01/</Dir>
     <Dir>artifacts/src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/</Dir>
     <Dir>artifacts/src/common.6e37cdfe96ac8b06a923242120169fafacd720e6/</Dir>
+    <Dir>artifacts/src/cssparser.d6d86bcd8c162b1ae22ef00955ff748d028dd0ee/</Dir>
+    <Dir>artifacts/src/diagnostics.47296ca69bb66180c132f3b16667f904dfc7c6c7/</Dir>
     <Dir>artifacts/src/fsharp.068ebd3c599bc5a47163a18b8b90d2fe5517186e/</Dir>
     <Dir>artifacts/src/installer.473d1b592e8c281f03dcc4024c04c7c188e99c03/</Dir>
     <Dir>artifacts/src/known-good-tests./</Dir>
@@ -24,7 +26,9 @@
     <Dir>artifacts/src/runtime.38017c3935de95d0335bac04f4901ddfc2718656/</Dir>
     <Dir>artifacts/src/sdk.394fae2553937858c8f05a6158613dcc7f821fba/</Dir>
     <Dir>artifacts/src/sourcelink.f175b06862f889474b689a57527e489101c774cc/</Dir>
+    <Dir>artifacts/src/symreader.f8a3ba85aed339fb8d08ca26f3876b28c32d58ee/</Dir>
     <Dir>artifacts/src/templating.da62f3656cac0ac4bfb6b012bc072b3499f78e6c/</Dir>
+    <Dir>artifacts/src/test-templates.956e14dedd3a3ac981b320d66c6d389387a2954a/</Dir>
     <Dir>artifacts/src/vstest.0c0fafa64de5c73981e7c40a99d7363f57635f60/</Dir>
     <Dir>artifacts/src/xliff-tasks.a52f3d7fb58470749ee4035fbbcb7e63c78b0459/</Dir>
     <Dir>Tools/</Dir>
@@ -33,23 +37,18 @@
     <Dir></Dir>
   </ProjectDirectories>
   <Usages>
-      <!-- OSX-only prebuilts.  please do not remove these when updating this baseline, except for updating versions when necessary -->
+    <!-- OSX-only prebuilts.  please do not remove these when updating this baseline, except for updating versions when necessary -->
     <Usage Id="Microsoft.AspNetCore.App.Runtime.linux-x64" Version="5.0.0-rc.1.20451.17" />
     <Usage Id="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="4.8.1-servicing.19605.5" />
     <Usage Id="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20451.14" />
     <Usage Id="Microsoft.NETCore.App.Host.linux-x64" Version="5.0.0-rc.1.20451.14" />
     <!-- End OSX-only prebuilts -->
-    <Usage Id="MessagePack" Version="2.1.90" />
-    <Usage Id="MessagePack.Annotations" Version="2.1.90" />
     <Usage Id="MicroBuild.Core" Version="0.2.0" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="MicroBuild.Core" Version="0.3.0" IsDirectDependency="true" />
     <Usage Id="MicroBuild.Core.Sentinel" Version="1.0.0" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="Microsoft.AspNetCore.App.Ref" Version="3.0.1" />
     <Usage Id="Microsoft.AspNetCore.App.Ref" Version="3.1.2" />
     <Usage Id="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rc.1.20451.17" />
-    <Usage Id="Microsoft.AspNetCore.App.Runtime.linux-musl-x64" Version="5.0.0-rc.1.20451.17" />
-    <Usage Id="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0-rc.1.20451.17" />
-    <Usage Id="Microsoft.AspNetCore.App.Runtime.win-x86" Version="5.0.0-rc.1.20451.17" />
     <Usage Id="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
     <Usage Id="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
     <Usage Id="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
@@ -59,16 +58,13 @@
     <Usage Id="Microsoft.Build.Framework" Version="15.3.409" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build.Framework" Version="15.4.8" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build.Framework" Version="15.7.179" />
-    <Usage Id="Microsoft.Build.Framework" Version="16.8.0-preview-20451-02" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build.Tasks.Core" Version="15.3.409" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build.Tasks.Core" Version="15.7.179" IsDirectDependency="true" />
-    <Usage Id="Microsoft.Build.Tasks.Core" Version="16.8.0-preview-20451-02" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build.Traversal" Version="2.1.1" />
     <Usage Id="Microsoft.Build.Utilities.Core" Version="15.1.1012" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build.Utilities.Core" Version="15.3.409" />
     <Usage Id="Microsoft.Build.Utilities.Core" Version="15.4.8" IsDirectDependency="true" />
     <Usage Id="Microsoft.Build.Utilities.Core" Version="15.7.179" />
-    <Usage Id="Microsoft.Build.Utilities.Core" Version="16.8.0-preview-20451-02" IsDirectDependency="true" />
     <Usage Id="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1" />
     <Usage Id="Microsoft.CodeAnalysis.Analyzers" Version="2.9.6" />
     <Usage Id="Microsoft.CodeAnalysis.Common" Version="2.9.0" />
@@ -76,18 +72,12 @@
     <Usage Id="Microsoft.CodeAnalysis.CSharp" Version="2.9.0" IsDirectDependency="true" />
     <Usage Id="Microsoft.CodeAnalysis.CSharp" Version="3.4.0" IsDirectDependency="true" />
     <Usage Id="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.8.0-3.20425.2" IsDirectDependency="true" />
-    <Usage Id="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.0-rc1.20413.9" IsDirectDependency="true" />
     <Usage Id="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.0-rc1.20428.12" IsDirectDependency="true" />
-    <Usage Id="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.0.0" IsDirectDependency="true" />
     <Usage Id="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" Version="3.8.0-3.20425.2" IsDirectDependency="true" />
     <Usage Id="Microsoft.CSharp" Version="4.0.1" IsDirectDependency="true" />
     <Usage Id="Microsoft.CSharp" Version="4.3.0" IsDirectDependency="true" />
     <Usage Id="Microsoft.CSharp" Version="4.4.1" />
-    <Usage Id="Microsoft.Css.Parser" Version="1.0.0-20200708.1" IsDirectDependency="true" IsAutoReferenced="true" />
-    <Usage Id="Microsoft.Diagnostics.NETCore.Client" Version="0.2.0-preview.20419.2" IsDirectDependency="true" />
     <Usage Id="Microsoft.Diagnostics.Tracing.EventSource.Redist" Version="2.1.0" />
-    <Usage Id="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.55" IsDirectDependency="true" />
-    <Usage Id="Microsoft.DiaSymReader" Version="1.3.0" />
     <Usage Id="Microsoft.Docker.Sdk" Version="1.1.0" />
     <Usage Id="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20426.4" />
     <Usage Id="Microsoft.DotNet.Common.ItemTemplates" Version="1.0.2-beta3" />
@@ -96,10 +86,6 @@
     <Usage Id="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
     <Usage Id="Microsoft.DotNet.SignTool" Version="5.0.0-beta.20426.4" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="microsoft.dotnet.templateLocator" Version="5.0.100-rc.1.20421.19" />
-    <Usage Id="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="1.0.2-beta4.20420.1" />
-    <Usage Id="Microsoft.DotNet.Test.ProjectTemplates.3.0" Version="1.0.2-beta4.20420.1" />
-    <Usage Id="Microsoft.DotNet.Test.ProjectTemplates.3.1" Version="1.0.2-beta4.20420.1" />
-    <Usage Id="Microsoft.DotNet.Test.ProjectTemplates.5.0" Version="1.0.2-beta4.20420.1" />
     <Usage Id="Microsoft.DotNet.Web.ItemTemplates" Version="2.1.14" />
     <Usage Id="Microsoft.DotNet.Web.ItemTemplates" Version="3.0.1" />
     <Usage Id="Microsoft.DotNet.Web.ItemTemplates" Version="3.1.7" />
@@ -112,10 +98,6 @@
     <Usage Id="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.0" Version="3.0.1" />
     <Usage Id="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.1" Version="3.1.7" />
     <Usage Id="Microsoft.DotNet.Web.Spa.ProjectTemplates.5.0" Version="5.0.0-rc.1.20451.17" />
-    <Usage Id="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="4.8.0-rc2.19462.10" />
-    <Usage Id="Microsoft.DotNet.Wpf.ProjectTemplates" Version="3.0.0" />
-    <Usage Id="Microsoft.DotNet.Wpf.ProjectTemplates" Version="3.1.2-servicing.20066.4" />
-    <Usage Id="Microsoft.DotNet.Wpf.ProjectTemplates" Version="5.0.0-rc.1.20451.6" />
     <Usage Id="Microsoft.Extensions.Caching.Abstractions" Version="3.1.2" />
     <Usage Id="Microsoft.Extensions.Caching.Memory" Version="3.1.2" />
     <Usage Id="Microsoft.Extensions.Configuration" Version="2.2.0" />
@@ -171,19 +153,11 @@
     <Usage Id="Microsoft.NETCore.App" Version="2.0.0" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="Microsoft.NETCore.App" Version="2.1.0" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="Microsoft.NETCore.App" Version="2.1.17" IsDirectDependency="true" IsAutoReferenced="true" />
-    <Usage Id="Microsoft.NETCore.App.Host.linux-musl-x64" Version="5.0.0-rc.1.20451.14" />
     <Usage Id="Microsoft.NETCore.App.Host.linux-x64" Version="3.0.3" />
     <Usage Id="Microsoft.NETCore.App.Host.linux-x64" Version="3.1.7" />
-    <Usage Id="Microsoft.NETCore.App.Host.win-x64" Version="5.0.0-rc.1.20451.14" />
-    <Usage Id="Microsoft.NETCore.App.Host.win-x86" Version="5.0.0-rc.1.20451.14" />
     <Usage Id="Microsoft.NETCore.App.Ref" Version="3.0.0" />
     <Usage Id="Microsoft.NETCore.App.Ref" Version="3.1.0" />
     <Usage Id="Microsoft.NETCore.App.Ref" Version="5.0.0-rc.1.20451.14" />
-    <Usage Id="Microsoft.NETCore.App.Runtime.linux-musl-x64" Version="5.0.0-rc.1.20451.14" />
-    <Usage Id="Microsoft.NETCore.App.Runtime.linux-x64" Version="5.0.0-rc.1.20451.14" />
-    <Usage Id="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-rc.1.20451.14" />
-    <Usage Id="Microsoft.NETCore.App.Runtime.win-x86" Version="5.0.0-rc.1.20451.14" />
-    <Usage Id="Microsoft.NETCore.CoreDisTools" Version="1.0.1-prerelease-00005" IsDirectDependency="true" />
     <Usage Id="Microsoft.NETCore.DotNetAppHost" Version="2.0.0" />
     <Usage Id="Microsoft.NETCore.DotNetAppHost" Version="2.1.0" />
     <Usage Id="Microsoft.NETCore.DotNetAppHost" Version="2.1.17" />
@@ -209,10 +183,10 @@
     <Usage Id="Microsoft.NETCore.Targets" Version="2.1.0" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" IsDirectDependency="true" IsAutoReferenced="true" />
+    <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net20" Version="1.0.0-preview.2" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net40" Version="1.0.0" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.0" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net46" Version="1.0.0" />
-    <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0-preview.2" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.0" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net47" Version="1.0.0" />
@@ -220,10 +194,6 @@
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.0" />
     <Usage Id="Microsoft.SymbolUploader.Build.Task" Version="1.1.141804" IsDirectDependency="true" IsAutoReferenced="true" />
-    <Usage Id="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" />
-    <Usage Id="Microsoft.VisualStudio.Threading" Version="16.6.13" />
-    <Usage Id="Microsoft.VisualStudio.Threading.Analyzers" Version="16.6.13" />
-    <Usage Id="Microsoft.VisualStudio.Validation" Version="15.5.31" />
     <Usage Id="Microsoft.Win32.Primitives" Version="4.0.1" />
     <Usage Id="Microsoft.Win32.Primitives" Version="4.3.0" />
     <Usage Id="Microsoft.Win32.Registry" Version="4.0.0" />
@@ -235,7 +205,6 @@
     <Usage Id="Microsoft.Win32.SystemEvents" Version="4.7.0" />
     <Usage Id="Microsoft.XmlSerializer.Generator" Version="2.1.0" />
     <Usage Id="Mono.Cecil" Version="0.11.2" IsDirectDependency="true" />
-    <Usage Id="Nerdbank.Streams" Version="2.4.73" />
     <Usage Id="NETStandard.Library" Version="1.6.0" />
     <Usage Id="NETStandard.Library" Version="1.6.1" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="NETStandard.Library" Version="2.0.0" />
@@ -244,49 +213,30 @@
     <Usage Id="NETStandard.Library.NETFramework" Version="2.0.1-servicing-26011-01" IsDirectDependency="true" />
     <Usage Id="NETStandard.Library.Ref" Version="2.1.0" />
     <Usage Id="NuGet.Commands" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
-    <Usage Id="NuGet.Common" Version="4.9.4+ed6e2dca9391d13b431f4eff58c5194f0ebcee13" />
+    <Usage Id="NuGet.Common" Version="5.1.0+08414feaac77473f29f6ac182ab4c390ecd3542f" />
     <Usage Id="NuGet.Common" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
-    <Usage Id="NuGet.Configuration" Version="4.9.4+ed6e2dca9391d13b431f4eff58c5194f0ebcee13" />
+    <Usage Id="NuGet.Configuration" Version="5.1.0+08414feaac77473f29f6ac182ab4c390ecd3542f" />
     <Usage Id="NuGet.Configuration" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
     <Usage Id="NuGet.Credentials" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
-    <Usage Id="NuGet.DependencyResolver.Core" Version="4.9.4+ed6e2dca9391d13b431f4eff58c5194f0ebcee13" />
+    <Usage Id="NuGet.DependencyResolver.Core" Version="5.1.0+08414feaac77473f29f6ac182ab4c390ecd3542f" />
     <Usage Id="NuGet.DependencyResolver.Core" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
-    <Usage Id="NuGet.Frameworks" Version="4.9.4+ed6e2dca9391d13b431f4eff58c5194f0ebcee13" />
+    <Usage Id="NuGet.Frameworks" Version="5.1.0+08414feaac77473f29f6ac182ab4c390ecd3542f" />
     <Usage Id="NuGet.Frameworks" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
-    <Usage Id="NuGet.LibraryModel" Version="4.9.4+ed6e2dca9391d13b431f4eff58c5194f0ebcee13" />
+    <Usage Id="NuGet.LibraryModel" Version="5.1.0+08414feaac77473f29f6ac182ab4c390ecd3542f" />
     <Usage Id="NuGet.LibraryModel" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
-    <Usage Id="NuGet.Packaging" Version="4.9.4+ed6e2dca9391d13b431f4eff58c5194f0ebcee13" />
+    <Usage Id="NuGet.Packaging" Version="5.1.0+08414feaac77473f29f6ac182ab4c390ecd3542f" />
     <Usage Id="NuGet.Packaging" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
-    <Usage Id="NuGet.Packaging.Core" Version="4.9.4+ed6e2dca9391d13b431f4eff58c5194f0ebcee13" />
-    <Usage Id="NuGet.ProjectModel" Version="4.9.4+ed6e2dca9391d13b431f4eff58c5194f0ebcee13" />
+    <Usage Id="NuGet.ProjectModel" Version="5.1.0+08414feaac77473f29f6ac182ab4c390ecd3542f" />
     <Usage Id="NuGet.ProjectModel" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
-    <Usage Id="NuGet.Protocol" Version="4.9.4+ed6e2dca9391d13b431f4eff58c5194f0ebcee13" />
+    <Usage Id="NuGet.Protocol" Version="5.1.0+08414feaac77473f29f6ac182ab4c390ecd3542f" />
     <Usage Id="NuGet.Protocol" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
     <Usage Id="NuGet.Versioning" Version="4.4.0" IsDirectDependency="true" />
-    <Usage Id="NuGet.Versioning" Version="4.9.4+ed6e2dca9391d13b431f4eff58c5194f0ebcee13" />
+    <Usage Id="NuGet.Versioning" Version="5.1.0+08414feaac77473f29f6ac182ab4c390ecd3542f" />
     <Usage Id="NuGet.Versioning" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
     <Usage Id="NUnit3.DotNetNew.Template" Version="1.5.3" />
     <Usage Id="NUnit3.DotNetNew.Template" Version="1.6.5" />
     <Usage Id="NUnit3.DotNetNew.Template" Version="1.7.2" />
     <Usage Id="NUnit3.DotNetNew.Template" Version="1.8.1" />
-    <Usage Id="RichCodeNav.EnvVarDump" Version="0.1.1643-alpha" IsDirectDependency="true" />
-    <Usage Id="runtime.any.System.Collections" Version="4.3.0" Rid="any" />
-    <Usage Id="runtime.any.System.Diagnostics.Tools" Version="4.3.0" Rid="any" />
-    <Usage Id="runtime.any.System.Diagnostics.Tracing" Version="4.3.0" Rid="any" />
-    <Usage Id="runtime.any.System.Globalization" Version="4.3.0" Rid="any" />
-    <Usage Id="runtime.any.System.Globalization.Calendars" Version="4.3.0" Rid="any" />
-    <Usage Id="runtime.any.System.IO" Version="4.3.0" Rid="any" />
-    <Usage Id="runtime.any.System.Reflection" Version="4.3.0" Rid="any" />
-    <Usage Id="runtime.any.System.Reflection.Extensions" Version="4.3.0" Rid="any" />
-    <Usage Id="runtime.any.System.Reflection.Primitives" Version="4.3.0" Rid="any" />
-    <Usage Id="runtime.any.System.Resources.ResourceManager" Version="4.3.0" Rid="any" />
-    <Usage Id="runtime.any.System.Runtime" Version="4.3.0" Rid="any" />
-    <Usage Id="runtime.any.System.Runtime.Handles" Version="4.3.0" Rid="any" />
-    <Usage Id="runtime.any.System.Runtime.InteropServices" Version="4.3.0" Rid="any" />
-    <Usage Id="runtime.any.System.Text.Encoding" Version="4.3.0" Rid="any" />
-    <Usage Id="runtime.any.System.Text.Encoding.Extensions" Version="4.3.0" Rid="any" />
-    <Usage Id="runtime.any.System.Threading.Tasks" Version="4.3.0" Rid="any" />
-    <Usage Id="runtime.any.System.Threading.Timer" Version="4.3.0" Rid="any" />
     <Usage Id="runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.0" Rid="debian.8-x64" />
     <Usage Id="runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.2" Rid="debian.8-x64" />
     <Usage Id="runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.0" Rid="fedora.23-x64" />
@@ -320,38 +270,18 @@
     <Usage Id="runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.2" Rid="ubuntu.16.04-x64" />
     <Usage Id="runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.0" Rid="ubuntu.16.10-x64" />
     <Usage Id="runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.2" Rid="ubuntu.16.10-x64" />
-    <Usage Id="runtime.unix.Microsoft.Win32.Primitives" Version="4.3.0" Rid="unix" />
-    <Usage Id="runtime.unix.System.Console" Version="4.3.0" Rid="unix" />
-    <Usage Id="runtime.unix.System.Diagnostics.Debug" Version="4.3.0" Rid="unix" />
-    <Usage Id="runtime.unix.System.IO.FileSystem" Version="4.3.0" Rid="unix" />
-    <Usage Id="runtime.unix.System.Net.Primitives" Version="4.3.0" Rid="unix" />
-    <Usage Id="runtime.unix.System.Net.Sockets" Version="4.3.0" Rid="unix" />
-    <Usage Id="runtime.unix.System.Private.Uri" Version="4.3.0" Rid="unix" />
-    <Usage Id="runtime.unix.System.Runtime.Extensions" Version="4.3.0" Rid="unix" />
     <Usage Id="runtime.win-arm64.runtime.native.System.Data.SqlClient.sni" Version="4.4.0" Rid="win-arm64" />
     <Usage Id="runtime.win-x64.Microsoft.NETCore.App" Version="2.1.0" Rid="win-x64" />
-    <Usage Id="runtime.win-x64.Microsoft.NETCore.CoreDisTools" Version="1.0.1-prerelease-00005" Rid="win-x64" />
     <Usage Id="runtime.win-x64.Microsoft.NETCore.DotNetAppHost" Version="2.1.0" Rid="win-x64" />
     <Usage Id="runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy" Version="2.1.0" Rid="win-x64" />
     <Usage Id="runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" Version="2.1.0" Rid="win-x64" />
     <Usage Id="runtime.win-x64.runtime.native.System.Data.SqlClient.sni" Version="4.4.0" Rid="win-x64" />
     <Usage Id="runtime.win-x86.Microsoft.NETCore.App" Version="2.1.17" Rid="win-x86" />
-    <Usage Id="runtime.win-x86.Microsoft.NETCore.CoreDisTools" Version="1.0.1-prerelease-00005" Rid="win-x86" />
     <Usage Id="runtime.win-x86.Microsoft.NETCore.DotNetAppHost" Version="2.1.17" Rid="win-x86" />
     <Usage Id="runtime.win-x86.Microsoft.NETCore.DotNetHostPolicy" Version="2.1.17" Rid="win-x86" />
     <Usage Id="runtime.win-x86.Microsoft.NETCore.DotNetHostResolver" Version="2.1.17" Rid="win-x86" />
     <Usage Id="runtime.win-x86.runtime.native.System.Data.SqlClient.sni" Version="4.4.0" Rid="win-x86" />
-    <Usage Id="runtime.win.Microsoft.Win32.Primitives" Version="4.3.0" Rid="win" />
-    <Usage Id="runtime.win.System.Console" Version="4.3.0" Rid="win" />
-    <Usage Id="runtime.win.System.Diagnostics.Debug" Version="4.3.0" Rid="win" />
-    <Usage Id="runtime.win.System.IO.FileSystem" Version="4.3.0" Rid="win" />
-    <Usage Id="runtime.win.System.Net.Primitives" Version="4.3.0" Rid="win" />
-    <Usage Id="runtime.win.System.Net.Sockets" Version="4.3.0" Rid="win" />
-    <Usage Id="runtime.win.System.Runtime.Extensions" Version="4.3.0" Rid="win" />
     <Usage Id="sn" Version="1.0.0" IsDirectDependency="true" IsAutoReferenced="true" />
-    <Usage Id="StreamJsonRpc" Version="2.4.48" />
-    <Usage Id="StyleCop.Analyzers" Version="1.2.0-beta.164" IsDirectDependency="true" />
-    <Usage Id="StyleCop.Analyzers.Unstable" Version="1.2.0.164" />
     <Usage Id="System.AppContext" Version="4.1.0" />
     <Usage Id="System.AppContext" Version="4.3.0" />
     <Usage Id="System.Buffers" Version="4.0.0" />
@@ -449,7 +379,6 @@
     <Usage Id="System.IO.MemoryMappedFiles" Version="4.3.0" />
     <Usage Id="System.IO.Packaging" Version="4.6.0" />
     <Usage Id="System.IO.Pipelines" Version="4.6.0" />
-    <Usage Id="System.IO.Pipelines" Version="4.7.0" />
     <Usage Id="System.IO.Pipes" Version="4.3.0" />
     <Usage Id="System.IO.Pipes.AccessControl" Version="4.3.0" />
     <Usage Id="System.IO.Pipes.AccessControl" Version="4.5.1" IsDirectDependency="true" />
@@ -469,7 +398,6 @@
     <Usage Id="System.Net.Http" Version="4.3.0" />
     <Usage Id="System.Net.Http" Version="4.3.4" IsDirectDependency="true" />
     <Usage Id="System.Net.Http.WinHttpHandler" Version="4.6.0" />
-    <Usage Id="System.Net.NameResolution" Version="4.3.0" />
     <Usage Id="System.Net.Primitives" Version="4.0.11" />
     <Usage Id="System.Net.Primitives" Version="4.3.0" />
     <Usage Id="System.Net.Requests" Version="4.0.11" IsDirectDependency="true" />
@@ -479,7 +407,6 @@
     <Usage Id="System.Net.Sockets" Version="4.3.0" />
     <Usage Id="System.Net.WebHeaderCollection" Version="4.0.1" />
     <Usage Id="System.Net.WebHeaderCollection" Version="4.3.0" />
-    <Usage Id="System.Net.WebSockets" Version="4.3.0" />
     <Usage Id="System.Net.WebSockets.WebSocketProtocol" Version="4.6.0" />
     <Usage Id="System.Numerics.Tensors" Version="0.1.0" />
     <Usage Id="System.Numerics.Vectors" Version="4.4.0" />
@@ -487,18 +414,15 @@
     <Usage Id="System.ObjectModel" Version="4.0.12" IsDirectDependency="true" />
     <Usage Id="System.ObjectModel" Version="4.3.0" />
     <Usage Id="System.Private.DataContractSerialization" Version="4.1.1" />
-    <Usage Id="System.Private.Uri" Version="4.3.0" />
     <Usage Id="System.Reflection" Version="4.1.0" IsDirectDependency="true" />
     <Usage Id="System.Reflection" Version="4.3.0" />
     <Usage Id="System.Reflection.Context" Version="4.6.0" />
     <Usage Id="System.Reflection.Emit" Version="4.0.1" />
     <Usage Id="System.Reflection.Emit" Version="4.3.0" />
-    <Usage Id="System.Reflection.Emit" Version="4.6.0" />
     <Usage Id="System.Reflection.Emit.ILGeneration" Version="4.0.1" />
     <Usage Id="System.Reflection.Emit.ILGeneration" Version="4.3.0" />
     <Usage Id="System.Reflection.Emit.Lightweight" Version="4.0.1" />
     <Usage Id="System.Reflection.Emit.Lightweight" Version="4.3.0" />
-    <Usage Id="System.Reflection.Emit.Lightweight" Version="4.6.0" />
     <Usage Id="System.Reflection.Extensions" Version="4.0.1" IsDirectDependency="true" />
     <Usage Id="System.Reflection.Extensions" Version="4.3.0" />
     <Usage Id="System.Reflection.Metadata" Version="1.3.0" />
@@ -527,7 +451,6 @@
     <Usage Id="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
     <Usage Id="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
     <Usage Id="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" />
-    <Usage Id="System.Runtime.CompilerServices.Unsafe" Version="4.6.0" />
     <Usage Id="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
     <Usage Id="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
     <Usage Id="System.Runtime.CompilerServices.Unsafe" Version="5.0.0-preview.4.20202.18" />
@@ -616,7 +539,6 @@
     <Usage Id="System.Threading.Overlapped" Version="4.3.0" />
     <Usage Id="System.Threading.Tasks" Version="4.0.11" IsDirectDependency="true" />
     <Usage Id="System.Threading.Tasks" Version="4.3.0" />
-    <Usage Id="System.Threading.Tasks.Dataflow" Version="4.5.24" />
     <Usage Id="System.Threading.Tasks.Dataflow" Version="4.6.0" />
     <Usage Id="System.Threading.Tasks.Dataflow" Version="4.9.0" />
     <Usage Id="System.Threading.Tasks.Dataflow" Version="4.10.0" />


### PR DESCRIPTION
Update RefOnlyNuget*Versions to use 5.1.0 rather than 4.9.4, since 5.1.0 already exists as a reference package in source-build-reference-packages