### PR TITLE
Update previously-source-built tarball and prebuilt baselines

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,6 +8,6 @@
   <!-- Production Dependencies -->
   <PropertyGroup>
     <PrivateSourceBuildReferencePackagesPackageVersion>1.0.0-beta.20521.1</PrivateSourceBuildReferencePackagesPackageVersion>
-    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-5.0.100-bootstrap.13</PrivateSourceBuiltArtifactsPackageVersion>
+    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-5.0.100-877538</PrivateSourceBuiltArtifactsPackageVersion>
   </PropertyGroup>
 </Project>

--- a/tools-local/prebuilt-baseline-offline.xml
+++ b/tools-local/prebuilt-baseline-offline.xml
@@ -40,6 +40,7 @@
     <PackageIdentity Id="MicroBuild.Core" Version="0.2.0" />
     <PackageIdentity Id="MicroBuild.Core.Sentinel" Version="1.0.0" />
     <PackageIdentity Id="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
+    <PackageIdentity Id="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0-rc.1.20451.14" />
     <PackageIdentity Id="Microsoft.Build.Framework" Version="15.3.409" />
     <PackageIdentity Id="Microsoft.Build.Framework" Version="15.4.8" />
     <PackageIdentity Id="Microsoft.Build.Tasks.Core" Version="15.3.409" />
@@ -50,8 +51,21 @@
     <PackageIdentity Id="Microsoft.CodeAnalysis.CSharp" Version="3.4.0" />
     <PackageIdentity Id="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.8.0-2.20414.4" />
     <PackageIdentity Id="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" Version="3.8.0-2.20414.4" />
+    <PackageIdentity Id="Microsoft.Extensions.DependencyModel" Version="3.1.6" />
+    <PackageIdentity Id="Microsoft.NETCore.Platforms" Version="2.1.2" />
     <PackageIdentity Id="Microsoft.SymbolUploader.Build.Task" Version="1.1.141804" />
     <PackageIdentity Id="NETStandard.Library" Version="1.6.0" />
+    <PackageIdentity Id="NuGet.Commands" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
+    <PackageIdentity Id="NuGet.Common" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
+    <PackageIdentity Id="NuGet.Configuration" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
+    <PackageIdentity Id="NuGet.Credentials" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
+    <PackageIdentity Id="NuGet.DependencyResolver.Core" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
+    <PackageIdentity Id="NuGet.Frameworks" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
+    <PackageIdentity Id="NuGet.LibraryModel" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
+    <PackageIdentity Id="NuGet.Packaging" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
+    <PackageIdentity Id="NuGet.ProjectModel" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
+    <PackageIdentity Id="NuGet.Protocol" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
+    <PackageIdentity Id="NuGet.Versioning" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
     <PackageIdentity Id="runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.0" />
     <PackageIdentity Id="runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.2" />
     <PackageIdentity Id="runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.0" />
@@ -60,6 +74,7 @@
     <PackageIdentity Id="runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.2" />
     <PackageIdentity Id="runtime.native.System" Version="4.0.0" />
     <PackageIdentity Id="runtime.native.System" Version="4.3.0" />
+    <PackageIdentity Id="runtime.native.System.Data.SqlClient.sni" Version="4.7.0" />
     <PackageIdentity Id="runtime.native.System.IO.Compression" Version="4.1.0" />
     <PackageIdentity Id="runtime.native.System.IO.Compression" Version="4.3.0" />
     <PackageIdentity Id="runtime.native.System.Net.Http" Version="4.0.1" />
@@ -84,8 +99,17 @@
     <PackageIdentity Id="runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.2" />
     <PackageIdentity Id="runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.0" />
     <PackageIdentity Id="runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.2" />
+    <PackageIdentity Id="runtime.win-arm64.runtime.native.System.Data.SqlClient.sni" Version="4.4.0" />
+    <PackageIdentity Id="runtime.win-x64.runtime.native.System.Data.SqlClient.sni" Version="4.4.0" />
+    <PackageIdentity Id="runtime.win-x86.runtime.native.System.Data.SqlClient.sni" Version="4.4.0" />
+    <PackageIdentity Id="System.Collections.Immutable" Version="5.0.0-preview.8.20407.11" />
     <PackageIdentity Id="System.Composition" Version="1.0.31" />
+    <PackageIdentity Id="System.Reflection.Metadata" Version="5.0.0-preview.8.20407.11" />
+    <PackageIdentity Id="System.Runtime.CompilerServices.Unsafe" Version="5.0.0-rc.1.20451.14" />
     <PackageIdentity Id="System.Text.Encodings.Web" Version="4.7.1" />
+    <PackageIdentity Id="System.Text.Encodings.Web" Version="5.0.0-rc.1.20451.14" />
+    <PackageIdentity Id="System.Text.Json" Version="4.7.2" />
+    <PackageIdentity Id="System.Text.Json" Version="5.0.0-rc.1.20451.14" />
     <PackageIdentity Id="System.Xml.XPath.XmlDocument" Version="4.0.1" />
     <PackageIdentity Id="XliffTasks" Version="1.0.0-beta.20420.1" />
   </NeverRestoredTarballPrebuilts>
@@ -139,7 +163,6 @@
     <Usage Id="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" />
     <Usage Id="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.0" IsDirectDependency="true" />
     <Usage Id="Microsoft.Diagnostics.NETCore.Client" Version="0.2.0-preview.20419.2" IsDirectDependency="true" />
-    <Usage Id="Microsoft.Diagnostics.Tracing.EventSource.Redist" Version="2.1.0" />
     <Usage Id="Microsoft.Docker.Sdk" Version="1.1.0" />
     <Usage Id="Microsoft.DotNet.Common.ItemTemplates" Version="1.0.2-beta3" />
     <Usage Id="Microsoft.DotNet.Common.ItemTemplates" Version="2.0.0-preview8.19373.1" />
