### PR TITLE
For 5.0.0, use bootstrapping in CI, not N-1

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -70,7 +70,11 @@
 
   <Target Name="DownloadSourceBuiltArtifacts"
           AfterTargets="Build"
-          Condition="'$(OfflineBuild)' != 'true' and '$(OS)' != 'Windows_NT' and '$(SkipDownloadingPreviouslySourceBuiltPackages)' != 'true'"
+          Condition="
+            '$(OfflineBuild)' != 'true' and
+            '$(OS)' != 'Windows_NT' and
+            '$(SkipDownloadingPreviouslySourceBuiltPackages)' != 'true' and
+            '$(PrivateSourceBuiltArtifactsPackageVersion)' != ''"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(CompletedSemaphorePath)DownloadSourceBuiltArtifacts.complete" >
     <PropertyGroup Condition="'$(DownloadSourceBuiltArtifactsTimeoutSeconds)' == ''">

--- a/eng/SourceBuild.Tarball.targets
+++ b/eng/SourceBuild.Tarball.targets
@@ -185,8 +185,24 @@
       <PreviouslySourceBuiltPackageFile Include="$(CustomPreviouslySourceBuiltPackagesDir)**\*.nupkg" />
     </ItemGroup>
 
+    <ItemGroup>
+      <!-- Use a downloaded previously source built artifacts tar.gz if specified. -->
+      <PrivateSourceBuiltArtifactsTarGzFile
+        Condition="'$(PrivateSourceBuiltArtifactsPackageVersion)' != ''"
+        Include="$(ExternalTarballsDir)Private.SourceBuilt.Artifacts.*.tar.gz" />
+
+      <!-- If not using previously source built artifacts tar.gz, use Production build output. -->
+      <PrivateSourceBuiltArtifactsTarGzFile
+        Condition="'$(PrivateSourceBuiltArtifactsPackageVersion)' == ''"
+        Include="$(OutputPath)$(SourceBuiltArtifactsTarballName).*.tar.gz" />
+    </ItemGroup>
+
+    <Error
+      Text="Expected one PrivateSourceBuiltArtifactsTarGzFile item, got @(PrivateSourceBuiltArtifactsTarGzFile->Count())"
+      Condition="@(PrivateSourceBuiltArtifactsTarGzFile->Count()) != 1" />
+
     <Exec
-      Command="tar -tf $(ExternalTarballsDir)Private.SourceBuilt.Artifacts.*.tar.gz | tr '[:upper:]' '[:lower:]'"
+      Command="tar -tf @(PrivateSourceBuiltArtifactsTarGzFile) | tr '[:upper:]' '[:lower:]'"
       ConsoleToMsBuild="true"
       StandardOutputImportance="low"
       Condition="'$(CustomPreviouslySourceBuiltPackagesDir)' == ''">
@@ -256,10 +272,17 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="AddTarballExternalTarballs">
+  <Target Name="AddTarballExternalTarballs"
+          DependsOnTargets="AddTarballPackages">
     <ItemGroup>
       <ExternalTarballFile
         Include="$(ExternalTarballsDir)*.tar.gz"
+        RelativeRoot="packages\archive\" />
+
+      <!-- If not using previously source built artifacts tar.gz, use Production build output. -->
+      <ExternalTarballFile
+        Condition="'$(PrivateSourceBuiltArtifactsPackageVersion)' == ''"
+        Include="@(PrivateSourceBuiltArtifactsTarGzFile)"
         RelativeRoot="packages\archive\" />
 
       <TarballCopyFile Include="@(ExternalTarballFile);" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,6 +8,5 @@
   <!-- Production Dependencies -->
   <PropertyGroup>
     <PrivateSourceBuildReferencePackagesPackageVersion>1.0.0-beta.20562.2</PrivateSourceBuildReferencePackagesPackageVersion>
-    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-5.0.100-877538</PrivateSourceBuiltArtifactsPackageVersion>
   </PropertyGroup>
 </Project>

