### PR TITLE
Add misc exclude build triggers

### DIFF
--- a/.vsts.pipelines/builds/ci.yml
+++ b/.vsts.pipelines/builds/ci.yml
@@ -4,12 +4,22 @@ trigger:
     include:
     - master
     - release/*
+  paths:
+    exclude:
+    - .github/*
+    - Documentation/*
+    - '*.md'
 
 pr:
   branches:
     include:
     - master
     - release/*
+  paths:
+    exclude:
+    - .github/*
+    - Documentation/*
+    - '*.md'
 
 stages:
 - stage: build


### PR DESCRIPTION
Add exclude paths to the build triggers so that CI/PR validation does not get run for documentation only changes.   Every time the ArPow implementation status is updated CI is currently running.