### PR TITLE
Improve "Build net4* in source-build" patch doc

### DIFF
--- a/patches/runtime/0033-Build-net4-in-source-build.patch
+++ b/patches/runtime/0033-Build-net4-in-source-build.patch
@@ -3,8 +3,20 @@ From: Davis Goodin <dagood@microsoft.com>
 Date: Wed, 9 Dec 2020 14:01:09 -0600
 Subject: [PATCH] Build net4* in source-build
 
-Remove some ref/[...].csproj ProjectReferences to avoid build errors
-like these:
+Build net4XX TFMs to support OmniSharp. OmniSharp uses Mono, which needs to be
+able to find net4XX binaries. See https://github.com/OmniSharp/omnisharp-roslyn/issues/1973
+
+This patch moves the list of all net4XX TFMs (except net48) that was already
+present in dotnet/runtime into a property called
+"NETFrameworkTargetFrameworksExcept48". The list is missing net48 because
+dotnet/runtime uses this list to automatically build non-net48 TFMs when the dev
+specifies net48. Source-build reuses this variable to build all the net4XX TFMs
+for source-build. (net48 is added individually to fill the gap.) If this patch
+hits a conflict due to the list of TFMs changing, make sure that every net4XX
+TFM ends up in AdditionalBuildTargetFrameworks during source-build.
+
+The patch also removes some ref/[...].csproj ProjectReferences to avoid build
+errors like these:
 
   /work/artifacts/src/runtime.cf258a14b70ad9069470a108f13765e0e5988f51/src/libraries/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.cs(1383,140):
     error CS0433: The type 'PermissionSet' exists in both 'System.Security.Permissions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' and 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' [/work/artifacts/src/runtime.cf258a14b70ad9069470a108f13765e0e5988f51/src/libraries/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.csproj]
@@ -14,6 +26,7 @@ like these:
   /work/artifacts/src/runtime.cf258a14b70ad9069470a108f13765e0e5988f51/src/libraries/System.ServiceProcess.ServiceController/ref/System.ServiceProcess.ServiceController.cs(39,43):
     error CS0433: The type 'EventLog' exists in both 'System.Diagnostics.EventLog, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' and 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' [/work/artifacts/src/runtime.cf258a14b70ad9069470a108f13765e0e5988f51/src/libraries/System.ServiceProcess.ServiceController/ref/System.ServiceProcess.ServiceController.csproj]
   /work/.dotnet/sdk/5.0.100-rc.1.20452.10/Microsoft.Common.CrossTargeting.targets(88,5): error MSB4181: The "MSBuild" task returned false but did not log an error. [/work/artifacts/src/runtime.cf258a14b70ad9069470a108f13765e0e5988f51/src/libraries/System.ServiceProcess.ServiceController/ref/System.ServiceProcess.ServiceController.csproj]
+
 ---
  src/libraries/Directory.Build.props                          | 5 +++--
  .../src/Microsoft.Extensions.Configuration.Xml.csproj        | 3 +++


### PR DESCRIPTION
Follow up on https://github.com/dotnet/source-build/pull/1928#discussion_r541174488. I tried to include context and guidance for what to do if this patch conflicts.