### PR TITLE
Update SBRP to 1.0.0-beta.20575.3

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,9 +5,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>6eec4404c2df5bfa46e5da52383c881c5cca3a9f</Sha>
     </Dependency>
-    <Dependency Name="Private.SourceBuild.ReferencePackages" Version="1.0.0-beta.20573.3">
+    <Dependency Name="Private.SourceBuild.ReferencePackages" Version="1.0.0-beta.20575.3">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>fe6afa24c69cc135200bbe1f12a90a11a450dcb0</Sha>
+      <Sha>f041a764460c12af7a3e5ff539a1c411a5262fd3</Sha>
     </Dependency>
   </ToolsetDependencies>
   <ProductDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,6 +11,6 @@
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>
-    <PrivateSourceBuildReferencePackagesPackageVersion>1.0.0-beta.20573.3</PrivateSourceBuildReferencePackagesPackageVersion>
+    <PrivateSourceBuildReferencePackagesPackageVersion>1.0.0-beta.20575.3</PrivateSourceBuildReferencePackagesPackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR updates to `.3` in parallel to `.2` (https://github.com/dotnet/source-build/pull/1924) in case one has issues and the other doesn't.

With this PR, all prebuilts should be gone except the targeting packs blocked by https://github.com/dotnet/runtime/issues/45183.