### PR TITLE
Patch roslyn-analyzers: remove analyzer prebuilts

### DIFF
--- a/patches/roslyn-analyzers/0005-Disable-code-analyzers-when-building-from-source.patch
+++ b/patches/roslyn-analyzers/0005-Disable-code-analyzers-when-building-from-source.patch
@@ -1,0 +1,30 @@
+From 6511158d415c1a7d87b825d8975b231a96f97c65 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Wed, 18 Nov 2020 14:30:39 -0600
+Subject: [PATCH] Disable code analyzers when building from source
+
+Some analyzers are not buildable from source due to VS dependencies. We
+might as well disable all analyzers, because the analyzers seem most
+important to run against PRs in upstream. In source-build, we don't
+expect to make impactful changes to the C# code so they're unlikely to
+catch anything.
+---
+ src/Directory.Build.props | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Directory.Build.props b/src/Directory.Build.props
+index 6c95f9d7b..63c1ce376 100644
+--- a/src/Directory.Build.props
++++ b/src/Directory.Build.props
+@@ -16,7 +16,7 @@
+   </ItemGroup>
+ 
+   <!-- Code analyzers -->
+-  <ItemGroup>
++  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
+     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="$(MicrosoftCodeAnalysisFXCopAnalyzersVersion)" />
+     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />
+     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)" />
+-- 
+2.25.2
+

--- a/tools-local/prebuilt-baseline-offline.xml
+++ b/tools-local/prebuilt-baseline-offline.xml
@@ -164,9 +164,6 @@
     <Usage Id="Microsoft.AspNetCore.App.Ref" Version="5.0.0" />
     <Usage Id="Microsoft.AspNetCore.Components.WebAssembly.Templates" Version="3.2.1" />
     <Usage Id="Microsoft.Build.Traversal" Version="2.1.1" />
-    <Usage Id="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0" IsDirectDependency="true" />
-    <Usage Id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" Version="3.3.0" />
-    <Usage Id="Microsoft.CodeQuality.Analyzers" Version="3.3.0" />
     <Usage Id="Microsoft.Docker.Sdk" Version="1.1.0" />
     <Usage Id="Microsoft.DotNet.Common.ItemTemplates" Version="1.0.2-beta3" />
     <Usage Id="Microsoft.DotNet.Common.ItemTemplates" Version="2.0.0-preview8.19373.1" />
@@ -185,7 +182,6 @@
     <Usage Id="Microsoft.DotNet.Web.Spa.ProjectTemplates.3.1" Version="3.1.8" />
     <Usage Id="Microsoft.DotNet.Web.Spa.ProjectTemplates.5.0" Version="5.0.0" />
     <Usage Id="Microsoft.NET.Sdk.IL" Version="5.0.0-preview.8.20359.4" />
-    <Usage Id="Microsoft.NetCore.Analyzers" Version="3.3.0" />
     <Usage Id="Microsoft.NETCore.App.Host.linux-x64" Version="3.0.3" />
     <Usage Id="Microsoft.NETCore.App.Host.linux-x64" Version="3.1.7" />
     <Usage Id="Microsoft.NETCore.App.Ref" Version="5.0.0" />


### PR DESCRIPTION
For https://github.com/dotnet/source-build/issues/1893. (More details in patch.)