--- a/patches/arcade/0015-Override-Microsoft.CodeAnalysis.CSharp-pkg-deps.patch
+++ b/patches/arcade/0015-Override-Microsoft.CodeAnalysis.CSharp-pkg-deps.patch
@@ -1,0 +1,41 @@
+From 0cc84816123aa8a2cd0ea2d65b4d3be5028b77e0 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Fri, 13 Nov 2020 13:16:19 -0600
+Subject: [PATCH] Override Microsoft.CodeAnalysis.CSharp pkg deps
+
+Microsoft.CodeAnalysis.CSharp brings in System.Collections.Immutable and
+System.Reflection.Metadata dependencies with prebuilt versions. We can
+override them to the version that we built.
+
+dotnet/arcade already defines SystemCollectionsImmutableVersion and
+SystemReflectionMetadataVersion, and it seems safe to use their values.
+
+See https://github.com/dotnet/source-build/pull/1881
+---
+ .../Microsoft.DotNet.CodeAnalysis.csproj               | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/src/Microsoft.DotNet.CodeAnalysis/Microsoft.DotNet.CodeAnalysis.csproj b/src/Microsoft.DotNet.CodeAnalysis/Microsoft.DotNet.CodeAnalysis.csproj
+index 5cdfd539..d1ac5ccb 100644
+--- a/src/Microsoft.DotNet.CodeAnalysis/Microsoft.DotNet.CodeAnalysis.csproj
++++ b/src/Microsoft.DotNet.CodeAnalysis/Microsoft.DotNet.CodeAnalysis.csproj
+@@ -12,6 +12,16 @@
+     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersion)" ExcludeAssets="analyzers" />
+   </ItemGroup>
+ 
++  <!--
++    In the source-build tarball build, Microsoft.CodeAnalysis.CSharp has dependencies on old
++    versions of these packages due to repo build order. Override to lift them to the versions passed
++    in via DotNetPackageVersionPropsPath.
++  -->
++  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
++    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
++    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
++  </ItemGroup>
++
+   <ItemGroup>
+     <Content Include="build/*.*" PackagePath="build" />
+     <Content Include="content/*.*" PackagePath="content" />
+-- 
+2.25.2
+

--- a/patches/arcade/0015-Override-Microsoft.CodeAnalysis.CSharp-pkg-deps.patch
+++ b/patches/arcade/0015-Override-Microsoft.CodeAnalysis.CSharp-pkg-deps.patch
@@ -1,6 +1,6 @@
-From 0cc84816123aa8a2cd0ea2d65b4d3be5028b77e0 Mon Sep 17 00:00:00 2001
+From a99a8874966fbc6c6d2aa75ae636bfecdf99412c Mon Sep 17 00:00:00 2001
 From: Davis Goodin <dagood@microsoft.com>
-Date: Fri, 13 Nov 2020 13:16:19 -0600
+Date: Mon, 16 Nov 2020 10:21:33 -0600
 Subject: [PATCH] Override Microsoft.CodeAnalysis.CSharp pkg deps
 
 Microsoft.CodeAnalysis.CSharp brings in System.Collections.Immutable and
@@ -13,7 +13,8 @@ SystemReflectionMetadataVersion, and it seems safe to use their values.
 See https://github.com/dotnet/source-build/pull/1881
 ---
  .../Microsoft.DotNet.CodeAnalysis.csproj               | 10 ++++++++++
- 1 file changed, 10 insertions(+)
+ .../Microsoft.DotNet.GenFacades.csproj                 |  9 +++++++++
+ 2 files changed, 19 insertions(+)
 
 diff --git a/src/Microsoft.DotNet.CodeAnalysis/Microsoft.DotNet.CodeAnalysis.csproj b/src/Microsoft.DotNet.CodeAnalysis/Microsoft.DotNet.CodeAnalysis.csproj
 index 5cdfd539..d1ac5ccb 100644
@@ -36,6 +37,26 @@ index 5cdfd539..d1ac5ccb 100644
    <ItemGroup>
      <Content Include="build/*.*" PackagePath="build" />
      <Content Include="content/*.*" PackagePath="content" />