@@ -157,78 +180,22 @@
     <Usage Id="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.0" Version="3.0.1" />
     <Usage Id="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.1" Version="3.1.8" />
     <Usage Id="Microsoft.DotNet.Web.Spa.ProjectTemplates.5.0" Version="5.0.0" />
-    <Usage Id="Microsoft.Extensions.Caching.Abstractions" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Caching.Memory" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Configuration" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.Configuration" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.Configuration.Binder" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Configuration.Ini" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Configuration.Json" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Configuration.Xml" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.DependencyInjection" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.DependencyModel" Version="3.1.6" />
-    <Usage Id="Microsoft.Extensions.FileProviders.Abstractions" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.FileProviders.Abstractions" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.FileProviders.Composite" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.FileProviders.Physical" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.FileProviders.Physical" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.FileSystemGlobbing" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.1" />
-    <Usage Id="Microsoft.Extensions.Hosting" Version="2.2.0" IsDirectDependency="true" />
-    <Usage Id="Microsoft.Extensions.Hosting" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Hosting.Abstractions" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Http" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.Logging" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.Logging.Abstractions" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Logging.Configuration" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Logging.Console" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Logging.Debug" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Logging.EventLog" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Logging.EventSource" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Logging.TraceSource" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Options" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.Options" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Options.DataAnnotations" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Primitives" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.Primitives" Version="3.1.2" />
-    <Usage Id="Microsoft.IO.Redist" Version="4.6.0" />
     <Usage Id="Microsoft.NET.Sdk.IL" Version="5.0.0-preview.8.20359.4" />
-    <Usage Id="Microsoft.NETCore.App" Version="2.1.17" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="Microsoft.NETCore.App.Host.linux-x64" Version="3.0.3" />
     <Usage Id="Microsoft.NETCore.App.Host.linux-x64" Version="3.1.7" />
     <Usage Id="Microsoft.NETCore.App.Ref" Version="5.0.0" />
     <Usage Id="Microsoft.NETCore.DotNetAppHost" Version="2.0.0" />
     <Usage Id="Microsoft.NETCore.DotNetAppHost" Version="2.1.0" />
-    <Usage Id="Microsoft.NETCore.DotNetAppHost" Version="2.1.17" />
     <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="2.0.0" />
     <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="2.1.0" />
-    <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="2.1.17" />
     <Usage Id="Microsoft.NETCore.DotNetHostResolver" Version="2.0.0" />
     <Usage Id="Microsoft.NETCore.DotNetHostResolver" Version="2.1.0" />
-    <Usage Id="Microsoft.NETCore.DotNetHostResolver" Version="2.1.17" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="1.0.1" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="1.1.1" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="2.0.0" />
-    <Usage Id="Microsoft.NETCore.Platforms" Version="2.1.2" />
-    <Usage Id="Microsoft.NETCore.Platforms" Version="2.1.9" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="3.1.0" />
     <Usage Id="Microsoft.NETCore.Targets" Version="1.0.1" />
     <Usage Id="Microsoft.NETCore.Targets" Version="1.1.3" />
-    <Usage Id="Microsoft.NETCore.Targets" Version="2.0.0" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net20" Version="1.0.0-preview.2" />
@@ -240,93 +207,22 @@
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net47" Version="1.0.0" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.0" />
-    <Usage Id="Microsoft.Win32.Registry" Version="4.6.0" IsDirectDependency="true" />
-    <Usage Id="Microsoft.Win32.Registry.AccessControl" Version="4.6.0" />
-    <Usage Id="Microsoft.Win32.SystemEvents" Version="4.6.0" />
     <Usage Id="Microsoft.Win32.SystemEvents" Version="4.7.0" />
-    <Usage Id="Microsoft.XmlSerializer.Generator" Version="2.1.0" />
     <Usage Id="NETStandard.Library" Version="1.6.1" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="NETStandard.Library" Version="2.2.0-prerelease.19564.1" />
-    <Usage Id="NuGet.Commands" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
-    <Usage Id="NuGet.Common" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
-    <Usage Id="NuGet.Configuration" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
-    <Usage Id="NuGet.Credentials" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
-    <Usage Id="NuGet.DependencyResolver.Core" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
-    <Usage Id="NuGet.Frameworks" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
-    <Usage Id="NuGet.LibraryModel" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
-    <Usage Id="NuGet.Packaging" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
-    <Usage Id="NuGet.ProjectModel" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
-    <Usage Id="NuGet.Protocol" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
-    <Usage Id="NuGet.Versioning" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
     <Usage Id="NUnit3.DotNetNew.Template" Version="1.5.3" />
     <Usage Id="NUnit3.DotNetNew.Template" Version="1.6.5" />
     <Usage Id="NUnit3.DotNetNew.Template" Version="1.7.2" />
     <Usage Id="NUnit3.DotNetNew.Template" Version="1.8.1" />
