### PR TITLE
Download single artifact in PrepareArtifacts

### DIFF
--- a/.vsts.pipelines/stages/prepare-artifacts.yml
+++ b/.vsts.pipelines/stages/prepare-artifacts.yml
@@ -47,6 +47,7 @@ stages:
           downloadType: single
           artifactName: ${{ coalesce(gather.artifactName, format('Tarball {0}', gather.job)) }}
           downloadPath: $(nonportableSourceBuiltStageDir)
+          itemPattern: /*/Private.SourceBuilt.Artifacts.*.tar.gz
           allowPartiallySucceededBuilds: true
 
     - task: DownloadBuildArtifacts@0
@@ -56,6 +57,7 @@ stages:
         downloadType: single
         artifactName: 'Tarball ${{ parameters.gatherPortableJob }}'
         downloadPath: $(portableSourceBuiltStageDir)
+        itemPattern: /*/Private.SourceBuilt.Artifacts.*.tar.gz
         allowPartiallySucceededBuilds: true
 
     - script: |


### PR DESCRIPTION
PrepareArtifacts downloads all artifacts from a given build job.  This is causing the host to run out of space.  Add an itemPattern to just download Private.SourceBuilt.Artifacts.