### PR TITLE
Add fix from runtime for - ilasm doesn't preserve "where T:struct"...

### DIFF
--- a/patches/runtime/0032-Fix-issue-45183-ilasm-doesnt-preserve-where-t.patch
+++ b/patches/runtime/0032-Fix-issue-45183-ilasm-doesnt-preserve-where-t.patch
@@ -1,0 +1,45 @@
+From a396e60097a61cc7d0425583b004bce5c9b9ee72 Mon Sep 17 00:00:00 2001
+From: Brian Sullivan <briansul@microsoft.com>
+Date: Sat, 28 Nov 2020 23:26:29 -0800
+Subject: [PATCH] Fix issue 45183    Preserve the paramAttrs
+
+---
+ src/coreclr/src/ilasm/assembler.cpp | 14 ++++++++++----
+ 1 file changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/src/coreclr/src/ilasm/assembler.cpp b/src/coreclr/src/ilasm/assembler.cpp
+index 2e674db..b9bc13f 100644
+--- a/src/coreclr/src/ilasm/assembler.cpp
++++ b/src/coreclr/src/ilasm/assembler.cpp
+@@ -2715,18 +2715,24 @@ void Assembler::EmitGenericParamConstraints(int numTyPars, TyParDescr* pTyPars,
+ 
+         if (currParamNumConstraints > 0)
+         {
+-            mdGenericParam tkGenericParam = pTyPars[paramIndex].Token();
+-            ULONG currNumConstraints      = (ULONG) nConstraintsArr[paramIndex];
+-            mdToken* currConstraintArr    = pConstraintsArr[paramIndex];
++            mdGenericParam tkGenericParam     = pTyPars[paramIndex].Token();
++            DWORD          paramAttrs         = pTyPars[paramIndex].Attrs();
++            ULONG          currNumConstraints = (ULONG) nConstraintsArr[paramIndex];
++            mdToken*       currConstraintArr  = pConstraintsArr[paramIndex];
+             mdGenericParamConstraint* currGPConstraintArr = pGPConstraintsArr[paramIndex];
+ 
+             // call SetGenericParamProps for each generic parameter that has a non-zero count of constraints
+             // to record each generic parameters tyupe constraints.
+             //
++            // Pass the paramAttrs, these contain values in CorGenericParamAttr such as:
++            //    gpReferenceTypeConstraint        = 0x0004,  // type argument must be a reference type
++            //    gpNotNullableValueTypeConstraint = 0x0008,  // type argument must be a value type but not Nullable
++            //    gpDefaultConstructorConstraint   = 0x0010,  // type argument must have a public default constructor
++            //
+             // This Metadata operation will also create a new GenericParamConstraint token
+             // for each of the generic parameters type constraints.
+             //
+-            if (FAILED(m_pEmitter->SetGenericParamProps(tkGenericParam, 0, NULL, 0, currConstraintArr)))
++            if (FAILED(m_pEmitter->SetGenericParamProps(tkGenericParam, paramAttrs, NULL, 0, currConstraintArr)))
+             {
+                 report->error("Failed in SetGenericParamProp");
+             }
+-- 
+1.8.3.1
+


### PR DESCRIPTION
Fix is for https://github.com/dotnet/runtime/issues/45183