### PR TITLE
ArPow: Add plan for supplemental intermediate nupkgs

### DIFF
--- a/Documentation/planning/arcade-powered-source-build/README.md
+++ b/Documentation/planning/arcade-powered-source-build/README.md
@@ -179,10 +179,15 @@ A: We shouldn't! But if we have to, use a forked branch. See
 [incremental-official.md]: incremental-official.md
 [source-build-in-pipeline.md]: source-build-in-pipeline.md
 [speculative-build.md]: speculative-build.md
+[intermediate nupkgs]: intermediate-nupkg.md
 
 ---
 
 ## Revisions:
+
+**2021-02-11** dagood  
+Added a plan to use "supplemental intermediate nupkgs" to handle situations
+where the [intermediate nupkgs] are too large to publish to Azure DevOps.
 
 **2020-07-15** dagood  
 Removed the plan to test every added intermediate nupkg all the way downstream

--- a/Documentation/planning/arcade-powered-source-build/intermediate-nupkg.md
+++ b/Documentation/planning/arcade-powered-source-build/intermediate-nupkg.md
@@ -98,16 +98,16 @@ download sizes:
 
 Name | Download size (approx)
 -- | --
-Microsoft.NETCore.App.Ref | 1 MB
-Microsoft.NETCore.App.Ref.archive | 1 MB
-Microsoft.NETCore.App.Runtime | 107 MB
-Microsoft.NETCore.App.Runtime.archive | 93 MB
-Microsoft.NETCore.App.Host | 47 MB
-Microsoft.NETCore.App.Host.archive | 47 MB
-Microsoft.NETCore.App.Crossgen2 | 167 MB
-Microsoft.NETCore.App.Crossgen2.archive | 167 MB
-libraries | 6 MB
-coreclr (ilasm/ildasm/testhost) | 6 MB
+RefPack | 1 MB
+RefPack.Archive | 1 MB
+RuntimePack | 107 MB
+RuntimePack.Archive | 93 MB
+HostPack | 47 MB
+HostPack.Archive | 47 MB
+Crossgen2Pack | 167 MB
+Crossgen2Pack.Archive | 167 MB
+Libraries | 6 MB
+CoreCLR (ilasm/ildasm/testhost) | 6 MB
 
 For context, some other repositories' intermediate nupkg total download size
 that do not need any supplemental nupkgs:

--- a/Documentation/planning/arcade-powered-source-build/intermediate-nupkg.md
+++ b/Documentation/planning/arcade-powered-source-build/intermediate-nupkg.md
@@ -45,16 +45,24 @@ RID.
 
 * `Microsoft.SourceBuild.Intermediate.runtime.libraries.linux.x64/6.0.0-foo`
   * Contains the dotnet/runtime platform extensions libraries.
+  * E.g. `System.IO.Pipelines.6.0.0-ci.nupkg`, `System.Numerics.Tensors.6.0.0-ci.nupkg`, ...
 * `Microsoft.SourceBuild.Intermediate.runtime.Microsoft.NETCore.App.Crossgen2.linux.x64/6.0.0-foo`
-  * Contains the crossgen2 pack nupkg.
-  * `Microsoft.NETCore.App.Crossgen2` is the name of the crossgen2 pack without
-    its RID, so use that as the name by convention.
+  * Contains the crossgen2 framework pack:
+    * `Microsoft.NETCore.App.Crossgen2.linux-x64.6.0.0-foo.nupkg`
+  * By convention, we use the identity of the crossgen2 pack without its RID for
+    the supplemental nupkg name. 
 * `Microsoft.SourceBuild.Intermediate.runtime.Microsoft.NETCore.App.Crossgen2.archive.linux.x64/6.0.0-foo`
