### PR TITLE
Fix broken Arcade Powered Source-build link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To build the full .NET SDK from source, pick a specific Git tag with your desire
 * [`release/3.1`](https://github.com/dotnet/source-build/tree/release/3.1)
 * [`release/2.1`](https://github.com/dotnet/source-build/tree/release/2.1)
 
-The current branch is a work in progress that produces several .NET SDK components for [Arcade-powered source-build](./Documentation/planning/arcade-powered-source-build/). Once Arcade-powered source-build is complete, it will allow building a .NET SDK from source directly from the [dotnet/installer](https://github.com/dotnet/installer) repository.
+The current branch is a work in progress that produces several .NET SDK components for [Arcade-powered source-build](Documentation/planning/arcade-powered-source-build). Once Arcade-powered source-build is complete, it will allow building a .NET SDK from source directly from the [dotnet/installer](https://github.com/dotnet/installer) repository.
 
 ## Using this repository
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To build the full .NET SDK from source, pick a specific Git tag with your desire
 * [`release/3.1`](https://github.com/dotnet/source-build/tree/release/3.1)
 * [`release/2.1`](https://github.com/dotnet/source-build/tree/release/2.1)
 
-The current branch is a work in progress that produces several .NET SDK components for [Arcade-powered source-build](Documentation\planning\arcade-powered-source-build). Once Arcade-powered source-build is complete, it will allow building a .NET SDK from source directly from the [dotnet/installer](https://github.com/dotnet/installer) repository.
+The current branch is a work in progress that produces several .NET SDK components for [Arcade-powered source-build](./Documentation/planning/arcade-powered-source-build/). Once Arcade-powered source-build is complete, it will allow building a .NET SDK from source directly from the [dotnet/installer](https://github.com/dotnet/installer) repository.
 
 ## Using this repository
 


### PR DESCRIPTION
The original `[Arcade-powered source-build](Documentation\planning\arcade-powered-source-build)` link produces a 405 because it gets translated to `https://github.com/dotnet/source-build/blob/master/Documentation%5Cplanning%5Carcade-powered-source-build` in GitHub.   Other tooling handles the back slashes just fine like VsCode.