### PR TITLE
[release/3.1] Fix fetch-microsoft-sdk script

### DIFF
--- a/scripts/fetch-microsoft-sdk.sh
+++ b/scripts/fetch-microsoft-sdk.sh
@@ -54,7 +54,7 @@ else
 fi
 
 chmod +x "${install_script}"
-url=$("${install_script_dir}/dotnet-install.sh" --dry-run --version "${sdk_version}" | grep https | sed -E 's|.*(https://.*tar.gz)$|\1|' | head -1)
+url=$("${install_script_dir}/dotnet-install.sh" --dry-run --version "${sdk_version}" | grep -E 'https://.*tar.gz' | sed -E 's|.*(https://.*tar.gz)$|\1|' | head -1)
 echo "${url}"
 
 # Use curl if available, otherwise use wget


### PR DESCRIPTION
The script internally uses dotnet-install. The output of dotnet-install has changed: it now prints multiple urls and only one of them is the one we want.

> dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
> dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
> dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
> dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
>
> dotnet-install: Payload URLs:
> dotnet-install: Primary named payload URL: https://dotnetcli.azureedge.net/dotnet/Sdk/3.1.110/dotnet-sdk-3.1.110-linux-x64.tar.gz
> dotnet-install: Repeatable invocation: ./dotnet-install.sh --version "3.1.110" --install-dir "$HOME/.dotnet" --architecture "x64 "

Fix the grep expression to pick up the payload URL.