-  * This stores the `tar.gz` version of the crossgen2 pack.
+  * This stores the `tar.gz` version of the crossgen2 framework pack:
+    * `dotnet-crossgen2-6.0.0-ci-linux-x64.tar.gz`
+  * We could give this supplemental nupkg a distinct name, say,
+    `dotnet-crossgen2` rather than `Microsoft.NETCore.App.Crossgen2.archive`,
+    but these are just different formats of the same fundamental framework pack.
+    * Naming is ultimately up to the project owner. Arcade-powered source-build
+      doesn't require the name to correspond to artifact filenames.
+    * Calling it `archive` rather than `tarball` lets it handle `zip` files, to
+      allow for Windows support in the future.
   * Crossgen2 is huge (~167 MB), so we need one supplemental nupkg for each
-    artifact--the nupkg and the archive.
-  * The name should apply to any RID, so I use `archive` rather than `tarball`
-    to allow Windows support in the future.
+    artifact. One for the nupkg, another for the archive.
 
 Each nupkg should either be < 20 MB, or contain only one artifact. This is a
 heuristic to use to decide when to produce supplemental nupkgs and how to split

--- a/Documentation/planning/arcade-powered-source-build/intermediate-nupkg.md
+++ b/Documentation/planning/arcade-powered-source-build/intermediate-nupkg.md
@@ -64,19 +64,27 @@ RID.
   * Crossgen2 is huge (~167 MB), so we need one supplemental nupkg for each
     artifact. One for the nupkg, another for the archive.
 
+### Contents
+
 Each nupkg should either be < 20 MB, or contain only one artifact. This is a
 heuristic to use to decide when to produce supplemental nupkgs and how to split
 them up.
 
-The intermediate nupkg we produce now (non-supplemental) contains:
+The non-supplemental intermediate nupkg contains:
 
 * The prebuilt report.
 * Any artifacts that are < 20 MB total and that all downstreams use.
-* A list of supplemental intermediate nupkg names produced by the repo.
+* [New!] A list of supplemental intermediate nupkg names produced by the repo.
   * This shouldn't be read by any tooling. (Avoid complicated implementation.)
   * This makes it easier to figure out what supplemental nupkgs to include when
     working on a downstream repo. Just restore the main one and look at the list
     to see what to add.
+
+The supplemental intermediate nupkgs only contain one or more artifacts--no
+reports, and no list of supplemental nupkg names. The single *non-supplemental*
+nupkg is always restored if *any supplemental* nupkg is restored, so the
+report/metadata is always available to someone investigating a downstream build
+that uses supplemental nupkgs. There is no need to deliver redundant data.
 
 The supplemental packages of dotnet/runtime will have approximately these
 download sizes:
@@ -101,7 +109,9 @@ that do not need any supplemental nupkgs:
 * SourceLink's intermediate nupkg is < 1 MB.
 * xliff-tasks's intermediate nupkg is < 100 kB.
 
-There are a few alternate designs that aren't suitable:
+### Alternatives to manually split supplemental nupkgs
+
+There are a few alternate solutions that aren't suitable:
 
 * Split just enough for the nupkg to fit on Azure DevOps, and always restore
   every supplemental package.

--- a/Documentation/planning/arcade-powered-source-build/intermediate-nupkg.md
+++ b/Documentation/planning/arcade-powered-source-build/intermediate-nupkg.md
@@ -45,7 +45,7 @@ RID.
 
 * `Microsoft.SourceBuild.Intermediate.runtime.libraries.linux.x64/6.0.0-foo`
   * Contains the dotnet/runtime platform extensions libraries.
-  * E.g. `System.IO.Pipelines.6.0.0-ci.nupkg`, `System.Numerics.Tensors.6.0.0-ci.nupkg`, ...
+  * E.g. `System.IO.Pipelines.6.0.0-foo.nupkg`, `System.Numerics.Tensors.6.0.0-foo.nupkg`, ...
 * `Microsoft.SourceBuild.Intermediate.runtime.Microsoft.NETCore.App.Crossgen2.linux.x64/6.0.0-foo`
   * Contains the crossgen2 framework pack:
     * `Microsoft.NETCore.App.Crossgen2.linux-x64.6.0.0-foo.nupkg`
