### PR TITLE
Lift dotnet/runtime dependencies in dotnet/sdk to use 5.0.0 packages in toolset

### DIFF
--- a/patches/sdk/00015-Lift-dotnet-runtime-dependencies-for-source-build.patch
+++ b/patches/sdk/00015-Lift-dotnet-runtime-dependencies-for-source-build.patch
@@ -1,0 +1,38 @@
+From 98fa28ea4ac8e12ea9926c65a479286cc0331b26 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Wed, 18 Nov 2020 11:09:42 -0600
+Subject: [PATCH] Lift dotnet/runtime dependencies for source-build
+
+---
+ src/Layout/Directory.Build.props | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+ create mode 100644 src/Layout/Directory.Build.props
+
+diff --git a/src/Layout/Directory.Build.props b/src/Layout/Directory.Build.props
+new file mode 100644
+index 000000000..72bf6fcf6
+--- /dev/null
++++ b/src/Layout/Directory.Build.props
+@@ -0,0 +1,19 @@
++<Project>
++  <Import Project="..\..\Directory.Build.props" />
++
++  <!--
++    Lift dotnet/runtime dependencies for source-build to use the source-built version. This avoids
++    prebuilts, allows upstreams to continue targeting netcoreapp3.1 using
++    source-build-reference-packages ref-only packages, and prevents downstream from breaking when
++    this repo redists ref-only packages when it shouldn't.
++  -->
++  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
++    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="$(MicrosoftWin32SystemEventsVersion)" />
++    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
++    <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />
++    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsVersion)" />
++    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
++    <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsVersion)" />
++  </ItemGroup>
++
++</Project>
+-- 
+2.25.2
+


### PR DESCRIPTION
For https://github.com/dotnet/source-build/issues/1896

This doesn't directly remove any prebuilts, but I expect it to allow us to add more SBRP packages without interfering with the SDK build.

A diff of annotated offline build usages seems to confirm this is doing what we want it to: https://gist.github.com/dagood/02e720f836a47b722a3f1e4f01f618d9