### PR TITLE
Stop harvesting packages in runtime: remove prebuilts

### DIFF
--- a/patches/runtime/0027-Remove-libraries-packages.proj-harvesting.patch
+++ b/patches/runtime/0027-Remove-libraries-packages.proj-harvesting.patch
@@ -1,0 +1,27 @@
+From e45904a0ce2e16d1fe49341af1dd4ab84ce729f5 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Mon, 2 Nov 2020 11:54:57 -0600
+Subject: [PATCH] Remove libraries-packages.proj harvesting
+
+Remove some prebuilts by removing package harvesting. Package harvesting
+is not compatible with the concept of a prebuiltless source-build.
+---
+ src/libraries/libraries-packages.proj | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/libraries/libraries-packages.proj b/src/libraries/libraries-packages.proj
+index f2eef864898..5e156775bcc 100644
+--- a/src/libraries/libraries-packages.proj
++++ b/src/libraries/libraries-packages.proj
+@@ -24,7 +24,7 @@
+   <Import Project="$(PkgDir)baseline\baseline.props" />
+ 
+   <!-- Calculate PackageDownload items for restore. -->
+-  <Import Project="$(RepositoryEngineeringDir)restore\harvestPackages.targets" Condition="'$(MSBuildRestoreSessionId)' != ''" />
++  <Import Project="$(RepositoryEngineeringDir)restore\harvestPackages.targets" Condition="'$(MSBuildRestoreSessionId)' != '' and '$(DotNetBuildFromSource)' != 'true'" />
+ 
+   <!--
+     Updates the package index to mark all packages we are building that can go stable as stable.
+-- 
+2.25.2
+


### PR DESCRIPTION
Conditionally remove the import of `restore\harvestPackages.targets` to remove some PackageDownload elements bringing in prebuilts.

For https://github.com/dotnet/source-build/issues/1844.