### PR TITLE
Add repos added for 5.0 GA to table

### DIFF
--- a/Documentation/planning/arcade-powered-source-build/implementation-plan.md
+++ b/Documentation/planning/arcade-powered-source-build/implementation-plan.md
@@ -12,9 +12,13 @@ To get each repo building with the new source-build 5.0 plan, [Arcade-Powered So
 | Tools | arcade | [Mark Wilkie](https://github.com/markwilkie) | ✔️ | | | | | |
 | 1 | application-insights | [Reiley Yang](https://github.com/reyang) | ✔️ | ✔️ | | | | |
 | 1 | aspnet-xdt | [Vijay Ramakrishnan](https://github.com/vijayrkn) | ✔️ | | | | | |
+| ? | cssparser | ? | ✔️ | | | | | |
+| ? | diagnostics | ? | ✔️ | | | | | |
 | 1 | newtonsoft-json | [Chris Rummel](https://github.com/crummel) | ✔️ | | | | | |
 | 1 | netcorecli-fsc | [Chris Rummel](https://github.com/crummel) | ✔️ | ✔️ | | | | |
 | 1 | newtonsoft-json901 | [Chris Rummel](https://github.com/crummel) | ✔️ | ✔️ | | | | |
+| ? | symreader | ? | ✔️ | | | | | |
+| ? | test-templates | ? | ✔️ | | | | | |
 | 1 | xliff-tasks | [Mark Wilkie](https://github.com/markwilkie) | ✔️ | ✔️ | | | | |
 | 1 | clicommandlineparser | [Sarah Oslund](https://github.com/sfoslund) | ✔️ | | | | | |
 | 1 | command-line-api | [?](https://github.com/) | ⏱ | | | | | |


### PR DESCRIPTION
We've added some repos for 5.0 GA. We need to track these for arcade-powered source-build. I haven't looked into ownership yet for these ones, but we can at least add them to the table now for easy reference.