### PR TITLE
[master] Update README: more specific branch and plan info

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,44 +3,35 @@
 [![Build Status](https://dev.azure.com/dnceng/internal/_apis/build/status/dotnet/source-build/source-build-rolling-CI?branchName=master)](https://dev.azure.com/dnceng/internal/_build/latest?definitionId=114&branchName=master)
 [![Join the chat at https://gitter.im/dotnet/source-build](https://badges.gitter.im/dotnet/source-build.svg)](https://gitter.im/dotnet/source-build?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-This repository contains infrastructure for building the .NET Core Runtime and SDK from source. The scripts allow .NET Core package maintainers to comply with common Linux distribution guidelines.
+This repository helps .NET SDK and .NET Runtime package maintainers comply with common Linux distribution guidelines.
 
-## Using this repository
+To build the full .NET SDK from source, pick a specific Git tag with your desired version, or use a release branch to build the latest servicing release of that version. Refer to the tag/branch's README for build instructions:
 
-The scripts are written for Bash and supported on macOS and Linux. See [Documentation](Documentation) for complete instructions.
-
-> The source-build repository doesn't currently support Windows. See [source-build#1190](https://github.com/dotnet/source-build/issues/1190).
-
-The `master` branch of this repository is being reworked to build several components of the .NET SDK, instead of the entire .NET SDK. This is part of the [arcade-powered source-build](Documentation\planning\arcade-powered-source-build) design. Once this plan is complete, [dotnet/installer](https://github.com/dotnet/installer) will directly support building from source.
-
-To build the full .NET SDK from source, pick a specific Git tag, or use the release branches:
 * [`release/5.0`](https://github.com/dotnet/source-build/tree/release/5.0)
 * [`release/3.1`](https://github.com/dotnet/source-build/tree/release/3.1)
 * [`release/2.1`](https://github.com/dotnet/source-build/tree/release/2.1)
 
+The current branch is a work in progress that produces several .NET SDK components for [Arcade-powered source-build](Documentation\planning\arcade-powered-source-build). Once Arcade-powered source-build is complete, it will allow building a .NET SDK from source directly from the [dotnet/installer](https://github.com/dotnet/installer) repository.
+
+## Using this repository
+
+The scripts are written for Bash and supported on macOS and Linux.
+
+> The source-build repository doesn't currently support Windows. See [source-build#1190](https://github.com/dotnet/source-build/issues/1190).
+
 ### Build on Linux or macOS
 
-In a release branch, run this command:
+Optionally, run `./check-submodules.sh` to ensure the submodules are set up and synchronized. Then, run the build command:
 
 ```console
 ./build.sh
 ```
 
-Once the build is successful, the built SDK tarball is placed at:
-
-```
-artifacts/${ARCHITECTURE}/Release/dotnet-sdk-${SDK_VERSION}-${RUNTIME_ID}.tar.gz
-```
-
-- `${ARCHITECTURE}` is your platform architecture (probably `x64`)
-- `${SDK_VERSION}` is the SDK version you are building
-- `${RUNTIME_ID}` is your OS name and architecture (something like `debian.9-x64` or `fedora.33-x64`)
-
-For example, building a 5.0.100 SDK on an x64 (aka x86\_64) platform running Fedora 32 will produce `artifacts/x64/Release/dotnet-sdk-5.0.100-fedora.32-x64.tar.gz`.
+Once the build is successful, the outputs are placed in `artifacts/packages/Debug/`.
 
 ## Goals
 
-The key goal of this repository is to satisfy the official packaging rules of commonly used Linux distributions, such as [Fedora](https://fedoraproject.org/wiki/Packaging:Guidelines) and [Debian](https://www.debian.org/doc/manuals/maint-guide/build.en.html). Many Linux distributions have similar rules. These rules tend to have two main principles: consistent reproducibility, and source code for everything.
+The key goal of source-build is to satisfy the official packaging rules of commonly used Linux distributions, such as [Fedora](https://fedoraproject.org/wiki/Packaging:Guidelines) and [Debian](https://www.debian.org/doc/manuals/maint-guide/build.en.html). Many Linux distributions have similar rules. These rules tend to have two main principles: consistent reproducibility, and source code for everything.
 
 A secondary goal of source-build is to allow .NET Core contributors to build a .NET Core SDK with coordinated changes in multiple repositories. However, the developer experience is significantly better in individual repositories and, if possible, contributors should make and test changes in the target repo, not source-build.
 


### PR DESCRIPTION
I mentioned in my earlier PR for the readme that I think it needs some more polish. Here I'm trying to put the release branches as early as possible and update the build commands to match the new state.

I removed the link to `Documentation/` because it details the full .NET SDK build that no longer happens in `master`. I think we should probably only keep the old docs in `release/5.0` because it seems like it would be too confusing to have to put intros about which branch each doc actually applies to. Once ArPow isdone, end-to-end-style docs should go to either dotnet/installer or dotnet/arcade.

It would be nice to make a new repo rather than use dotnet/source-build for this new purpose. It just seems too easy to argue that reuse makes sense since there is a relatively simple cutoff point--we won't mix ArPow and traditional dotnet/source-build infra: it's either ArPow or traditional. Once we have the plan complete I think it'll be easier to describe.

@omajid I'm curious what you think about all this... does this readme make sense?

Preview: https://github.com/dagood/source-build/blob/arpow-readme/README.md