-    <Usage Id="runtime.native.System.Data.SqlClient.sni" Version="4.7.0" />
-    <Usage Id="runtime.win-arm64.runtime.native.System.Data.SqlClient.sni" Version="4.4.0" Rid="win-arm64" />
-    <Usage Id="runtime.win-x64.Microsoft.NETCore.App" Version="2.1.0" Rid="win-x64" />
-    <Usage Id="runtime.win-x64.Microsoft.NETCore.DotNetAppHost" Version="2.1.0" Rid="win-x64" />
-    <Usage Id="runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy" Version="2.1.0" Rid="win-x64" />
-    <Usage Id="runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" Version="2.1.0" Rid="win-x64" />
-    <Usage Id="runtime.win-x64.runtime.native.System.Data.SqlClient.sni" Version="4.4.0" Rid="win-x64" />
-    <Usage Id="runtime.win-x86.Microsoft.NETCore.App" Version="2.1.17" Rid="win-x86" />
-    <Usage Id="runtime.win-x86.Microsoft.NETCore.DotNetAppHost" Version="2.1.17" Rid="win-x86" />
-    <Usage Id="runtime.win-x86.Microsoft.NETCore.DotNetHostPolicy" Version="2.1.17" Rid="win-x86" />
-    <Usage Id="runtime.win-x86.Microsoft.NETCore.DotNetHostResolver" Version="2.1.17" Rid="win-x86" />
-    <Usage Id="runtime.win-x86.runtime.native.System.Data.SqlClient.sni" Version="4.4.0" Rid="win-x86" />
-    <Usage Id="System.CodeDom" Version="4.6.0" />
-    <Usage Id="System.Collections.Immutable" Version="5.0.0-preview.8.20407.11" />
-    <Usage Id="System.ComponentModel.Annotations" Version="4.5.0" />
-    <Usage Id="System.ComponentModel.Annotations" Version="4.6.0" />
     <Usage Id="System.ComponentModel.Annotations" Version="4.7.0" />
-    <Usage Id="System.ComponentModel.Composition" Version="4.6.0" />
-    <Usage Id="System.ComponentModel.Composition.Registration" Version="4.6.0" />
-    <Usage Id="System.Configuration.ConfigurationManager" Version="4.6.0" />
-    <Usage Id="System.Data.Odbc" Version="4.6.0" />
-    <Usage Id="System.Data.OleDb" Version="4.6.0" />
-    <Usage Id="System.Data.SqlClient" Version="4.8.2" IsDirectDependency="true" />
-    <Usage Id="System.Diagnostics.DiagnosticSource" Version="4.6.0" />
-    <Usage Id="System.Diagnostics.EventLog" Version="4.6.0" />
-    <Usage Id="System.Diagnostics.PerformanceCounter" Version="4.6.0" />
-    <Usage Id="System.DirectoryServices" Version="4.6.0" />
-    <Usage Id="System.DirectoryServices.AccountManagement" Version="4.6.0" />
-    <Usage Id="System.DirectoryServices.Protocols" Version="4.6.0" />
     <Usage Id="System.Drawing.Common" Version="4.7.0" />
-    <Usage Id="System.IO.FileSystem.AccessControl" Version="4.6.0" />
-    <Usage Id="System.IO.Packaging" Version="4.6.0" />
-    <Usage Id="System.IO.Pipelines" Version="4.6.0" />
-    <Usage Id="System.IO.Ports" Version="4.6.0" />
-    <Usage Id="System.Management" Version="4.6.0" />
-    <Usage Id="System.Net.Http.WinHttpHandler" Version="4.6.0" />
-    <Usage Id="System.Net.WebSockets.WebSocketProtocol" Version="4.6.0" />
-    <Usage Id="System.Numerics.Tensors" Version="0.1.0" />
-    <Usage Id="System.Reflection.Context" Version="4.6.0" />
-    <Usage Id="System.Reflection.Metadata" Version="5.0.0-preview.8.20407.11" />
-    <Usage Id="System.Reflection.MetadataLoadContext" Version="4.6.0" />
-    <Usage Id="System.Runtime.Caching" Version="4.6.0" />
-    <Usage Id="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
-    <Usage Id="System.Security.AccessControl" Version="4.6.0" />
     <Usage Id="System.Security.Cryptography.Algorithms" Version="4.3.1" />
-    <Usage Id="System.Security.Cryptography.Cng" Version="4.6.1" />
     <Usage Id="System.Security.Cryptography.Cng" Version="4.7.0" />
     <Usage Id="System.Security.Cryptography.Cng" Version="5.0.0-preview.3.20214.6" />
-    <Usage Id="System.Security.Cryptography.OpenSsl" Version="4.6.0" />
-    <Usage Id="System.Security.Cryptography.Pkcs" Version="4.6.0" />
     <Usage Id="System.Security.Cryptography.Pkcs" Version="4.7.0" />
     <Usage Id="System.Security.Cryptography.Pkcs" Version="5.0.0-preview.3.20214.6" />
     <Usage Id="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
-    <Usage Id="System.Security.Cryptography.ProtectedData" Version="4.6.0" />
-    <Usage Id="System.Security.Cryptography.Xml" Version="4.6.0" />
     <Usage Id="System.Security.Cryptography.Xml" Version="4.7.0" />
-    <Usage Id="System.Security.Permissions" Version="4.6.0" />
-    <Usage Id="System.Security.Principal.Windows" Version="4.6.0" />
-    <Usage Id="System.ServiceModel.Syndication" Version="4.6.0" />
-    <Usage Id="System.ServiceProcess.ServiceController" Version="4.6.0" />
-    <Usage Id="System.Text.Encoding.CodePages" Version="4.6.0" />
-    <Usage Id="System.Threading.AccessControl" Version="4.6.0" />
-    <Usage Id="System.Threading.Channels" Version="4.6.0" />
-    <Usage Id="System.Threading.Tasks.Dataflow" Version="4.10.0" />
-    <Usage Id="System.Windows.Extensions" Version="4.6.0" />
     <Usage Id="System.Windows.Extensions" Version="4.7.0" />
   </Usages>
 </UsageData>

