### PR TITLE
[master] Replace legacy MyGet feeds

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,7 +9,7 @@
     <add key="darc-pub-dotnet-aspnetcore-371a26f" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-371a26f0/nuget/v3/index.json" />
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
+    <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
     <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="dotnet5-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />

--- a/repos/Directory.Build.targets
+++ b/repos/Directory.Build.targets
@@ -143,37 +143,37 @@
     <!-- Update NuGet.Config files that have deprecated myget feeds -->
     <ItemGroup>
       <LegacyFeedMapping Include="https://dotnet.myget.org/F/nuget-build/api/v3/index.json"
-                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
+                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
       <LegacyFeedMapping Include="https://www.myget.org/F/nugetbuild/api/v3/index.json"
-                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
+                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
       <LegacyFeedMapping Include="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json"
-                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json" />
+                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json" />
       <LegacyFeedMapping Include="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json"
-                        NewFeed="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+                         NewFeed="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
       <LegacyFeedMapping Include="https://dotnet.myget.org/F/vstest/api/v3/index.json"
-                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
+                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
       <LegacyFeedMapping Include="https://dotnet.myget.org/F/mstestv2/auth/1e768268-8c95-4e7e-9fd2-0eb1b1b69b18/api/v3/index.json"
-                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
+                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
       <LegacyFeedMapping Include="https://dotnet.myget.org/F/roslyn/api/v3/index.json"
-                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
       <LegacyFeedMapping Include="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json"
-                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
       <LegacyFeedMapping Include="https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json"
-                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
       <LegacyFeedMapping Include="https://dotnet.myget.org/F/roslyn-master-nightly/api/v3/index.json"
-                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
       <LegacyFeedMapping Include="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json"
-                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
       <LegacyFeedMapping Include="https://dotnet.myget.org/F/interactive-window/api/v3/index.json"
-                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
       <LegacyFeedMapping Include="https://dotnet.myget.org/F/mstestv2/api/v3/index.json"
-                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
+                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
       <LegacyFeedMapping Include="https://dotnet.myget.org/F/vsunittesting/api/v3/index.json"
-                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
       <LegacyFeedMapping Include="https://dotnet.myget.org/F/msbuild/api/v3/index.json"
-                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
       <LegacyFeedMapping Include="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json"
-                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
+                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
     </ItemGroup>
 
     <ReplaceFeedsInNugetConfig InputFile="%(NuGetConfigFiles.Identity)"

--- a/repos/Directory.Build.targets
+++ b/repos/Directory.Build.targets
@@ -9,6 +9,7 @@
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="GetSourceBuiltNupkgCacheConflicts" />
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="ReadNuGetPackageInfos" />
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="RemoveInternetSourcesFromNuGetConfig" />
+  <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="ReplaceFeedsInNuGetConfig" />
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="UpdateJson" />
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="ValidateUsageAgainstBaseline" />
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="WriteBuildOutputProps" />
@@ -138,6 +139,45 @@
                             SourceName="ExtraSources"
                             SourcePath="$(ExtraRestoreSourcePath)"
                             Condition="'$(ExtraRestoreSourcePath)' != ''" />
+
+    <!-- Update NuGet.Config files that have deprecated myget feeds -->
+    <ItemGroup>
+      <LegacyFeedMapping Include="https://dotnet.myget.org/F/nuget-build/api/v3/index.json"
+                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
+      <LegacyFeedMapping Include="https://www.myget.org/F/nugetbuild/api/v3/index.json"
+                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
+      <LegacyFeedMapping Include="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json"
+                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json" />
+      <LegacyFeedMapping Include="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json"
+                        NewFeed="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+      <LegacyFeedMapping Include="https://dotnet.myget.org/F/vstest/api/v3/index.json"
+                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
+      <LegacyFeedMapping Include="https://dotnet.myget.org/F/mstestv2/auth/1e768268-8c95-4e7e-9fd2-0eb1b1b69b18/api/v3/index.json"
+                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
+      <LegacyFeedMapping Include="https://dotnet.myget.org/F/roslyn/api/v3/index.json"
+                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+      <LegacyFeedMapping Include="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json"
+                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+      <LegacyFeedMapping Include="https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json"
+                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+      <LegacyFeedMapping Include="https://dotnet.myget.org/F/roslyn-master-nightly/api/v3/index.json"
+                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+      <LegacyFeedMapping Include="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json"
+                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+      <LegacyFeedMapping Include="https://dotnet.myget.org/F/interactive-window/api/v3/index.json"
+                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+      <LegacyFeedMapping Include="https://dotnet.myget.org/F/mstestv2/api/v3/index.json"
+                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
+      <LegacyFeedMapping Include="https://dotnet.myget.org/F/vsunittesting/api/v3/index.json"
+                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+      <LegacyFeedMapping Include="https://dotnet.myget.org/F/msbuild/api/v3/index.json"
+                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+      <LegacyFeedMapping Include="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json"
+                        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
+    </ItemGroup>
+
+    <ReplaceFeedsInNugetConfig InputFile="%(NuGetConfigFiles.Identity)"
+                               FeedMapping="@(LegacyFeedMapping)" />
 
     <WriteLinesToFile File="$(RepoCompletedSemaphorePath)UpdateNuGetConfig.complete" Overwrite="true" />
   </Target>