+diff --git a/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj b/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj
+index 00a413da..df155ae0 100644
+--- a/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj
++++ b/src/Microsoft.DotNet.GenFacades/Microsoft.DotNet.GenFacades.csproj
+@@ -28,6 +28,15 @@
+     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+   </ItemGroup>
+ 
++  <!--
++    In the source-build tarball build, Microsoft.CodeAnalysis.CSharp has dependencies on old
++    versions of these packages due to repo build order. Override to lift them to the versions passed
++    in via DotNetPackageVersionPropsPath.
++  -->
++  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
++    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
++  </ItemGroup>
++
+   <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
+     <ProjectReference Include="..\Microsoft.Cci.Extensions\Microsoft.Cci.Extensions.csproj" />
+   </ItemGroup>
 -- 
 2.25.2
 

--- a/tools-local/prebuilt-baseline-offline.xml
+++ b/tools-local/prebuilt-baseline-offline.xml
@@ -48,12 +48,15 @@
     <PackageIdentity Id="Microsoft.Build.Utilities.Core" Version="15.3.409" />
     <PackageIdentity Id="Microsoft.Build.Utilities.Core" Version="15.4.8" />
     <PackageIdentity Id="Microsoft.CodeAnalysis.Analyzers" Version="2.9.6" />
+    <PackageIdentity Id="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" />
+    <PackageIdentity Id="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0" />
+    <PackageIdentity Id="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.0" />
     <PackageIdentity Id="Microsoft.CodeAnalysis.Common" Version="3.4.0" />
     <PackageIdentity Id="Microsoft.CodeAnalysis.CSharp" Version="3.4.0" />
     <PackageIdentity Id="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.8.0-2.20414.4" />
+    <PackageIdentity Id="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.0" />
     <PackageIdentity Id="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" Version="3.8.0-2.20414.4" />
     <PackageIdentity Id="Microsoft.Extensions.DependencyModel" Version="3.1.6" />
-    <PackageIdentity Id="Microsoft.NETCore.Platforms" Version="2.1.2" />
     <PackageIdentity Id="Microsoft.SymbolUploader.Build.Task" Version="1.1.141804" />
     <PackageIdentity Id="NETStandard.Library" Version="1.6.0" />
     <PackageIdentity Id="NuGet.Commands" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
@@ -67,6 +70,7 @@
     <PackageIdentity Id="NuGet.ProjectModel" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
     <PackageIdentity Id="NuGet.Protocol" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
     <PackageIdentity Id="NuGet.Versioning" Version="5.6.0-preview.2.6489+5433d816f748d4ad78b75fc320397d8117f57771" />
+    <PackageIdentity Id="Roslyn.Diagnostics.Analyzers" Version="3.3.0" />
     <PackageIdentity Id="runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.0" />
     <PackageIdentity Id="runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.2" />
     <PackageIdentity Id="runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl" Version="4.3.0" />
@@ -160,11 +164,7 @@
     <Usage Id="Microsoft.AspNetCore.App.Ref" Version="5.0.0" />
     <Usage Id="Microsoft.AspNetCore.Components.WebAssembly.Templates" Version="3.2.1" />
     <Usage Id="Microsoft.Build.Traversal" Version="2.1.1" />
-    <Usage Id="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" />
-    <Usage Id="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0" IsDirectDependency="true" />
-    <Usage Id="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.0" IsDirectDependency="true" />
     <Usage Id="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0" IsDirectDependency="true" />
-    <Usage Id="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.0" IsDirectDependency="true" />
     <Usage Id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" Version="3.3.0" />
     <Usage Id="Microsoft.CodeQuality.Analyzers" Version="3.3.0" />
     <Usage Id="Microsoft.Docker.Sdk" Version="1.1.0" />
@@ -198,6 +198,7 @@
     <Usage Id="Microsoft.NETCore.Platforms" Version="1.0.1" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="1.1.1" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="2.0.0" />
+    <Usage Id="Microsoft.NETCore.Platforms" Version="2.1.2" />
     <Usage Id="Microsoft.NETCore.Platforms" Version="3.1.0" />
     <Usage Id="Microsoft.NETCore.Targets" Version="1.0.1" />
     <Usage Id="Microsoft.NETCore.Targets" Version="1.1.3" />


### PR DESCRIPTION
Instead of downloading previously-source-built packages (prev-sb) from some N-1 build, use the tar.gz that the Production build built. This simulates a bootstrapping flow.

For https://github.com/dotnet/source-build/issues/1880