### PR TITLE
Fix Roslyn version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,8 +20,6 @@
     <Platform Condition="'$(Platform)' == '' AND '$(BuildArchitecture)' == 'arm64'">$(BuildArchitecture)</Platform>
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
 
-    <UseStableVersions Condition="'$(UseStableVersions)' == ''">true</UseStableVersions>
-
     <!-- new supported portable/nonportable options.  These control whether to build portable runtime
          or portable SDK.  The PortableBuild flag is only set in runtime-portable.proj and should
          no longer be passed in.  -->

--- a/patches/aspnetcore/0016-Don-t-warn-on-CA1416.patch
+++ b/patches/aspnetcore/0016-Don-t-warn-on-CA1416.patch
@@ -1,26 +1,29 @@
 From 0e7e210394d152c097facaf9e3cde68a0a04eb87 Mon Sep 17 00:00:00 2001
 From: dseefeld <dseefeld@microsoft.com>
 Date: Thu, 8 Oct 2020 14:18:02 +0000
-Subject: [PATCH] Don't warn on CA1416
+Subject: [PATCH] Don't warn on CA1416 & NU5104
 
 ---
- Directory.Build.props | 3 +++
- 1 file changed, 3 insertions(+)
+ Directory.Build.props | 6 ++++++
+ 1 file changed, 6 insertions(+)
 
 diff --git a/Directory.Build.props b/Directory.Build.props
 index 9f3a6d3..40fc07b 100644
 --- a/Directory.Build.props
 +++ b/Directory.Build.props
-@@ -100,6 +100,9 @@
- 
+@@ -100,6 +100,12 @@
+
    <!-- Warnings and errors -->
    <PropertyGroup>
 +    <!-- Don't warn on CA1416 since source-build TFM changes
 +        are causing the warning to occur -->
 +    <NoWarn>$(NoWarn);CA1416</NoWarn>
++    <!-- Don't warn on NU5104 - PVP provides built versions
++        which may be unstable versions, causing this error -->
++    <NoWarn>$(NoWarn);NU5104</NoWarn>
      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
      <!-- Don't make missing XML docs a fatal build error, but still surface so we have visibility into undocumented APIs. -->
      <WarningsNotAsErrors>$(WarningsNotAsErrors);CS1591</WarningsNotAsErrors>
--- 
+--
 1.8.3.1
 

--- a/patches/roslyn/0011-Don-t-call-dotnet-without-path.patch
+++ b/patches/roslyn/0011-Don-t-call-dotnet-without-path.patch
@@ -1,0 +1,26 @@
+From b2b6d6d756a12c307e506f21936e47d63ba9ffdf Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Wed, 4 Nov 2020 23:21:14 +0000
+Subject: [PATCH] Don't call dotnet without path
+
+---
+ eng/common/tools.sh | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/eng/common/tools.sh b/eng/common/tools.sh
+index acbb0c5..3840f69 100755
+--- a/eng/common/tools.sh
++++ b/eng/common/tools.sh
+@@ -369,9 +369,6 @@ function MSBuild {
+ 
+     # Work around issues with Azure Artifacts credential provider
+     # https://github.com/dotnet/arcade/issues/3932
+-    if [[ "$ci" == true ]]; then
+-      dotnet nuget locals http-cache -c
+-    fi
+ 
+     local toolset_dir="${_InitializeToolset%/*}"
+     local logger_path="$toolset_dir/$_InitializeBuildToolFramework/Microsoft.DotNet.Arcade.Sdk.dll"
+-- 
+1.8.3.1
+

--- a/repos/Directory.Build.props
+++ b/repos/Directory.Build.props
@@ -63,22 +63,6 @@
     <EnvironmentVariables Include="_DotNetInstallDir=$(DotNetCliToolDir)" />
     <EnvironmentVariables Include="_InitializeToolset=$(ProjectDir)Tools/source-built/Microsoft.DotNet.Arcade.Sdk/tools/Build.proj" Condition="'$(UseBootstrapArcade)' != 'true'" />
 
-    <!--
-      With ProdCon v2, stabilization options are checked in, unlike ProdCon v1. These should be
-      deprecated but are left in to avoid potentially regressing edge-case versioning.
-    -->
-    <EnvironmentVariables Include="StabilizePackageVersion=$(IsStable)" Condition="'$(IsStable)' != '' and '$(IsToolingProject)' != 'true'" />
-    <EnvironmentVariables Include="PB_IsStable=$(IsStable)" Condition="'$(IsStable)' != '' and '$(IsToolingProject)' != 'true'" />
-    <EnvironmentVariables Include="IsStableBuild=$(IsStable)" Condition="'$(IsStable)' != '' and '$(IsToolingProject)' != 'true'" />
-    <EnvironmentVariables Include="DotNetFinalVersionKind=release" Condition="'$(IsStable)' == 'true' and '$(IsToolingProject)' != 'true'" />
-    <EnvironmentVariables Include="DropSuffix=true" Condition="'$(IsStable)' == 'true' and '$(IsToolingProject)' != 'true'" />
-
-    <EnvironmentVariables Include="DotNetUseShippingVersions=true" />
-
-    <EnvironmentVariables Include="PreReleaseVersionLabel=$(PreReleaseVersionLabel)" />
-    <EnvironmentVariables Include="PackageVersionStamp=$(PreReleaseVersionLabel)" />
-    <EnvironmentVariables Include="PB_VersionStamp=$(PreReleaseVersionLabel)" />
-
     <!-- We pass '-ci', but also apply ci mode via env var for edge cases. (E.g. misbehaving inner builds.) -->
     <EnvironmentVariables Include="ContinuousIntegrationBuild=true" />
 

--- a/repos/roslyn.proj
+++ b/repos/roslyn.proj
@@ -6,6 +6,7 @@
     <BuildCommandArgs>$(BuildCommandArgs) --configuration $(Configuration)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) -v $(LogVerbosity)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) -bl</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) --ci</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:TreatWarningsAsErrors=false</BuildCommandArgs>
 
     <!-- Versioning args. -->


### PR DESCRIPTION
As part of the 5.0GA update, the roslyn repo was building with a "-dev" version.  To fix this, the `UseStableVersions` propery was set to true, but this caused it to not build the version that ships with the Microsoft build.  Fix this issue by removing the `UseStableVersions` property and add `--ci` to the roslyn build to get it to build the correct version.