### PR TITLE
Exclude System.CommandLine.Hosting from source-build

### DIFF
--- a/patches/command-line-api/0004-Exclude-System.CommandLine.Hosting.patch
+++ b/patches/command-line-api/0004-Exclude-System.CommandLine.Hosting.patch
@@ -1,0 +1,25 @@
+From f4053c72fd35e1ec0b238cb5f27f818b837a3632 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Thu, 5 Nov 2020 10:48:59 -0600
+Subject: [PATCH] Exclude System.CommandLine.Hosting
+
+This project is not used by downstream repos and restores prebuilts.
+---
+ src/System.CommandLine.Hosting/System.CommandLine.Hosting.csproj | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/System.CommandLine.Hosting/System.CommandLine.Hosting.csproj b/src/System.CommandLine.Hosting/System.CommandLine.Hosting.csproj
+index 7342c1c..e4a97a0 100644
+--- a/src/System.CommandLine.Hosting/System.CommandLine.Hosting.csproj
++++ b/src/System.CommandLine.Hosting/System.CommandLine.Hosting.csproj
+@@ -5,6 +5,7 @@
+     <TargetFramework>netcoreapp3.1</TargetFramework>
+     <LangVersion>latest</LangVersion>
+     <Description>This package provides support for using System.CommandLine with Microsoft.Extensions.Hosting.</Description>
++    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+   </PropertyGroup>
+ 
+   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+-- 
+2.25.2
+


### PR DESCRIPTION
From the annotated report in a GA build, this seems to be the only user of:

```
  <AnnotatedUsage Id="Microsoft.Extensions.Configuration" Version="2.2.0" File="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/artifacts/obj/System.CommandLine.Hosting/project.assets.json" Project="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/" SourceBuildPackageIdCreator="runtime MicrosoftExtensionsConfigurationPackageVersion/5.0.0" />
  <AnnotatedUsage Id="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" File="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/artifacts/obj/System.CommandLine.Hosting/project.assets.json" Project="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/" SourceBuildPackageIdCreator="runtime MicrosoftExtensionsConfigurationAbstractionsPackageVersion/5.0.0" />
  <AnnotatedUsage Id="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" File="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/artifacts/obj/System.CommandLine.Hosting/project.assets.json" Project="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/" SourceBuildPackageIdCreator="runtime MicrosoftExtensionsConfigurationBinderPackageVersion/5.0.0" />
  <AnnotatedUsage Id="Microsoft.Extensions.DependencyInjection" Version="2.2.0" File="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/artifacts/obj/System.CommandLine.Hosting/project.assets.json" Project="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/" SourceBuildPackageIdCreator="runtime MicrosoftExtensionsDependencyInjectionPackageVersion/5.0.0" />
  <AnnotatedUsage Id="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" File="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/artifacts/obj/System.CommandLine.Hosting/project.assets.json" Project="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/" SourceBuildPackageIdCreator="runtime MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion/5.0.0" />
  <AnnotatedUsage Id="Microsoft.Extensions.FileProviders.Abstractions" Version="2.2.0" File="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/artifacts/obj/System.CommandLine.Hosting/project.assets.json" Project="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/" SourceBuildPackageIdCreator="runtime MicrosoftExtensionsFileProvidersAbstractionsPackageVersion/5.0.0" />
  <AnnotatedUsage Id="Microsoft.Extensions.FileProviders.Physical" Version="2.2.0" File="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/artifacts/obj/System.CommandLine.Hosting/project.assets.json" Project="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/" SourceBuildPackageIdCreator="runtime MicrosoftExtensionsFileProvidersPhysicalPackageVersion/5.0.0" />
  <AnnotatedUsage Id="Microsoft.Extensions.FileSystemGlobbing" Version="2.2.0" File="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/artifacts/obj/System.CommandLine.Hosting/project.assets.json" Project="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/" SourceBuildPackageIdCreator="runtime MicrosoftExtensionsFileSystemGlobbingPackageVersion/5.0.0" />
  <AnnotatedUsage Id="Microsoft.Extensions.Hosting" Version="2.2.0" File="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/artifacts/obj/System.CommandLine.Hosting/project.assets.json" IsDirectDependency="true" Project="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/" SourceBuildPackageIdCreator="runtime MicrosoftExtensionsHostingPackageVersion/5.0.0" />
  <AnnotatedUsage Id="Microsoft.Extensions.Hosting.Abstractions" Version="2.2.0" File="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/artifacts/obj/System.CommandLine.Hosting/project.assets.json" Project="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/" SourceBuildPackageIdCreator="runtime MicrosoftExtensionsHostingAbstractionsPackageVersion/5.0.0" />
  <AnnotatedUsage Id="Microsoft.Extensions.Logging" Version="2.2.0" File="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/artifacts/obj/System.CommandLine.Hosting/project.assets.json" Project="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/" SourceBuildPackageIdCreator="runtime MicrosoftExtensionsLoggingPackageVersion/5.0.0" />
  <AnnotatedUsage Id="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" File="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/artifacts/obj/System.CommandLine.Hosting/project.assets.json" Project="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/" SourceBuildPackageIdCreator="runtime MicrosoftExtensionsLoggingAbstractionsPackageVersion/5.0.0" />
  <AnnotatedUsage Id="Microsoft.Extensions.Options" Version="2.2.0" File="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/artifacts/obj/System.CommandLine.Hosting/project.assets.json" Project="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/" SourceBuildPackageIdCreator="runtime MicrosoftExtensionsOptionsPackageVersion/5.0.0" />
  <AnnotatedUsage Id="Microsoft.Extensions.Primitives" Version="2.2.0" File="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/artifacts/obj/System.CommandLine.Hosting/project.assets.json" Project="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/" SourceBuildPackageIdCreator="runtime MicrosoftExtensionsPrimitivesPackageVersion/5.0.0" />

  <AnnotatedUsage Id="System.ComponentModel.Annotations" Version="4.5.0" File="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/artifacts/obj/System.CommandLine.Hosting/project.assets.json" Project="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/" SourceBuildPackageIdCreator="runtime SystemComponentModelAnnotationsPackageVersion/5.0.0" />

  <AnnotatedUsage Id="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" File="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/artifacts/obj/System.CommandLine.Hosting/project.assets.json" Project="src/command-line-api.afd010ba8cb3cbd714c734465d1a5de1ee133e2d/" SourceBuildPackageIdCreator="runtime SystemRuntimeCompilerServicesUnsafePackageVersion/5.0.0" />
```

Found this via `System.Runtime.CompilerServices.Unsafe/4.5.1`.