--- a/repos/Directory.Build.targets
+++ b/repos/Directory.Build.targets
@@ -142,38 +142,54 @@
 
     <!-- Update NuGet.Config files that have deprecated myget feeds -->
     <ItemGroup>
-      <LegacyFeedMapping Include="https://dotnet.myget.org/F/nuget-build/api/v3/index.json"
-                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
-      <LegacyFeedMapping Include="https://www.myget.org/F/nugetbuild/api/v3/index.json"
-                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
-      <LegacyFeedMapping Include="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json"
-                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json" />
-      <LegacyFeedMapping Include="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json"
-                         NewFeed="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
-      <LegacyFeedMapping Include="https://dotnet.myget.org/F/vstest/api/v3/index.json"
-                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
-      <LegacyFeedMapping Include="https://dotnet.myget.org/F/mstestv2/auth/1e768268-8c95-4e7e-9fd2-0eb1b1b69b18/api/v3/index.json"
-                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
-      <LegacyFeedMapping Include="https://dotnet.myget.org/F/roslyn/api/v3/index.json"
-                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
-      <LegacyFeedMapping Include="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json"
-                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
-      <LegacyFeedMapping Include="https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json"
-                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
-      <LegacyFeedMapping Include="https://dotnet.myget.org/F/roslyn-master-nightly/api/v3/index.json"
-                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
-      <LegacyFeedMapping Include="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json"
-                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-      <LegacyFeedMapping Include="https://dotnet.myget.org/F/interactive-window/api/v3/index.json"
-                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-      <LegacyFeedMapping Include="https://dotnet.myget.org/F/mstestv2/api/v3/index.json"
-                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
-      <LegacyFeedMapping Include="https://dotnet.myget.org/F/vsunittesting/api/v3/index.json"
-                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-      <LegacyFeedMapping Include="https://dotnet.myget.org/F/msbuild/api/v3/index.json"
-                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
-      <LegacyFeedMapping Include="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json"
-                         NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/nuget-build/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://www.myget.org/F/nugetbuild/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json"
+        NewFeed="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/vstest/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/mstestv2/auth/1e768268-8c95-4e7e-9fd2-0eb1b1b69b18/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/roslyn/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/roslyn-master-nightly/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/interactive-window/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/mstestv2/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/vsunittesting/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/msbuild/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
     </ItemGroup>
 
     <ReplaceFeedsInNugetConfig InputFile="%(NuGetConfigFiles.Identity)"

--- a/repos/aspnetcore.proj
+++ b/repos/aspnetcore.proj
@@ -41,8 +41,7 @@
     <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json</EnvironmentRestoreSources>
     <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/aspnet-blazor/index.json</EnvironmentRestoreSources>
     <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json</EnvironmentRestoreSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -253,7 +253,7 @@ function setupDevCerts() {
     echo "Setting up dotnet-dev-certs $devCertsVersion to generate dev certificate" | tee -a "$logFile"
     (
         set -x
-        "$dotnetDir/dotnet" tool install -g dotnet-dev-certs --version "$devCertsVersion" --add-source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json
+        "$dotnetDir/dotnet" tool install -g dotnet-dev-certs --version "$devCertsVersion" --add-source https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
         export DOTNET_ROOT="$dotnetDir"
         "$testingHome/.dotnet/tools/dotnet-dev-certs" https
     ) >> "$logFile" 2>&1

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/ReplaceFeedsInNuGetConfig.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/ReplaceFeedsInNuGetConfig.cs
@@ -22,8 +22,9 @@ namespace Microsoft.DotNet.Build.Tasks
         public string InputFile { get; set; }
 
         /// <summary>
-        /// An item group of feeds to update.  Each item must have metadata NewFeed
-        /// that specifies the replacement feed.
+        /// An item group of feeds to update.
+        /// %(Identity): The feed URL to find in the NuGet.Config.
+        /// %(NewFeed): The feed URL to replace %(Identity) with.
         /// </summary>
         [Required]
         public ITaskItem[] FeedMapping { get; set; }

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/ReplaceFeedsInNuGetConfig.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/ReplaceFeedsInNuGetConfig.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    /// <summary>
+    /// Replaces feeds in a NuGet.Config file given a mapping
+    /// of old feeds to new feeds.
+    /// </summary>
+    public class ReplaceFeedsInNuGetConfig : Task
+    {
+        /// <summary>
+        /// The NuGet.Config file in which to replace feeds.
+        /// </summary>
+        [Required]
+        public string InputFile { get; set; }
+
+        /// <summary>
+        /// An item group of feeds to update.  Each item must have metadata NewFeed
+        /// that specifies the replacement feed.
+        /// </summary>
+        [Required]
+        public ITaskItem[] FeedMapping { get; set; }
+
+        public override bool Execute()
+        {
+            string fileContents = File.ReadAllText(InputFile);
+            bool updated = false;
+
+            foreach (var feed in FeedMapping)
+            {
+                string oldFeed = feed.ItemSpec;
+                string newFeed = feed.GetMetadata("NewFeed");
+
+                if (fileContents.Contains(oldFeed))
+                {
+                    fileContents = fileContents.Replace(oldFeed, newFeed);
+                    updated = true;
+                }
+            }
+
+            if (updated) File.WriteAllText(InputFile, fileContents);
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
MyGet feeds have been deprecated and replaced with new feeds. 

This PR updates source-build infrastructure in cases where MyGet feeds were used and adds a task to update repo's NuGet.Config file(s) to replace feeds before building.

See #1971