### PR TITLE
Add Humanizer.Core

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -130,5 +130,10 @@
       <Uri>https://github.com/dotnet/cssparser</Uri>
       <Sha>d6d86bcd8c162b1ae22ef00955ff748d028dd0ee</Sha>
     </Dependency>
+    <Dependency Name="Humanizer.Core" Version="2.2.0">
+      <Uri>https://github.com/Humanizr/Humanizer</Uri>
+      <Sha>b30550eed103a6970d8465fe7c5c16300b70be81</Sha>
+      <RepoName>humanizer</RepoName>
+    </Dependency>
   </ProductDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,6 +5,10 @@
     <VersionPrefix>0.1.0</VersionPrefix>
     <PreReleaseVersionLabel>alpha.1</PreReleaseVersionLabel>
   </PropertyGroup>
+  <!-- Humanizer expects us to tell the version it's building -->
+  <PropertyGroup>
+    <HumanizerCorePackageVersion>2.2.0</HumanizerCorePackageVersion>
+  </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>
     <PrivateSourceBuildReferencePackagesPackageVersion>1.0.0-beta.20566.2</PrivateSourceBuildReferencePackagesPackageVersion>

--- a/patches/humanizer/0001-Fix-building-in-a-source-build-context.patch
+++ b/patches/humanizer/0001-Fix-building-in-a-source-build-context.patch
@@ -1,0 +1,60 @@
+From a7a9cea5471babcf1055f1552f0946dda8927c40 Mon Sep 17 00:00:00 2001
+From: Omair Majid <omajid@redhat.com>
+Date: Tue, 17 Nov 2020 13:14:19 -0500
+Subject: [PATCH] Fix building in a source-build context
+
+The GitVersionTask is not compatible with .NET Core. So disable it and
+use an explicit PackageVersion.
+
+The NuGet feed points to something that returns an error for me. So just
+disable it for now.
+
+Disable SourceLink.Create.CommandLine since upstream is dead and we dont
+really need it for now.
+---
+ src/Humanizer/Humanizer.csproj | 5 ++---
+ src/NuGet.config               | 5 ++++-
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/src/Humanizer/Humanizer.csproj b/src/Humanizer/Humanizer.csproj
+index 842a373..e018285 100644
+--- a/src/Humanizer/Humanizer.csproj
++++ b/src/Humanizer/Humanizer.csproj
+@@ -3,6 +3,7 @@
+     <TargetFramework>netstandard1.0</TargetFramework>    
+     <Authors>Mehdi Khalili, Oren Novotny</Authors>
+     <PackageLicenseUrl>https://raw.githubusercontent.com/Humanizr/Humanizer/master/LICENSE</PackageLicenseUrl>
++    <PackageVersion>2.2.0</PackageVersion>
+     <PackageProjectUrl>https://github.com/Humanizr/Humanizer</PackageProjectUrl>
+     <MinClientVersion>2.12</MinClientVersion>
+     <Description>A micro-framework that turns your normal strings, type names, enum fields, date fields ETC into a human friendly format</Description>    
+@@ -16,7 +17,5 @@
+   </PropertyGroup>
+   
+   <ItemGroup>
+-    <PackageReference Include="GitVersionTask" Version="4.0.0-beta0011" PrivateAssets="All" />
+-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.1.1" PrivateAssets="All" />
+   </ItemGroup>
+-</Project>
+\ No newline at end of file
++</Project>
+diff --git a/src/NuGet.config b/src/NuGet.config
+index be02089..2fb8ff3 100644
+--- a/src/NuGet.config
++++ b/src/NuGet.config
+@@ -1,7 +1,10 @@
+ <?xml version="1.0" encoding="utf-8"?>
+ <configuration>
+   <packageSources>    
++    <!--
++    This feed gives an error: Feed does not exist.
+     <add key="CI Builds (Humanizer)" value="https://www.myget.org/F/humanizer/api/v3/index.json" />    
++    -->
+     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+   </packageSources>
+-</configuration>
+\ No newline at end of file
++</configuration>
+-- 
+2.26.2
+

--- a/repos/aspnetcore.proj
+++ b/repos/aspnetcore.proj
@@ -51,6 +51,7 @@
     <RepositoryReference Include="runtime" />
     <RepositoryReference Include="msbuild" />
     <RepositoryReference Include="roslyn" />
