### PR TITLE
[master] Add eng/Publishing.props to fix publishing

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <PublishingVersion>3</PublishingVersion>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This file with this content is required for Arcade publishing: https://github.com/dotnet/arcade/blob/0a67fb1cd008b0d30577f53d1633ed00db8bc1e6/Documentation/CorePackages/Publishing.md#how-to-upgrade-from-v2-to-v3

Otherwise, the inner publish job gets an error like this:

```
  Creating a task to publish assets from D:\a\1\a\AssetManifests\Unix-AnyCPU.xml
D:\a\1\s\.packages\microsoft.dotnet.arcade.sdk\6.0.0-beta.21101.7\tools\SdkTasks\PublishArtifactsInManifest.proj(103,5): error : The property TargetFeedConfig is required but doesn't have a value set.
##[error].packages\microsoft.dotnet.arcade.sdk\6.0.0-beta.21101.7\tools\SdkTasks\PublishArtifactsInManifest.proj(103,5): error : (NETCORE_ENGINEERING_TELEMETRY=Publish) The property TargetFeedConfig is required but doesn't have a value set.
D:\a\1\s\.packages\microsoft.dotnet.arcade.sdk\6.0.0-beta.21101.7\tools\SdkTasks\PublishArtifactsInManifest.proj(103,5): error : Missing required properties. Aborting execution.
##[error].packages\microsoft.dotnet.arcade.sdk\6.0.0-beta.21101.7\tools\SdkTasks\PublishArtifactsInManifest.proj(103,5): error : (NETCORE_ENGINEERING_TELEMETRY=Publish) Missing required properties. Aborting execution.

Build FAILED.
```