### PR TITLE
Re-enable macOS CI

### DIFF
--- a/.vsts.pipelines/builds/matrix.yml
+++ b/.vsts.pipelines/builds/matrix.yml
@@ -87,17 +87,16 @@ stages:
     jobParameters:
       imageName: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-source-build-20200401093015-ed32d26
 
-# Disable until CI break is fixed to avoid cognitive load while getting 5.0 prebuilts down: https://github.com/dotnet/source-build/issues/1819
-# - template: ../stages/stage-jobs-matrix.yml
-#   parameters:
-#     jobTemplateName: ../jobs/ci-local.yml
-#     name: osx
-#     jobParameters:
-#       pool:
-#         name: Hosted macOS
-#       scriptPrefix: ./
-#       scriptSuffix: .sh
-#       setupMac: true
+- template: ../stages/stage-jobs-matrix.yml
+  parameters:
+    jobTemplateName: ../jobs/ci-local.yml
+    name: osx
+    jobParameters:
+      pool:
+        name: Hosted macOS
+      scriptPrefix: ./
+      scriptSuffix: .sh
+      setupMac: true
 
 # Prepare artifacts in all situations but public PR validation.
 - ${{ if not(and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'))) }}:

--- a/repos/Directory.Build.targets
+++ b/repos/Directory.Build.targets
@@ -98,7 +98,7 @@
          See https://github.com/dotnet/source-build/issues/1914 for details. -->
     <ReplaceTextInFile InputFile="$(EngCommonToolsShFile)"
                        OldText="local logger_path=&quot;$toolset_dir/$_InitializeBuildToolFramework/Microsoft.DotNet.Arcade.Sdk.dll&quot;"
-                       NewText="logger_path=&quot;%24toolset_dir&quot;/%24%28cd &quot;$toolset_dir&quot; &amp;&amp; find -name Microsoft.DotNet.Arcade.Sdk.dll -regex &apos;.*netcoreapp2.1.*\|.*net5.0.*&apos;)" />
+                       NewText="logger_path=&quot;%24toolset_dir&quot;/%24%28cd &quot;$toolset_dir&quot; &amp;&amp; find . -name Microsoft.DotNet.Arcade.Sdk.dll \( -regex &apos;.*netcoreapp2.1.*&apos; -or -regex &apos;.*net5.0.*&apos; \) )" />
 
     <WriteLinesToFile File="$(RepoCompletedSemaphorePath)UpdateBuildToolFramework.complete" Overwrite="true" />
   </Target>

--- a/repos/runtime.proj
+++ b/repos/runtime.proj
@@ -15,7 +15,7 @@
     <!-- Additional Targets -->
   <Target Name="InstallJustBuiltRuntime" AfterTargets="RemoveBuiltPackagesFromCache">
     <!-- Install the runtime that was just built to be used by downstream repos, namely, aspnetcore -->
-    <Exec Command="tar -xvf $(SourceBuiltAssetsDir)dotnet-runtime-$(runtimeOutputPackageVersion)-$(TargetRid).tar.gz -C $(DotNetCliToolDir)" />
+    <Exec Command="tar -xvf $(SourceBuiltAssetsDir)dotnet-runtime-$(runtimeOutputPackageVersion)-$(OverrideTargetRid).tar.gz -C $(DotNetCliToolDir)" />
   </Target>
 
 


### PR DESCRIPTION
Enable the currently-commented out CI setup for macOS.

Fix the find command used for logger:
    
- Always specify path: the macOS version of find needs that or a -path argument to work.

- The regex engines differ between GNU find and macOS find. The `\|` part is parsed differently by both of them. Use a simpler regex that they can both support.
    
Use `TargetOverrideRid` (`osx-x64`) instead of `TargetRid` (`osx.10.13-x64`) to determine the RID of the runtime tarball.
    
Fixes: #1819