@@ -53,7 +53,7 @@ RID.
     the supplemental nupkg name. 
 * `Microsoft.SourceBuild.Intermediate.runtime.Microsoft.NETCore.App.Crossgen2.archive.linux.x64/6.0.0-foo`
   * This stores the `tar.gz` version of the crossgen2 framework pack:
-    * `dotnet-crossgen2-6.0.0-ci-linux-x64.tar.gz`
+    * `dotnet-crossgen2-6.0.0-foo-linux-x64.tar.gz`
   * We could give this supplemental nupkg a distinct name, say,
     `dotnet-crossgen2` rather than `Microsoft.NETCore.App.Crossgen2.archive`,
     but these are just different formats of the same fundamental framework pack.

--- a/Documentation/planning/arcade-powered-source-build/intermediate-nupkg.md
+++ b/Documentation/planning/arcade-powered-source-build/intermediate-nupkg.md
@@ -43,26 +43,33 @@ A "supplemental intermediate nupkg" uses the same naming convention as
 intermediate nupkgs, but inserts an extra name between the repo name and the
 RID.
 
-* `Microsoft.SourceBuild.Intermediate.runtime.libraries.linux.x64/6.0.0-foo`
+* `Microsoft.SourceBuild.Intermediate.runtime.Libraries.linux.x64/6.0.0-foo`
   * Contains the dotnet/runtime platform extensions libraries.
   * E.g. `System.IO.Pipelines.6.0.0-foo.nupkg`, `System.Numerics.Tensors.6.0.0-foo.nupkg`, ...
-* `Microsoft.SourceBuild.Intermediate.runtime.Microsoft.NETCore.App.Crossgen2.linux.x64/6.0.0-foo`
+* `Microsoft.SourceBuild.Intermediate.runtime.Crossgen2Pack.linux.x64/6.0.0-foo`
   * Contains the crossgen2 framework pack:
     * `Microsoft.NETCore.App.Crossgen2.linux-x64.6.0.0-foo.nupkg`
-  * By convention, we use the identity of the crossgen2 pack without its RID for
-    the supplemental nupkg name. 
-* `Microsoft.SourceBuild.Intermediate.runtime.Microsoft.NETCore.App.Crossgen2.archive.linux.x64/6.0.0-foo`
+* `Microsoft.SourceBuild.Intermediate.runtime.Crossgen2Pack.Archive.linux.x64/6.0.0-foo`
   * This stores the `tar.gz` version of the crossgen2 framework pack:
     * `dotnet-crossgen2-6.0.0-foo-linux-x64.tar.gz`
-  * We could give this supplemental nupkg a distinct name, say,
-    `dotnet-crossgen2` rather than `Microsoft.NETCore.App.Crossgen2.archive`,
-    but these are just different formats of the same fundamental framework pack.
-    * Naming is ultimately up to the project owner. Arcade-powered source-build
-      doesn't require the name to correspond to artifact filenames.
-    * Calling it `archive` rather than `tarball` lets it handle `zip` files, to
-      allow for Windows support in the future.
+  * Note: Calling it `.Archive` rather than `.Tarball` gives us room to handle
+    `zip` files, to allow for Windows support in the future.
   * Crossgen2 is huge (~167 MB), so we need one supplemental nupkg for each
-    artifact. One for the nupkg, another for the archive.
+    artifact: one for the nupkg, another for the archive.
+
+The names of the supplemental categories are based on the contents, but the
+exact names are arbitrary. The goal is that it's clear enough that downstream
+users will know what it contains.
+
+For example, it would be fine to give the `Crossgen2Pack.Archive` supplemental
+nupkg a name based on the artifact's filename, say, `dotnet-crossgen2`.
+Arcade-powered source-build doesn't require a specific naming style. In this
+case, making `Crossgen2Pack` and `Crossgen2Pack.Archive` similar seems
+reasonable, since these are simply the same bits packaged different ways. Naming
+is ultimately up to the project owner.
+
+In general, the name should be concise: long NuGet package IDs can cause path
+length problems.
 
 ### Contents
 