--- a/tools-local/prebuilt-baseline-online.xml
+++ b/tools-local/prebuilt-baseline-online.xml
@@ -52,7 +52,6 @@
     <Usage Id="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rc.1.20451.17" />
     <Usage Id="Microsoft.AspNetCore.App.Ref" Version="5.0.0" />
     <Usage Id="Microsoft.AspNetCore.Components.WebAssembly.Templates" Version="3.2.1" />
-    <Usage Id="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
     <Usage Id="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
     <Usage Id="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
     <Usage Id="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0-rc.1.20451.14" />
@@ -82,7 +81,6 @@
     <Usage Id="Microsoft.CSharp" Version="4.0.1" IsDirectDependency="true" />
     <Usage Id="Microsoft.CSharp" Version="4.3.0" IsDirectDependency="true" />
     <Usage Id="Microsoft.Diagnostics.NETCore.Client" Version="0.2.0-preview.20419.2" IsDirectDependency="true" />
-    <Usage Id="Microsoft.Diagnostics.Tracing.EventSource.Redist" Version="2.1.0" />
     <Usage Id="Microsoft.Docker.Sdk" Version="1.1.0" />
     <Usage Id="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20426.4" />
     <Usage Id="Microsoft.DotNet.Common.ItemTemplates" Version="1.0.2-beta3" />
@@ -103,60 +101,11 @@
     <Usage Id="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.0" Version="3.0.1" />
     <Usage Id="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.1" Version="3.1.8" />
     <Usage Id="Microsoft.DotNet.Web.Spa.ProjectTemplates.5.0" Version="5.0.0" />
-    <Usage Id="Microsoft.Extensions.Caching.Abstractions" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Caching.Memory" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Configuration" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.Configuration" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.Configuration.Binder" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Configuration.Ini" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Configuration.Json" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Configuration.Xml" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.DependencyInjection" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.2" />
     <Usage Id="Microsoft.Extensions.DependencyModel" Version="2.1.0" IsDirectDependency="true" />
     <Usage Id="Microsoft.Extensions.DependencyModel" Version="3.1.6" IsDirectDependency="true" />
-    <Usage Id="Microsoft.Extensions.FileProviders.Abstractions" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.FileProviders.Abstractions" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.FileProviders.Composite" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.FileProviders.Physical" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.FileProviders.Physical" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.FileSystemGlobbing" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.1" />
-    <Usage Id="Microsoft.Extensions.Hosting" Version="2.2.0" IsDirectDependency="true" />
-    <Usage Id="Microsoft.Extensions.Hosting" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Hosting.Abstractions" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Http" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.Logging" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.Logging.Abstractions" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Logging.Configuration" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Logging.Console" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Logging.Debug" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Logging.EventLog" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Logging.EventSource" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Logging.TraceSource" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Options" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.Options" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Options.DataAnnotations" Version="3.1.2" />
-    <Usage Id="Microsoft.Extensions.Primitives" Version="2.2.0" />
-    <Usage Id="Microsoft.Extensions.Primitives" Version="3.1.2" />
-    <Usage Id="Microsoft.IO.Redist" Version="4.6.0" />
     <Usage Id="Microsoft.NET.Sdk.IL" Version="5.0.0-preview.8.20359.4" />
     <Usage Id="Microsoft.NETCore.App" Version="2.0.0" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="Microsoft.NETCore.App" Version="2.1.0" IsDirectDependency="true" IsAutoReferenced="true" />
-    <Usage Id="Microsoft.NETCore.App" Version="2.1.17" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="Microsoft.NETCore.App.Host.linux-x64" Version="3.0.3" />
     <Usage Id="Microsoft.NETCore.App.Host.linux-x64" Version="3.1.7" />
     <Usage Id="Microsoft.NETCore.App.Ref" Version="3.0.0" />
@@ -164,26 +113,20 @@
     <Usage Id="Microsoft.NETCore.App.Ref" Version="5.0.0" />
     <Usage Id="Microsoft.NETCore.DotNetAppHost" Version="2.0.0" />
     <Usage Id="Microsoft.NETCore.DotNetAppHost" Version="2.1.0" />
-    <Usage Id="Microsoft.NETCore.DotNetAppHost" Version="2.1.17" />
     <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="2.0.0" />
     <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="2.1.0" />
-    <Usage Id="Microsoft.NETCore.DotNetHostPolicy" Version="2.1.17" />
     <Usage Id="Microsoft.NETCore.DotNetHostResolver" Version="2.0.0" />
     <Usage Id="Microsoft.NETCore.DotNetHostResolver" Version="2.1.0" />
-    <Usage Id="Microsoft.NETCore.DotNetHostResolver" Version="2.1.17" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="1.0.1" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="1.1.0" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="1.1.1" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="2.0.0" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="2.1.0" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="2.1.2" />
-    <Usage Id="Microsoft.NETCore.Platforms" Version="2.1.9" />
-    <Usage Id="Microsoft.NETCore.Platforms" Version="3.0.0" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="3.1.0" />
     <Usage Id="Microsoft.NETCore.Targets" Version="1.0.1" />
     <Usage Id="Microsoft.NETCore.Targets" Version="1.1.0" />
     <Usage Id="Microsoft.NETCore.Targets" Version="1.1.3" />
-    <Usage Id="Microsoft.NETCore.Targets" Version="2.0.0" />
     <Usage Id="Microsoft.NETCore.Targets" Version="2.1.0" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" IsDirectDependency="true" IsAutoReferenced="true" />
@@ -202,12 +145,8 @@
     <Usage Id="Microsoft.Win32.Primitives" Version="4.3.0" />
     <Usage Id="Microsoft.Win32.Registry" Version="4.0.0" />
     <Usage Id="Microsoft.Win32.Registry" Version="4.3.0" />
-    <Usage Id="Microsoft.Win32.Registry" Version="4.6.0" IsDirectDependency="true" />
     <Usage Id="Microsoft.Win32.Registry" Version="4.7.0" />
