### PR TITLE
[release/3.1] Replace legacy MyGet feeds

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -12,7 +12,7 @@
     <add key="darc-pub-dotnet-aspnetcore-e318707" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-e3187077/nuget/v3/index.json" />
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
+    <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
     <add key="arcade" value="https://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
   </packageSources>

--- a/global.json
+++ b/global.json
@@ -6,7 +6,7 @@
     "Microsoft.Build.CentralPackageVersions": "2.0.1",
     "Microsoft.Build.Traversal": "2.0.2",
     "Microsoft.NET.Sdk.IL": "3.0.0-preview-27107-01",
-    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19359.6",
+    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.20113.5",
     "Yarn.MSBuild": "1.15.2"
   }
 }

--- a/repos/Directory.Build.targets
+++ b/repos/Directory.Build.targets
@@ -412,7 +412,13 @@
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(RepoCompletedSemaphorePath)RemoveBuiltPackagesFromCache.complete">
 
-    <ReadNuGetPackageInfos PackagePaths="@(_BuiltPackages)">
+    <ItemGroup>
+        <!-- Excluding Arcade here will keep it in the cache, because that's where we're running from.
+             Subsequent projects will get Arcade from Tools/source-built. -->
+        <PackagePaths Include="@(_BuiltPackages)" Exclude="$(PackagesOutput)/Microsoft.DotNet.Arcade.Sdk.*.nupkg" />
+    </ItemGroup>
+
+    <ReadNuGetPackageInfos PackagePaths="@(PackagePaths)">
       <Output TaskParameter="PackageInfoItems" ItemName="_BuiltPackageInfos" />
     </ReadNuGetPackageInfos>
 

--- a/repos/Directory.Build.targets
+++ b/repos/Directory.Build.targets
@@ -9,6 +9,7 @@
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="GetSourceBuiltNupkgCacheConflicts" />
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="ReadNuGetPackageInfos" />
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="RemoveInternetSourcesFromNuGetConfig" />
+  <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="ReplaceFeedsInNuGetConfig" />
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="UpdateJson" />
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="ValidateUsageAgainstBaseline" />
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="WriteBuildOutputProps" />
@@ -119,6 +120,64 @@
     <AddSourceToNuGetConfig NuGetConfigFile="%(NuGetConfigFiles.Identity)"
                             SourceName="source-built"
                             SourcePath="$(SourceBuiltPackagesPath)" />
+
+    <!-- Update NuGet.Config files that have deprecated myget feeds -->
+    <ItemGroup>
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/nuget-build/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://www.myget.org/F/nugetbuild/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json"
+        NewFeed="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/system-commandline/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/vstest/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/mstestv2/auth/1e768268-8c95-4e7e-9fd2-0eb1b1b69b18/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/roslyn/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/roslyn-master-nightly/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/interactive-window/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/mstestv2/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/vsunittesting/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/msbuild/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+      <LegacyFeedMapping
+        Include="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json"
+        NewFeed="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
+    </ItemGroup>
+
+    <ReplaceFeedsInNugetConfig InputFile="%(NuGetConfigFiles.Identity)"
+                               FeedMapping="@(LegacyFeedMapping)" />
 
     <!--
       The internal transport feed is dynamically added by Arcade by a script called directly in the

--- a/repos/aspnetcore.proj
+++ b/repos/aspnetcore.proj
@@ -41,8 +41,7 @@
     <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json</EnvironmentRestoreSources>
     <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/aspnet-blazor/index.json</EnvironmentRestoreSources>
     <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json</EnvironmentRestoreSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/repos/msbuild.proj
+++ b/repos/msbuild.proj
@@ -39,10 +39,9 @@
     <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://api.nuget.org/v3/index.json</EnvironmentRestoreSources>
     <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</EnvironmentRestoreSources>
     <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnet.myget.org/F/nuget-build/api/v3/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnet.myget.org/F/roslyn/api/v3/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnet.myget.org/F/roslyn-tools/api/v3/index.json</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json</EnvironmentRestoreSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/repos/websdk.proj
+++ b/repos/websdk.proj
@@ -26,8 +26,7 @@
     <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://api.nuget.org/v3/index.json</EnvironmentRestoreSources>
     <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json</EnvironmentRestoreSources>
     <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnetfeed.blob.core.windows.net/aspnet-blazor/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json</EnvironmentRestoreSources>
-    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json</EnvironmentRestoreSources>
+    <EnvironmentRestoreSources Condition="'$(OfflineBuild)' != 'true'">$(EnvironmentRestoreSources)%3Bhttps://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json</EnvironmentRestoreSources>
 
     <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
   </PropertyGroup>

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -272,7 +272,7 @@ function setupDevCerts() {
     echo "Setting up dotnet-dev-certs $devCertsVersion to generate dev certificate" | tee -a "$logFile"
     (
         set -x
-        "$dotnetDir/dotnet" tool install -g dotnet-dev-certs --version "$devCertsVersion" --add-source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json
+        "$dotnetDir/dotnet" tool install -g dotnet-dev-certs --version "$devCertsVersion" --add-source https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
         export DOTNET_ROOT="$dotnetDir"
         "$testingHome/.dotnet/tools/dotnet-dev-certs" https
     ) >> "$logFile" 2>&1

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/ReplaceFeedsInNuGetConfig.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/ReplaceFeedsInNuGetConfig.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    /// <summary>
+    /// Replaces feeds in a NuGet.Config file given a mapping
+    /// of old feeds to new feeds.
+    /// </summary>
+    public class ReplaceFeedsInNuGetConfig : Task
+    {
+        /// <summary>
+        /// The NuGet.Config file in which to replace feeds.
+        /// </summary>
+        [Required]
+        public string InputFile { get; set; }
+
+        /// <summary>
+        /// An item group of feeds to update.
+        /// %(Identity): The feed URL to find in the NuGet.Config.
+        /// %(NewFeed): The feed URL to replace %(Identity) with.
+        /// </summary>
+        [Required]
+        public ITaskItem[] FeedMapping { get; set; }
+
+        public override bool Execute()
+        {
+            string fileContents = File.ReadAllText(InputFile);
+            bool updated = false;
+
+            foreach (var feed in FeedMapping)
+            {
+                string oldFeed = feed.ItemSpec;
+                string newFeed = feed.GetMetadata("NewFeed");
+
+                if (fileContents.Contains(oldFeed))
+                {
+                    fileContents = fileContents.Replace(oldFeed, newFeed);
+                    updated = true;
+                }
+            }
+
+            if (updated) File.WriteAllText(InputFile, fileContents);
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
MyGet feeds have been deprecated and replaced with new feeds.

This PR updates source-build infrastructure in cases where MyGet feeds were used and adds a task to update repo's NuGet.Config file(s) to replace feeds before building.

See #1971