### PR TITLE
Fix matching logger path against parent directories

### DIFF
--- a/repos/Directory.Build.targets
+++ b/repos/Directory.Build.targets
@@ -93,9 +93,11 @@
           Condition="'$(EngCommonToolsShFile)' != ''"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(RepoCompletedSemaphorePath)UpdateBuildToolFramework.complete" >
+    <!-- Use a relative find in NewText to avoid regex matches with parent directories.
+         See https://github.com/dotnet/source-build/issues/1914 for details. -->
     <ReplaceTextInFile InputFile="$(EngCommonToolsShFile)"
                        OldText="local logger_path=&quot;$toolset_dir/$_InitializeBuildToolFramework/Microsoft.DotNet.Arcade.Sdk.dll&quot;"
-                       NewText="logger_path=%24%28find &quot;$toolset_dir&quot; -name Microsoft.DotNet.Arcade.Sdk.dll -regex &apos;.*netcoreapp2.1.*\|.*net5.0.*&apos;)" />
+                       NewText="logger_path=&quot;%24toolset_dir&quot;/%24%28cd &quot;$toolset_dir&quot; &amp;&amp; find -name Microsoft.DotNet.Arcade.Sdk.dll -regex &apos;.*netcoreapp2.1.*\|.*net5.0.*&apos;)" />
 
     <WriteLinesToFile File="$(RepoCompletedSemaphorePath)UpdateBuildToolFramework.complete" Overwrite="true" />
   </Target>


### PR DESCRIPTION
Using a regex match with a full path results can result in the regex matching parent directories of the source directory. If the code is being compiled in a subdirectory with a full path that includes `net5.0`
(such as `dotnet5.0`), multiple loggers can match. Multiple loggers matching will produce an invalid msbuild command, failing the build.

To reproduce:

    mkdir dotnet5.0
    cd dotnet5.0
    git clone https://github.com/dotnet/source-build
    cd source-build
    git checkout master
    ./build.sh

In my case, sourcelink fails to build with this error message:

    MSBUILD : error MSB1008: Only one project can be specified.
      Switch: /home/omajid/dotnet5.0/source-build/packages/restored/microsoft.dotnet.arcade.sdk/5.0.0-beta.20426.4/tools/net472/Microsoft.DotNet.Arcade.Sdk.dll

Fixes: #1914