-    <Usage Id="Microsoft.Win32.Registry.AccessControl" Version="4.6.0" />
-    <Usage Id="Microsoft.Win32.SystemEvents" Version="4.6.0" />
     <Usage Id="Microsoft.Win32.SystemEvents" Version="4.7.0" />
-    <Usage Id="Microsoft.XmlSerializer.Generator" Version="2.1.0" />
     <Usage Id="NETStandard.Library" Version="1.6.0" />
     <Usage Id="NETStandard.Library" Version="1.6.1" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="NETStandard.Library" Version="2.0.0" />
@@ -218,21 +157,17 @@
     <Usage Id="NuGet.Commands" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
     <Usage Id="NuGet.Common" Version="5.1.0+08414feaac77473f29f6ac182ab4c390ecd3542f" />
     <Usage Id="NuGet.Common" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
-    <Usage Id="NuGet.Common" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
     <Usage Id="NuGet.Configuration" Version="5.1.0+08414feaac77473f29f6ac182ab4c390ecd3542f" />
     <Usage Id="NuGet.Configuration" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
-    <Usage Id="NuGet.Configuration" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
     <Usage Id="NuGet.Credentials" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
     <Usage Id="NuGet.DependencyResolver.Core" Version="5.1.0+08414feaac77473f29f6ac182ab4c390ecd3542f" />
     <Usage Id="NuGet.DependencyResolver.Core" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
     <Usage Id="NuGet.Frameworks" Version="5.1.0+08414feaac77473f29f6ac182ab4c390ecd3542f" />
     <Usage Id="NuGet.Frameworks" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
-    <Usage Id="NuGet.Frameworks" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
     <Usage Id="NuGet.LibraryModel" Version="5.1.0+08414feaac77473f29f6ac182ab4c390ecd3542f" />
     <Usage Id="NuGet.LibraryModel" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
     <Usage Id="NuGet.Packaging" Version="5.1.0+08414feaac77473f29f6ac182ab4c390ecd3542f" />
     <Usage Id="NuGet.Packaging" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
-    <Usage Id="NuGet.Packaging" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
     <Usage Id="NuGet.ProjectModel" Version="5.1.0+08414feaac77473f29f6ac182ab4c390ecd3542f" />
     <Usage Id="NuGet.ProjectModel" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
     <Usage Id="NuGet.Protocol" Version="5.1.0+08414feaac77473f29f6ac182ab4c390ecd3542f" />
@@ -240,7 +175,6 @@
     <Usage Id="NuGet.Versioning" Version="4.4.0" IsDirectDependency="true" />
     <Usage Id="NuGet.Versioning" Version="5.1.0+08414feaac77473f29f6ac182ab4c390ecd3542f" />
     <Usage Id="NuGet.Versioning" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
-    <Usage Id="NuGet.Versioning" Version="5.8.0-preview.2.6776+62e098bfb22998fa638ce1a6dff5f91276770500" />
     <Usage Id="NUnit3.DotNetNew.Template" Version="1.5.3" />
     <Usage Id="NUnit3.DotNetNew.Template" Version="1.6.5" />
     <Usage Id="NUnit3.DotNetNew.Template" Version="1.7.2" />
@@ -279,15 +213,7 @@
     <Usage Id="runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.0" Rid="ubuntu.16.10-x64" />
     <Usage Id="runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.2" Rid="ubuntu.16.10-x64" />
     <Usage Id="runtime.win-arm64.runtime.native.System.Data.SqlClient.sni" Version="4.4.0" Rid="win-arm64" />
-    <Usage Id="runtime.win-x64.Microsoft.NETCore.App" Version="2.1.0" Rid="win-x64" />
-    <Usage Id="runtime.win-x64.Microsoft.NETCore.DotNetAppHost" Version="2.1.0" Rid="win-x64" />
-    <Usage Id="runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy" Version="2.1.0" Rid="win-x64" />
-    <Usage Id="runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" Version="2.1.0" Rid="win-x64" />
     <Usage Id="runtime.win-x64.runtime.native.System.Data.SqlClient.sni" Version="4.4.0" Rid="win-x64" />
-    <Usage Id="runtime.win-x86.Microsoft.NETCore.App" Version="2.1.17" Rid="win-x86" />
-    <Usage Id="runtime.win-x86.Microsoft.NETCore.DotNetAppHost" Version="2.1.17" Rid="win-x86" />
-    <Usage Id="runtime.win-x86.Microsoft.NETCore.DotNetHostPolicy" Version="2.1.17" Rid="win-x86" />
-    <Usage Id="runtime.win-x86.Microsoft.NETCore.DotNetHostResolver" Version="2.1.17" Rid="win-x86" />
     <Usage Id="runtime.win-x86.runtime.native.System.Data.SqlClient.sni" Version="4.4.0" Rid="win-x86" />
     <Usage Id="sn" Version="1.0.0" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="System.AppContext" Version="4.1.0" />
@@ -298,7 +224,6 @@
     <Usage Id="System.Buffers" Version="4.5.0" />
     <Usage Id="System.Buffers" Version="4.5.1" />
     <Usage Id="System.CodeDom" Version="4.4.0" />
-    <Usage Id="System.CodeDom" Version="4.6.0" />
     <Usage Id="System.Collections" Version="4.0.11" IsDirectDependency="true" />
     <Usage Id="System.Collections" Version="4.3.0" />
     <Usage Id="System.Collections.Concurrent" Version="4.0.12" />
@@ -316,54 +241,34 @@
     <Usage Id="System.Collections.NonGeneric" Version="4.3.0" />
     <Usage Id="System.Collections.Specialized" Version="4.3.0" IsDirectDependency="true" />
     <Usage Id="System.ComponentModel" Version="4.3.0" />