+    <RepositoryReference Include="roslyn-analyzers" />
   </ItemGroup>
 
   <ItemGroup>

--- a/repos/humanizer.proj
+++ b/repos/humanizer.proj
@@ -1,0 +1,48 @@
+<Project>
+
+  <PropertyGroup>
+    <SourceDirectory>Humanizer</SourceDirectory>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <PackagesOutput>$(ProjectDirectory)/src/Humanizer/bin/$(Configuration)</PackagesOutput>
+    <RepoApiImplemented>false</RepoApiImplemented>
+    <DeterministicBuildOptOut>true</DeterministicBuildOptOut>
+    <NuGetConfigFile>$(ProjectDirectory)/src/NuGet.config</NuGetConfigFile>
+  </PropertyGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+  <ItemGroup>
+    <!-- Humanizer needs SourceLink.Create.CommandLine which is not produced from sourcelink repo
+    <RepositoryReference Include="sourcelink" />
+    -->
+  </ItemGroup>
+
+  <Target Name="RepoBuild">
+    <PropertyGroup>
+      <BuildCommandArgs>$(ProjectDirectory)src/Humanizer/Humanizer.csproj</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /p:Configuration=$(Configuration)</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /v:$(LogVerbosity)</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) $(RedirectRepoOutputToLog)</BuildCommandArgs>
+    </PropertyGroup>
+
+    <Exec Command="$(DotnetToolCommand) restore /bl:restore.binlog $(BuildCommandArgs)  "
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+
+    <Exec Command="$(DotnetToolCommand) build /bl:build.binlog $(BuildCommandArgs)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+
+    <Exec Command="$(DotnetToolCommand) pack $(ProjectDirectory)src/Humanizer/Humanizer.csproj /p:NuspecFile=$(ProjectDirectory)NuSpecs/Humanizer.Core.nuspec /p:NuspecBasePath=$(ProjectDirectory)src/ /p:NuspecProperties=Version=$(HumanizerCorePackageVersion) /p:Configuration=$(Configuration)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+  </Target>
+
+</Project>

--- a/repos/roslyn.proj
+++ b/repos/roslyn.proj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <RepositoryReference Include="arcade" />
     <RepositoryReference Include="command-line-api" />
+    <RepositoryReference Include="humanizer" />
     <RepositoryReference Include="xliff-tasks" />
   </ItemGroup>
 

--- a/tools-local/prebuilt-baseline-offline.xml
+++ b/tools-local/prebuilt-baseline-offline.xml
@@ -159,7 +159,6 @@
     <Usage Id="runtime.unix.System.Runtime.Extensions" Version="4.3.0" Rid="unix" />
     <Usage Id="System.Private.Uri" Version="4.3.0" />
   <!--End portable-build only prebuilts-->
-    <Usage Id="Humanizer.Core" Version="2.2.0" />
     <Usage Id="Microsoft.AspNetCore.App.Ref" Version="5.0.0-rc.1.20451.17" />
     <Usage Id="Microsoft.AspNetCore.App.Ref" Version="5.0.0" />
     <Usage Id="Microsoft.AspNetCore.Components.WebAssembly.Templates" Version="3.2.1" />

--- a/tools-local/prebuilt-baseline-online.xml
+++ b/tools-local/prebuilt-baseline-online.xml
@@ -44,7 +44,6 @@
     <Usage Id="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="5.0.0-rc.1.20451.14" />
     <Usage Id="Microsoft.NETCore.App.Host.linux-x64" Version="5.0.0-rc.1.20451.14" />
     <!-- End OSX-only prebuilts -->
-    <Usage Id="Humanizer.Core" Version="2.2.0" />
     <Usage Id="MicroBuild.Core" Version="0.2.0" IsDirectDependency="true" IsAutoReferenced="true" />
     <Usage Id="MicroBuild.Core" Version="0.3.0" IsDirectDependency="true" />
     <Usage Id="MicroBuild.Core.Sentinel" Version="1.0.0" IsDirectDependency="true" IsAutoReferenced="true" />


### PR DESCRIPTION
This is https://github.com/Humanizr/Humanizer (different from https://github.com/Humanizer/Humanizer !)

Humanizer shows up as a dependency of ASP.NET Core and roslyn-analyzers. This tries to fix that. Supposedly it also ships with the SDK.

Fixes: #1767