### PR TITLE
[master] Re-add symreader source-build champ

### DIFF
--- a/Documentation/planning/arcade-powered-source-build/implementation-plan.md
+++ b/Documentation/planning/arcade-powered-source-build/implementation-plan.md
@@ -23,7 +23,7 @@ Below, the repo status is in a graph to show the dependencies and make it easy t
 | 1 | command-line-api | [?](https://github.com/) | ✔️ | | | | |
 | 1 | diagnostics | ? | ✔️ | | | | |
 | 1 | roslyn | [Fred Silberberg](https://github.com/333fred) | | | | | |
-| 1 | symreader | ? | ✔️ | | | | |
+| 1 | symreader | [Tomas Matousek](https://github.com/tmat) | ✔️ | | | | |
 | 1 | test-templates | ? | ✔️ | | | | |
 | 1 | xliff-tasks | [Mark Wilkie](https://github.com/markwilkie) | ✔️ | | | | |
 | 2 | linker | [Dan Seefeldt](https://github.com/dseefeld) | ✔️ | | | | |


### PR DESCRIPTION
We lost @tmat's symreader champ listing in a remove/add shuffle: https://github.com/dotnet/source-build/issues/492 https://github.com/dotnet/source-build/issues/1812. Putting it back.

@tmat, let us know if you think it should be someone else now.
(I'm not aware of any reason it should change, but it has been a while. 😄)