-    <Usage Id="System.ComponentModel.Annotations" Version="4.5.0" />
-    <Usage Id="System.ComponentModel.Annotations" Version="4.6.0" />
     <Usage Id="System.ComponentModel.Annotations" Version="4.7.0" />
-    <Usage Id="System.ComponentModel.Composition" Version="4.6.0" />
-    <Usage Id="System.ComponentModel.Composition.Registration" Version="4.6.0" />
     <Usage Id="System.ComponentModel.Primitives" Version="4.3.0" />
     <Usage Id="System.ComponentModel.TypeConverter" Version="4.3.0" IsDirectDependency="true" />
     <Usage Id="System.Composition" Version="1.0.31" />
-    <Usage Id="System.Composition" Version="1.3.0" />
     <Usage Id="System.Composition.AttributedModel" Version="1.0.31" />
-    <Usage Id="System.Composition.AttributedModel" Version="1.3.0" />
     <Usage Id="System.Composition.Convention" Version="1.0.31" />
-    <Usage Id="System.Composition.Convention" Version="1.3.0" />
     <Usage Id="System.Composition.Hosting" Version="1.0.31" />
-    <Usage Id="System.Composition.Hosting" Version="1.3.0" />
     <Usage Id="System.Composition.Runtime" Version="1.0.31" />
-    <Usage Id="System.Composition.Runtime" Version="1.3.0" />
     <Usage Id="System.Composition.TypedParts" Version="1.0.31" />
-    <Usage Id="System.Composition.TypedParts" Version="1.3.0" />
-    <Usage Id="System.Configuration.ConfigurationManager" Version="4.6.0" />
     <Usage Id="System.Console" Version="4.0.0" />
     <Usage Id="System.Console" Version="4.3.0" />
-    <Usage Id="System.Data.Odbc" Version="4.6.0" />
-    <Usage Id="System.Data.OleDb" Version="4.6.0" />
     <Usage Id="System.Data.SqlClient" Version="4.8.1" IsDirectDependency="true" />
     <Usage Id="System.Diagnostics.Contracts" Version="4.3.0" IsDirectDependency="true" />
     <Usage Id="System.Diagnostics.Debug" Version="4.0.11" IsDirectDependency="true" />
     <Usage Id="System.Diagnostics.Debug" Version="4.3.0" />
     <Usage Id="System.Diagnostics.DiagnosticSource" Version="4.3.0" />
     <Usage Id="System.Diagnostics.DiagnosticSource" Version="4.4.0" IsDirectDependency="true" />
-    <Usage Id="System.Diagnostics.DiagnosticSource" Version="4.6.0" />
-    <Usage Id="System.Diagnostics.EventLog" Version="4.6.0" />
     <Usage Id="System.Diagnostics.FileVersionInfo" Version="4.0.0" IsDirectDependency="true" />
     <Usage Id="System.Diagnostics.FileVersionInfo" Version="4.3.0" />
-    <Usage Id="System.Diagnostics.PerformanceCounter" Version="4.6.0" />
     <Usage Id="System.Diagnostics.Process" Version="4.1.0" />
     <Usage Id="System.Diagnostics.Process" Version="4.3.0" IsDirectDependency="true" />
     <Usage Id="System.Diagnostics.StackTrace" Version="4.3.0" IsDirectDependency="true" />
-    <Usage Id="System.Diagnostics.TextWriterTraceListener" Version="4.0.0" IsDirectDependency="true" />
     <Usage Id="System.Diagnostics.Tools" Version="4.0.1" />
     <Usage Id="System.Diagnostics.Tools" Version="4.3.0" />
     <Usage Id="System.Diagnostics.TraceSource" Version="4.0.0" />
     <Usage Id="System.Diagnostics.TraceSource" Version="4.3.0" IsDirectDependency="true" />
     <Usage Id="System.Diagnostics.Tracing" Version="4.1.0" />
     <Usage Id="System.Diagnostics.Tracing" Version="4.3.0" />
-    <Usage Id="System.DirectoryServices" Version="4.6.0" />
-    <Usage Id="System.DirectoryServices.AccountManagement" Version="4.6.0" />
-    <Usage Id="System.DirectoryServices.Protocols" Version="4.6.0" />
     <Usage Id="System.Drawing.Common" Version="4.7.0" />
     <Usage Id="System.Dynamic.Runtime" Version="4.0.11" IsDirectDependency="true" />
     <Usage Id="System.Dynamic.Runtime" Version="4.3.0" />
@@ -381,16 +286,12 @@
     <Usage Id="System.IO.Compression.ZipFile" Version="4.3.0" />
     <Usage Id="System.IO.FileSystem" Version="4.0.1" />
     <Usage Id="System.IO.FileSystem" Version="4.3.0" />
-    <Usage Id="System.IO.FileSystem.AccessControl" Version="4.6.0" />
     <Usage Id="System.IO.FileSystem.Primitives" Version="4.0.1" />
     <Usage Id="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <Usage Id="System.IO.MemoryMappedFiles" Version="4.3.0" />
-    <Usage Id="System.IO.Packaging" Version="4.6.0" />
-    <Usage Id="System.IO.Pipelines" Version="4.6.0" />
     <Usage Id="System.IO.Pipes" Version="4.3.0" />
     <Usage Id="System.IO.Pipes.AccessControl" Version="4.3.0" />
     <Usage Id="System.IO.Pipes.AccessControl" Version="4.5.1" IsDirectDependency="true" />
