### PR TITLE
[master] Fix dependency on dotnet/arcade: use ArPow intermediate nupkg

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,6 +4,7 @@
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21101.7">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2b430e5bbfaec37a6cead2f0cf79157f01f1a623</Sha>
+      <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="5.0.0-alpha.1.20473.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>


### PR DESCRIPTION
The `<SourceBuild RepoName="arcade" ManagedOnly="true" />` element makes it so we get Arcade from the intermediate nupkg, reducing prebuilts:

```diff
 <AnnotatedUsages>
-  <AnnotatedUsage Id="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21101.2" />
-  <AnnotatedUsage Id="Microsoft.DotNet.SourceBuild.Tasks" Version="6.0.0-beta.21101.2" File="src/artifacts/toolset/Common/project.assets.json" IsDirectDependency="true" IsAutoReferenced="true" Project="src/" />
   <AnnotatedUsage Id="Microsoft.NETCore.Platforms" Version="1.0.1" File="src/src/newtonsoft-json901/Src/Newtonsoft.Json/obj/project.assets.json" Project="src/" />
   <AnnotatedUsage Id="Microsoft.NETCore.Targets" Version="1.0.1" File="src/src/newtonsoft-json901/Src/Newtonsoft.Json/obj/project.assets.json" Project="src/" />
+  <AnnotatedUsage Id="Microsoft.SourceBuild.Intermediate.arcade" Version="6.0.0-beta.21101.2" File="src/artifacts/toolset/Common/project.assets.json" IsDirectDependency="true" Project="src/" />
   <AnnotatedUsage Id="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="5.0.0-alpha.1.20473.1" File="src/artifacts/toolset/Common/project.assets.json" IsDirectDependency="true" Project="src/" />
   <AnnotatedUsage Id="NETStandard.Library" Version="1.6.1" File="src/src/application-insights/obj/Microsoft.ApplicationInsights/project.assets.json" IsDirectDependency="true" IsAutoReferenced="true" Project="src/" />
   <AnnotatedUsage Id="NETStandard.Library" Version="1.6.1" File="src/src/humanizer/src/Humanizer/obj/project.assets.json" IsDirectDependency="true" IsAutoReferenced="true" Project="src/" />
   <AnnotatedUsage Id="NETStandard.Library" Version="1.6.1" File="src/src/newtonsoft-json/Src/Newtonsoft.Json/obj/project.assets.json" IsDirectDependency="true" IsAutoReferenced="true" Project="src/" />
 </AnnotatedUsages>
```