### PR TITLE
[release/3.1] Fix smoke test timeout detection to work again

### DIFF
--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -212,17 +212,26 @@ function doCommand() {
                 "${dotnetCmd}" $newArgs --no-restore >> "$logFile" 2>&1
             fi
         elif [[ "$1" == "run" && "$proj" =~ ^(web|mvc|webapi|razor)$ ]]; then
+            # A separate log file that we will over-write all the time.
+            exitLogFile="$testingDir/exitLogFile"
+            echo > $exitLogFile
+            # Run an application in the background and redirect its
+            # stdout+stderr to a separate process (tee). The tee process
+            # writes its input to 2 files:
+            # - Either the normal log or stdout
+            # - A log that's only used to find out when it's safe to kill
+            #   the application.
             if [ "$projectOutput" == "true" ]; then
-                "${dotnetCmd}" $1 &
+                "${dotnetCmd}" $1 2>&1 > >(tee -a "$exitLogFile") &
             else
-                "${dotnetCmd}" $1 >> "$logFile" 2>&1 &
+                "${dotnetCmd}" $1 2>&1 > >(tee -a "$logFile" "$exitLogFile" >/dev/null) &
             fi
             webPid=$!
             killCommand="pkill -SIGTERM -P $webPid"
             echo "    waiting up to 30 seconds for web project with pid $webPid..."
             echo "    to clean up manually after an interactive cancellation, run: $killCommand"
             for seconds in $(seq 30); do
-                if [ "$(tail -n 1 "$logFile")" = 'Application started. Press Ctrl+C to shut down.' ]; then
+                if grep 'Application started. Press Ctrl+C to shut down.' "$exitLogFile"; then
                     echo "    app ready for shutdown after $seconds seconds"
                     break
                 fi


### PR DESCRIPTION
.NET Core 2.1 and 3.1 use separate strings of text to indicate that the application is running. Both include this text, though:

    Application started. Press Ctrl+C to shut down.

Update the timeout detection logic to be more flexible and catch this line of text anywhere in the output, not just in the last line.

This brings the timeout for some of these test runs down from 30 seconds to 2 or 3 seconds.

Fixes: #1655