### PR TITLE
Update SBRP to 1.0.0-beta.20574.1

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,9 +5,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>6eec4404c2df5bfa46e5da52383c881c5cca3a9f</Sha>
     </Dependency>
-    <Dependency Name="Private.SourceBuild.ReferencePackages" Version="1.0.0-beta.20573.3">
+    <Dependency Name="Private.SourceBuild.ReferencePackages" Version="1.0.0-beta.20574.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>fe6afa24c69cc135200bbe1f12a90a11a450dcb0</Sha>
+      <Sha>c52443b2ff14d485043d322bbc4c3dc4b592b3cd</Sha>
     </Dependency>
   </ToolsetDependencies>
   <ProductDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,6 +11,6 @@
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>
-    <PrivateSourceBuildReferencePackagesPackageVersion>1.0.0-beta.20573.3</PrivateSourceBuildReferencePackagesPackageVersion>
+    <PrivateSourceBuildReferencePackagesPackageVersion>1.0.0-beta.20574.1</PrivateSourceBuildReferencePackagesPackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is the version that is now building with 5.0 tools.

https://github.com/dotnet/source-build-reference-packages/pull/197

Uses https://github.com/dotnet/source-build/pull/1899.