--- a/Documentation/planning/arcade-powered-source-build/onboarding/local-onboarding.md
+++ b/Documentation/planning/arcade-powered-source-build/onboarding/local-onboarding.md
@@ -135,6 +135,53 @@ nupkg] ID. For example, running source-build on `dotnet/installer` with
 * `Microsoft.SourceBuild.Intermediate.source-build-reference-packages`
   * Ends with the `RepoName` without a suffix because `ManagedOnly="true"`.
 
+#### Supplemental intermediate nupkgs
+
+If the repo needs to *produce* [supplemental intermediate nupkgs], this needs to
+be configured. Exact implementation is to-be-documented. The repo needs to map
+each artifact to a supplemental category. Ideally this info can be stored in the
+project file responsible for producing each artifact, for maintainability.
+However, the faster approach is to use pattern matching to assign filenames in
+`artifacts/` to specific categories. This will likely be worked on
+incrementally.
+
+If the repo needs to *consume* [supplemental intermediate nupkgs] from an
+upstream, extra `<Supplemental ... />` elements need to be added to
+`eng/Version.Details.xml`. For example:
+
+```xml
+<Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0">
+  <Uri>https://github.com/dotnet/runtime</Uri>
+  <Sha>d9069470a108f13765e0e5988f51cf258a14b70a</Sha>
+  <SourceBuild RepoName="runtime">
+    <Supplemental Name="Microsoft.NETCore.App.Ref" />
+    <Supplemental Name="Microsoft.NETCore.App.Ref.archive" />
+    <Supplemental Name="Microsoft.NETCore.App.Runtime" />
+    <Supplemental Name="Microsoft.NETCore.App.Runtime.archive" />
+    <Supplemental Name="Microsoft.NETCore.App.Host" />
+    <Supplemental Name="Microsoft.NETCore.App.Host.archive" />
+    <Supplemental Name="Microsoft.NETCore.App.Crossgen2" />
+    <Supplemental Name="Microsoft.NETCore.App.Crossgen2.archive" />
+    <Supplemental Name="libraries" />
+    <Supplemental Name="coreclr" />
+  </SourceBuild>
+</Dependency>
+```
+
+This causes source-build to download:
+
+```
+Microsoft.DotNet.SourceBuild.runtime.linux-x64
+Microsoft.DotNet.SourceBuild.runtime.Microsoft.NETCore.App.Ref.linux-x64
+Microsoft.DotNet.SourceBuild.runtime.Microsoft.NETCore.App.Ref.archive.linux-x64
+...
+Microsoft.DotNet.SourceBuild.runtime.coreclr.linux-x64
+```
+
+The list of available supplemental intermediate nupkgs for a given repo can be
+found inside the repo's "base" intermediate nupkg, e.g.
+`Microsoft.DotNet.SourceBuild.runtime.linux-x64`.
+
 ### Patching
 
 Look at <https://github.com/dotnet/source-build/tree/release/5.0/patches> to
@@ -171,3 +218,4 @@ For each patch that isn't incorporated directly:
 
 
 [intermediate nupkg]: https://github.com/dotnet/source-build/blob/master/Documentation/planning/arcade-powered-source-build/intermediate-nupkg.md
+[supplemental intermediate nupkgs]: https://github.com/dotnet/source-build/blob/master/Documentation/planning/arcade-powered-source-build/intermediate-nupkg.md#too-large


### PR DESCRIPTION
I started writing out what I was considering in https://github.com/dotnet/source-build/issues/2034, but I wrote enough that it fits better in the docs. Also, line review comments are always nice, rather than just one issue thread.

So far I'd only expect these to be needed for dotnet/runtime -> dotnet/aspnetcore -> dotnet/installer, perhaps dotnet/sdk -> dotnet/installer. (Also dotnet/runtime -> repos that need platform extensions libraries.)

/cc @MichaelSimons @omajid 