-    <Usage Id="System.IO.Ports" Version="4.6.0" />
     <Usage Id="System.IO.UnmanagedMemoryStream" Version="4.3.0" />
     <Usage Id="System.Linq" Version="4.1.0" IsDirectDependency="true" />
     <Usage Id="System.Linq" Version="4.3.0" />
@@ -398,14 +299,11 @@
     <Usage Id="System.Linq.Expressions" Version="4.3.0" />
     <Usage Id="System.Linq.Parallel" Version="4.0.1" />
     <Usage Id="System.Linq.Queryable" Version="4.3.0" />
-    <Usage Id="System.Management" Version="4.6.0" />
-    <Usage Id="System.Memory" Version="4.5.1" />
     <Usage Id="System.Memory" Version="4.5.3" />
     <Usage Id="System.Memory" Version="4.5.4" />
     <Usage Id="System.Net.Http" Version="4.1.0" />
     <Usage Id="System.Net.Http" Version="4.3.0" />
     <Usage Id="System.Net.Http" Version="4.3.4" IsDirectDependency="true" />
-    <Usage Id="System.Net.Http.WinHttpHandler" Version="4.6.0" />
     <Usage Id="System.Net.Primitives" Version="4.0.11" />
     <Usage Id="System.Net.Primitives" Version="4.3.0" />
     <Usage Id="System.Net.Requests" Version="4.0.11" IsDirectDependency="true" />
@@ -415,8 +313,6 @@
     <Usage Id="System.Net.Sockets" Version="4.3.0" />
     <Usage Id="System.Net.WebHeaderCollection" Version="4.0.1" />
     <Usage Id="System.Net.WebHeaderCollection" Version="4.3.0" />
-    <Usage Id="System.Net.WebSockets.WebSocketProtocol" Version="4.6.0" />
-    <Usage Id="System.Numerics.Tensors" Version="0.1.0" />
     <Usage Id="System.Numerics.Vectors" Version="4.4.0" />
     <Usage Id="System.Numerics.Vectors" Version="4.5.0" />
     <Usage Id="System.ObjectModel" Version="4.0.12" IsDirectDependency="true" />
@@ -424,7 +320,6 @@
     <Usage Id="System.Private.DataContractSerialization" Version="4.1.1" />
     <Usage Id="System.Reflection" Version="4.1.0" IsDirectDependency="true" />
     <Usage Id="System.Reflection" Version="4.3.0" />
-    <Usage Id="System.Reflection.Context" Version="4.6.0" />
     <Usage Id="System.Reflection.Emit" Version="4.0.1" />
     <Usage Id="System.Reflection.Emit" Version="4.3.0" />
     <Usage Id="System.Reflection.Emit.ILGeneration" Version="4.0.1" />
@@ -442,12 +337,10 @@
     <Usage Id="System.Reflection.Metadata" Version="1.8.0" IsDirectDependency="true" />
     <Usage Id="System.Reflection.Metadata" Version="1.8.1" />
     <Usage Id="System.Reflection.Metadata" Version="5.0.0-preview.8.20407.11" />
-    <Usage Id="System.Reflection.MetadataLoadContext" Version="4.6.0" />
     <Usage Id="System.Reflection.Primitives" Version="4.0.1" />
     <Usage Id="System.Reflection.Primitives" Version="4.3.0" />
     <Usage Id="System.Reflection.TypeExtensions" Version="4.1.0" />
     <Usage Id="System.Reflection.TypeExtensions" Version="4.3.0" />
-    <Usage Id="System.Resources.Extensions" Version="4.6.0" />
     <Usage Id="System.Resources.Reader" Version="4.0.0" />
     <Usage Id="System.Resources.ResourceManager" Version="4.0.1" IsDirectDependency="true" />
     <Usage Id="System.Resources.ResourceManager" Version="4.3.0" />
@@ -455,8 +348,6 @@
     <Usage Id="System.Runtime" Version="4.1.0" IsDirectDependency="true" />
     <Usage Id="System.Runtime" Version="4.3.0" />
     <Usage Id="System.Runtime" Version="4.3.1" IsDirectDependency="true" />
-    <Usage Id="System.Runtime.Caching" Version="4.6.0" />
-    <Usage Id="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
     <Usage Id="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
     <Usage Id="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" />
     <Usage Id="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
@@ -480,7 +371,6 @@
     <Usage Id="System.Runtime.Serialization.Xml" Version="4.1.1" />
     <Usage Id="System.Security.AccessControl" Version="4.3.0" />
     <Usage Id="System.Security.AccessControl" Version="4.5.0" />
-    <Usage Id="System.Security.AccessControl" Version="4.6.0" />
     <Usage Id="System.Security.AccessControl" Version="4.7.0" />
     <Usage Id="System.Security.Claims" Version="4.0.1" />
     <Usage Id="System.Security.Claims" Version="4.3.0" />
@@ -489,7 +379,6 @@
     <Usage Id="System.Security.Cryptography.Algorithms" Version="4.3.1" />
     <Usage Id="System.Security.Cryptography.Cng" Version="4.2.0" />
     <Usage Id="System.Security.Cryptography.Cng" Version="4.3.0" />
-    <Usage Id="System.Security.Cryptography.Cng" Version="4.6.1" />
     <Usage Id="System.Security.Cryptography.Cng" Version="4.7.0" />
     <Usage Id="System.Security.Cryptography.Cng" Version="5.0.0-preview.3.20214.6" />
     <Usage Id="System.Security.Cryptography.Csp" Version="4.0.0" />
@@ -498,44 +387,33 @@
     <Usage Id="System.Security.Cryptography.Encoding" Version="4.3.0" />
     <Usage Id="System.Security.Cryptography.OpenSsl" Version="4.0.0" />
     <Usage Id="System.Security.Cryptography.OpenSsl" Version="4.3.0" />
