### PR TITLE
Fix aspnetcore .NET tool versions: depend on unstable aspnetcore package version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,7 +83,7 @@
       <Uri>https://github.com/dotnet/xliff-tasks</Uri>
       <Sha>a52f3d7fb58470749ee4035fbbcb7e63c78b0459</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.App.Runtime.win-x64" Version="5.0.0" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <Dependency Name="Microsoft.AspNetCore.App.Ref.Internal" Version="5.0.0-rtm.20526.5" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>371a26f07b23ad77c636332c2dfc0cbd1d8137ba</Sha>
       <RepoName>aspnetcore</RepoName>


### PR DESCRIPTION
The git-info file is generated based on the dependency version. We have to use a nonstable version so the aspnetcore .NET tools bundled in the SDK have the correct nonstable version.

For https://github.com/dotnet/source-build/issues/1876.