### PR TITLE
Remove Microsoft.NETCore.App.Host prebuilts from roslyn-analyzers

### DIFF
--- a/patches/roslyn-analyzers/0006-Disable-AppHost.patch
+++ b/patches/roslyn-analyzers/0006-Disable-AppHost.patch
@@ -1,0 +1,22 @@
+diff -ru a/src/Tools/GenerateDocumentationAndConfigFiles/GenerateDocumentationAndConfigFiles.csproj b/src/Tools/GenerateDocumentationAndConfigFiles/GenerateDocumentationAndConfigFiles.csproj
+--- a/src/Tools/GenerateDocumentationAndConfigFiles/GenerateDocumentationAndConfigFiles.csproj	2020-11-20 15:07:19.424841827 -0500
++++ a/src/Tools/GenerateDocumentationAndConfigFiles/GenerateDocumentationAndConfigFiles.csproj	2020-11-20 16:19:13.140657415 -0500
+@@ -5,6 +5,7 @@
+     <NonShipping>true</NonShipping>
+     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+     <MicrosoftCodeAnalysisVersion>$(MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion)</MicrosoftCodeAnalysisVersion>
++    <UseAppHost>false</UseAppHost>
+   </PropertyGroup>
+   <ItemGroup>
+     <Compile Include="..\..\Utilities\Compiler\Extensions\WellKnownDiagnosticTagsExtensions.cs" Link="WellKnownDiagnosticTagsExtensions.cs" />
+diff -ru a/src/Tools/GenerateGlobalAnalyzerConfigs/GenerateGlobalAnalyzerConfigs.csproj b/src/Tools/GenerateGlobalAnalyzerConfigs/GenerateGlobalAnalyzerConfigs.csproj
+--- a/src/Tools/GenerateGlobalAnalyzerConfigs/GenerateGlobalAnalyzerConfigs.csproj	2020-11-20 15:07:19.425841829 -0500
++++ b/src/Tools/GenerateGlobalAnalyzerConfigs/GenerateGlobalAnalyzerConfigs.csproj	2020-11-20 16:19:27.685668330 -0500
+@@ -5,6 +5,7 @@
+     <NonShipping>true</NonShipping>
+     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+     <MicrosoftCodeAnalysisVersion>$(MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion)</MicrosoftCodeAnalysisVersion>
++    <UseAppHost>false</UseAppHost>
+   </PropertyGroup>  
+   <ItemGroup>
+     <Compile Include="..\..\Microsoft.CodeAnalysis.Analyzers\Core\MetaAnalyzers\ReleaseTrackingHelper.cs" Link="ReleaseTrackingHelper.cs" />


### PR DESCRIPTION
See https://github.com/dotnet/source-build/issues/1905 for more information.

Upstream PR: https://github.com/dotnet/roslyn-analyzers/pull/4451