### PR TITLE
Build MSBuild.SourceBuild.slnf (new solution filter)

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -52,7 +52,7 @@
     </Dependency>
     <Dependency Name="Microsoft.Build" Version="16.8.0" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>126527ff107ae93fed10af675506c56d046aa5a3</Sha>
+      <Sha>c6ed2fef9d1cb5504eb51c6f6a9d529e4efd9054</Sha>
     </Dependency>
     <Dependency Name="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.0" CoherentParentDependency="Microsoft.NET.Sdk">
       <Uri>https://github.com/dotnet/roslyn-analyzers</Uri>

--- a/repos/msbuild.proj
+++ b/repos/msbuild.proj
@@ -11,7 +11,7 @@
     <BuildCommandArgs>$(BuildCommandArgs) /p:DotNetBuildFromSource=true</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:DotNetCoreSdkDir=$(DotNetCliToolDir)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) --configuration $(Configuration)</BuildCommandArgs>
-    <BuildCommandArgs>$(BuildCommandArgs) --projects $(ProjectDirectory)MSBuild.SourceBuild.sln</BuildCommandArgs>
+    <BuildCommandArgs>$(BuildCommandArgs) --projects $(ProjectDirectory)MSBuild.SourceBuild.slnf</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) $(FlagParameterPrefix)nodereuse $(ArcadeFalseBoolBuildArg)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) $(OutputVersionArgs)</BuildCommandArgs>
     <BuildCommandArgs>$(BuildCommandArgs) /p:DotNetPackageVersionPropsPath=$(PackageVersionPropsPath)</BuildCommandArgs>


### PR DESCRIPTION
https://github.com/dotnet/msbuild/pull/6010 replaced `MSBuild.SourceBuild.sln` with `MSBuild.SourceBuild.slnf`. The subset of projects it's building stays the same.