### PR TITLE
[release/3.1] (Checklist) Document how to make a commit available

### DIFF
--- a/.github/ISSUE_TEMPLATE/releases/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/releases/release_checklist.md
@@ -117,6 +117,7 @@
         - `/smoke-testNuGet.Config`
         - Do not remove from subrepos. The build infra removes these sources automatically while modifying each subrepo nuget.config file.
 1.  - [ ] [Internal] Push the servicing branch to your GitHub fork and submit a source-build PR.
+1.  - [ ] [Internal] If a build hits `fatal: reference is not a tree: cb5f173b`, [make the commit available on a fork and switch to it temporarily](https://github.com/dotnet/source-build/tree/release/3.1/Documentation/servicing/make-commit-available.md).
 1.  - [ ] [Internal] Add source-build team as reviewers.
 1.  - [ ] [Internal] When CI is green and two reviewers approve, merge.
       - Avoid squash/rebase: nice to preserve commit hashes. However, there are no known dependencies on *source-build* commits being preserved.

--- a/Documentation/servicing/make-commit-available.md
+++ b/Documentation/servicing/make-commit-available.md
@@ -1,0 +1,27 @@
+## Making a commit that exists on a repo network available to source-build
+
+On release day, there might be errors like this:
+
+```
+fatal: reference is not a tree: cb5f173b9696d9d00a544b953d95190ab3b56df2
+```
+
+```
+This commit does not belong to any branch on this repository, and may belong to a fork outside of the repository.
+```
+
+To unblock this:
+
+1. Go to your fork of the corresponding GitHub repo, e.g. https://github.com/dagood/runtime
+1. Add `/tree/{commit}` to the URL, e.g. https://github.com/dagood/runtime/tree/cb5f173b9696d9d00a544b953d95190ab3b56df2
+   * If the commit isn't available, then it hasn't been made public yet and the release is blocked.
+1. Click the branch dropdown.
+1. Type in a name for a branch to create, e.g. `release/5.0.2`
+   * The name doesn't matter, a branch just needs to exist.
+1. Press Enter to create the branch.
+1. Edit the repo's URI in `Version.Details.xml` to use your fork, e.g. https://github.com/dagood/runtime
+1. CI should now get past this point.
+   * It may fail on another repo if multiple haven't been tagged properly.
+1. ...Later, check the commit's availability in the non-fork repo, and switch the URI back to the official repository when possible.
+
+This is intended to temporarily unblock CI so it can continue to validate the build and flush out further problems. The commit's unavailability on the official repo should also be communicated to the release team so it can be fixed as soon as possible.


### PR DESCRIPTION
Brief doc to describe this process. Make it easy to find by putting it in the checklist.

This is a way to mitigate the effect release tagging unreliability has on our releases (lag): https://github.com/dotnet/arcade/issues/5686.