### PR TITLE
Use our Microsoft.Diagnostics.NETCore.Client, not prebuilt

### DIFF
--- a/patches/vstest/0007-Use-Microsoft.Diagnostics.NETCore.Client-from-PVP.patch
+++ b/patches/vstest/0007-Use-Microsoft.Diagnostics.NETCore.Client-from-PVP.patch
@@ -1,0 +1,39 @@
+From 38082210a35235e9a7c4b8da68fcf040b7a669c8 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Mon, 9 Nov 2020 14:10:53 -0600
+Subject: [PATCH] Use Microsoft.Diagnostics.NETCore.Client from PVP
+
+Source-build produces this package now, so it needs to be in eng/Versions.props.
+---
+ eng/Versions.props                                              | 1 +
+ .../Microsoft.TestPlatform.Extensions.BlameDataCollector.csproj | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/eng/Versions.props b/eng/Versions.props
+index cf2f6830..fe8f5028 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -26,6 +26,7 @@
+     <MicrosoftCodeAnalysisCSharpVersion>2.9.0</MicrosoftCodeAnalysisCSharpVersion>
+     <MsbuildTaskMicrosoftCodeAnalysisCSharpVersion>2.1.0</MsbuildTaskMicrosoftCodeAnalysisCSharpVersion>
+     <MicrosoftDotNetPlatformAbstractionsVersion>2.1.0</MicrosoftDotNetPlatformAbstractionsVersion>
++    <MicrosoftDiagnosticsNETCoreClientVersion>0.2.0-preview.20419.2</MicrosoftDiagnosticsNETCoreClientVersion>
+     <MicrosoftIdentityModelClientsActiveDirectoryVersion>3.19.8</MicrosoftIdentityModelClientsActiveDirectoryVersion>
+     <MicrosoftRestClientRuntimeVersion>2.3.13</MicrosoftRestClientRuntimeVersion>
+     <MicrosoftExtensionsDependencyModelVersion>2.1.0</MicrosoftExtensionsDependencyModelVersion>
+diff --git a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Microsoft.TestPlatform.Extensions.BlameDataCollector.csproj b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Microsoft.TestPlatform.Extensions.BlameDataCollector.csproj
+index 11a26e7f..3592917f 100644
+--- a/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Microsoft.TestPlatform.Extensions.BlameDataCollector.csproj
++++ b/src/Microsoft.TestPlatform.Extensions.BlameDataCollector/Microsoft.TestPlatform.Extensions.BlameDataCollector.csproj
+@@ -32,7 +32,7 @@
+   </ItemGroup>
+   <ItemGroup>
+     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client">
+-      <Version>0.2.0-preview.20419.2</Version>
++      <Version>$(MicrosoftDiagnosticsNETCoreClientVersion)</Version>
+     </PackageReference>
+   </ItemGroup>
+   <ItemGroup>
+-- 
+2.25.2
+

--- a/tools-local/prebuilt-baseline-offline.xml
+++ b/tools-local/prebuilt-baseline-offline.xml
@@ -162,7 +162,6 @@
     <Usage Id="Microsoft.Build.Traversal" Version="2.1.1" />
     <Usage Id="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" />
     <Usage Id="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.0" IsDirectDependency="true" />
-    <Usage Id="Microsoft.Diagnostics.NETCore.Client" Version="0.2.0-preview.20419.2" IsDirectDependency="true" />
     <Usage Id="Microsoft.Docker.Sdk" Version="1.1.0" />
     <Usage Id="Microsoft.DotNet.Common.ItemTemplates" Version="1.0.2-beta3" />
     <Usage Id="Microsoft.DotNet.Common.ItemTemplates" Version="2.0.0-preview8.19373.1" />

--- a/tools-local/prebuilt-baseline-online.xml
+++ b/tools-local/prebuilt-baseline-online.xml
@@ -80,7 +80,6 @@
     <Usage Id="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" Version="3.8.0-2.20414.4" IsDirectDependency="true" />
     <Usage Id="Microsoft.CSharp" Version="4.0.1" IsDirectDependency="true" />
     <Usage Id="Microsoft.CSharp" Version="4.3.0" IsDirectDependency="true" />
-    <Usage Id="Microsoft.Diagnostics.NETCore.Client" Version="0.2.0-preview.20419.2" IsDirectDependency="true" />
     <Usage Id="Microsoft.Docker.Sdk" Version="1.1.0" />
     <Usage Id="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20426.4" />
     <Usage Id="Microsoft.DotNet.Common.ItemTemplates" Version="1.0.2-beta3" />


### PR DESCRIPTION
We build `Microsoft.Diagnostics.NETCore.Client/0.2.0` thanks to https://github.com/dotnet/source-build/pull/1824. Add a patch to dotnet/vstest to use the version from the PVP file rather than the hard-coded `0.2.0-preview.20419.2`.