-    <Usage Id="System.Security.Cryptography.OpenSsl" Version="4.6.0" />
-    <Usage Id="System.Security.Cryptography.Pkcs" Version="4.6.0" />
     <Usage Id="System.Security.Cryptography.Pkcs" Version="4.7.0" />
     <Usage Id="System.Security.Cryptography.Pkcs" Version="5.0.0-preview.3.20214.6" />
     <Usage Id="System.Security.Cryptography.Primitives" Version="4.0.0" />
     <Usage Id="System.Security.Cryptography.Primitives" Version="4.3.0" />
     <Usage Id="System.Security.Cryptography.ProtectedData" Version="4.3.0" />
     <Usage Id="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
-    <Usage Id="System.Security.Cryptography.ProtectedData" Version="4.6.0" />
     <Usage Id="System.Security.Cryptography.X509Certificates" Version="4.1.0" />
     <Usage Id="System.Security.Cryptography.X509Certificates" Version="4.3.0" />
-    <Usage Id="System.Security.Cryptography.Xml" Version="4.6.0" />
     <Usage Id="System.Security.Cryptography.Xml" Version="4.7.0" />
-    <Usage Id="System.Security.Permissions" Version="4.6.0" />
     <Usage Id="System.Security.Permissions" Version="4.7.0" />
     <Usage Id="System.Security.Principal" Version="4.0.1" />
     <Usage Id="System.Security.Principal" Version="4.3.0" />
     <Usage Id="System.Security.Principal.Windows" Version="4.0.0" IsDirectDependency="true" />
     <Usage Id="System.Security.Principal.Windows" Version="4.3.0" />
     <Usage Id="System.Security.Principal.Windows" Version="4.5.0" />
-    <Usage Id="System.Security.Principal.Windows" Version="4.6.0" />
     <Usage Id="System.Security.Principal.Windows" Version="4.7.0" />
-    <Usage Id="System.ServiceModel.Syndication" Version="4.6.0" />
-    <Usage Id="System.ServiceProcess.ServiceController" Version="4.6.0" />
     <Usage Id="System.Text.Encoding" Version="4.0.11" IsDirectDependency="true" />
     <Usage Id="System.Text.Encoding" Version="4.3.0" />
     <Usage Id="System.Text.Encoding.CodePages" Version="4.0.1" />
     <Usage Id="System.Text.Encoding.CodePages" Version="4.3.0" />
     <Usage Id="System.Text.Encoding.CodePages" Version="4.4.0" />
     <Usage Id="System.Text.Encoding.CodePages" Version="4.5.1" />
-    <Usage Id="System.Text.Encoding.CodePages" Version="4.6.0" />
     <Usage Id="System.Text.Encoding.Extensions" Version="4.0.11" IsDirectDependency="true" />
     <Usage Id="System.Text.Encoding.Extensions" Version="4.3.0" />
-    <Usage Id="System.Text.Encodings.Web" Version="4.6.0" />
     <Usage Id="System.Text.Encodings.Web" Version="4.7.0" />
     <Usage Id="System.Text.Encodings.Web" Version="4.7.1" />
     <Usage Id="System.Text.Encodings.Web" Version="5.0.0-rc.1.20451.14" />
-    <Usage Id="System.Text.Json" Version="4.6.0" />
     <Usage Id="System.Text.Json" Version="4.7.0" />
     <Usage Id="System.Text.Json" Version="4.7.2" />
     <Usage Id="System.Text.Json" Version="5.0.0-rc.1.20451.14" IsDirectDependency="true" />
@@ -543,14 +421,11 @@
     <Usage Id="System.Text.RegularExpressions" Version="4.3.0" />
     <Usage Id="System.Threading" Version="4.0.11" IsDirectDependency="true" />
     <Usage Id="System.Threading" Version="4.3.0" />
-    <Usage Id="System.Threading.AccessControl" Version="4.6.0" />
-    <Usage Id="System.Threading.Channels" Version="4.6.0" />
     <Usage Id="System.Threading.Overlapped" Version="4.3.0" />
     <Usage Id="System.Threading.Tasks" Version="4.0.11" IsDirectDependency="true" />
     <Usage Id="System.Threading.Tasks" Version="4.3.0" />
     <Usage Id="System.Threading.Tasks.Dataflow" Version="4.6.0" />
     <Usage Id="System.Threading.Tasks.Dataflow" Version="4.9.0" />
-    <Usage Id="System.Threading.Tasks.Dataflow" Version="4.10.0" />
     <Usage Id="System.Threading.Tasks.Extensions" Version="4.0.0" />
     <Usage Id="System.Threading.Tasks.Extensions" Version="4.3.0" />
     <Usage Id="System.Threading.Tasks.Extensions" Version="4.5.2" />
@@ -566,7 +441,6 @@
     <Usage Id="System.ValueTuple" Version="4.3.0" />
     <Usage Id="System.ValueTuple" Version="4.4.0" />
     <Usage Id="System.ValueTuple" Version="4.5.0" IsDirectDependency="true" />
-    <Usage Id="System.Windows.Extensions" Version="4.6.0" />
     <Usage Id="System.Windows.Extensions" Version="4.7.0" />
     <Usage Id="System.Xml.ReaderWriter" Version="4.0.11" IsDirectDependency="true" />
     <Usage Id="System.Xml.ReaderWriter" Version="4.3.0" />


### PR DESCRIPTION
Upgrade previously-source built to `0.1.0-5.0.100-877538` (https://dev.azure.com/dnceng/internal/_build/results?buildId=877538&view=results, ccde1aa) and update the baselines.

For https://github.com/dotnet/source-build/issues/1865