### PR TITLE
Add a test to verify xml/intellisense docs are present

### DIFF
--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -334,6 +334,219 @@ function runWebTests() {
     doCommand F# webapi "$@" new restore build run multi-rid-publish
 }
 
+function runXmlDocTests() {
+    targetingPacksDir="$dotnetDir/packs/"
+    echo "Looking for xml docs in targeting packs in $targetingPacksDir"
+
+    netstandardIgnoreList=(
+        Microsoft.Win32.Primitives.xml
+        mscorlib.xml
+        System.AppContext.xml
+        System.Buffers.xml
+        System.Collections.Concurrent.xml
+        System.Collections.NonGeneric.xml
+        System.Collections.Specialized.xml
+        System.Collections.xml
+        System.ComponentModel.Composition.xml
+        System.ComponentModel.EventBasedAsync.xml
+        System.ComponentModel.Primitives.xml
+        System.ComponentModel.TypeConverter.xml
+        System.ComponentModel.xml
+        System.Console.xml
+        System.Core.xml
+        System.Data.Common.xml
+        System.Data.xml
+        System.Diagnostics.Contracts.xml
+        System.Diagnostics.Debug.xml
+        System.Diagnostics.FileVersionInfo.xml
+        System.Diagnostics.Process.xml
+        System.Diagnostics.StackTrace.xml
+        System.Diagnostics.TextWriterTraceListener.xml
+        System.Diagnostics.Tools.xml
+        System.Diagnostics.TraceSource.xml
+        System.Diagnostics.Tracing.xml
+        System.Drawing.Primitives.xml
+        System.Drawing.xml
+        System.Dynamic.Runtime.xml
+        System.Globalization.Calendars.xml
+        System.Globalization.Extensions.xml
+        System.Globalization.xml
+        System.IO.Compression.FileSystem.xml
+        System.IO.Compression.xml
+        System.IO.Compression.ZipFile.xml
+        System.IO.FileSystem.DriveInfo.xml
+        System.IO.FileSystem.Primitives.xml
+        System.IO.FileSystem.Watcher.xml
+        System.IO.FileSystem.xml
+        System.IO.IsolatedStorage.xml
+        System.IO.MemoryMappedFiles.xml
+        System.IO.Pipes.xml
+        System.IO.UnmanagedMemoryStream.xml
+        System.IO.xml
+        System.Linq.Expressions.xml
+        System.Linq.Parallel.xml
+        System.Linq.Queryable.xml
+        System.Linq.xml
+        System.Memory.xml
+        System.Net.Http.xml
+        System.Net.NameResolution.xml
+        System.Net.NetworkInformation.xml
+        System.Net.Ping.xml
+        System.Net.Primitives.xml
+        System.Net.Requests.xml
+        System.Net.Security.xml
+        System.Net.Sockets.xml
+        System.Net.WebHeaderCollection.xml
+        System.Net.WebSockets.Client.xml
+        System.Net.WebSockets.xml
+        System.Net.xml
+        System.Numerics.Vectors.xml
+        System.Numerics.xml
+        System.ObjectModel.xml
+        System.Reflection.DispatchProxy.xml
+        System.Reflection.Emit.ILGeneration.xml
+        System.Reflection.Emit.Lightweight.xml
+        System.Reflection.Emit.xml
+        System.Reflection.Extensions.xml
+        System.Reflection.Primitives.xml
+        System.Reflection.xml
+        System.Resources.Reader.xml
+        System.Resources.ResourceManager.xml
+        System.Resources.Writer.xml
+        System.Runtime.CompilerServices.VisualC.xml
+        System.Runtime.Extensions.xml
+        System.Runtime.Handles.xml
+        System.Runtime.InteropServices.RuntimeInformation.xml
+        System.Runtime.InteropServices.xml
+        System.Runtime.Numerics.xml
+        System.Runtime.Serialization.Formatters.xml
+        System.Runtime.Serialization.Json.xml
+        System.Runtime.Serialization.Primitives.xml
+        System.Runtime.Serialization.xml
+        System.Runtime.Serialization.Xml.xml
+        System.Runtime.xml
+        System.Security.Claims.xml
+        System.Security.Cryptography.Algorithms.xml
+        System.Security.Cryptography.Csp.xml
+        System.Security.Cryptography.Encoding.xml
+        System.Security.Cryptography.Primitives.xml
+        System.Security.Cryptography.X509Certificates.xml
+        System.Security.Principal.xml
+        System.Security.SecureString.xml
+        System.ServiceModel.Web.xml
+        System.Text.Encoding.Extensions.xml
+        System.Text.Encoding.xml
+        System.Text.RegularExpressions.xml
+        System.Threading.Overlapped.xml
+        System.Threading.Tasks.Extensions.xml
+        System.Threading.Tasks.Parallel.xml
+        System.Threading.Tasks.xml
+        System.Threading.ThreadPool.xml
+        System.Threading.Thread.xml
+        System.Threading.Timer.xml
+        System.Threading.xml
+        System.Transactions.xml
+        System.ValueTuple.xml
+        System.Web.xml
+        System.Windows.xml
+        System.xml
+        System.Xml.Linq.xml
+        System.Xml.ReaderWriter.xml
+        System.Xml.Serialization.xml
+        System.Xml.XDocument.xml
+        System.Xml.xml
+        System.Xml.XmlDocument.xml
+        System.Xml.XmlSerializer.xml
+        System.Xml.XPath.XDocument.xml
+        System.Xml.XPath.xml
+    )
+
+    netcoreappIgnoreList=(
+        Microsoft.VisualBasic.xml
+        netstandard.xml
+        System.AppContext.xml
+        System.Buffers.xml
+        System.ComponentModel.DataAnnotations.xml
+        System.Configuration.xml
+        System.Core.xml
+        System.Data.DataSetExtensions.xml
+        System.Data.xml
+        System.Diagnostics.Debug.xml
+        System.Diagnostics.Tools.xml
+        System.Drawing.xml
+        System.Dynamic.Runtime.xml
+        System.Globalization.Calendars.xml
+        System.Globalization.Extensions.xml
+        System.Globalization.xml
+        System.IO.Compression.FileSystem.xml
+        System.IO.FileSystem.Primitives.xml
+        System.IO.UnmanagedMemoryStream.xml
+        System.IO.xml
+        System.Net.xml
+        System.Numerics.xml
+        System.Reflection.Extensions.xml
+        System.Reflection.xml
+        System.Resources.Reader.xml
+        System.Resources.ResourceManager.xml
+        System.Runtime.Extensions.xml
+        System.Runtime.Handles.xml
+        System.Runtime.Serialization.xml
+        System.Security.Principal.xml
+        System.Security.SecureString.xml
+        System.Security.xml
+        System.ServiceModel.Web.xml
+        System.ServiceProcess.xml
+        System.Text.Encoding.xml
+        System.Threading.Tasks.Extensions.xml
+        System.Threading.Tasks.xml
+        System.Threading.Timer.xml
+        System.Transactions.xml
+        System.ValueTuple.xml
+        System.Web.xml
+        System.Windows.xml
+        System.xml
+        System.Xml.Linq.xml
+        System.Xml.Serialization.xml
+        System.Xml.xml
+        System.Xml.XmlDocument.xml
+    )
+
+    error=0
+    while IFS= read -r -d '' dllFile; do
+        xmlDocFile=${dllFile%.*}.xml
+        skip=0
+        if [[ "$xmlDocFile" == *"/packs/Microsoft.NETCore.App.Ref"* ]]; then
+            xmlFileBasename=$(basename "$xmlDocFile")
+            for ignoreItem in "${netcoreappIgnoreList[@]}"; do
+                if [[ "$ignoreItem" == "$xmlFileBasename" ]]; then
+                    skip=1;
+                    break
+                fi
+            done
+        fi
+        if [[ "$xmlDocFile" == *"/packs/NETStandard.Library.Ref"* ]]; then
+            xmlFileBasename=$(basename "$xmlDocFile")
+            for ignoreItem in "${netstandardIgnoreList[@]}"; do
+                if [[ "$ignoreItem" == "$xmlFileBasename" ]]; then
+                    skip=1;
+                    break
+                fi
+            done
+        fi
+        if [[ $skip == 0 ]] && [[ ! -f "$xmlDocFile" ]]; then
+            error=1
+            echo "error: missing $xmlDocFile"
+        fi
+    done < <(find "$targetingPacksDir" -name '*.dll' -print0)
+
+    if [[ $error != 0 ]]; then
+        echo "error: Missing xml documents"
+        exit 1
+    else
+        echo "All expected xml docs are present"
+    fi
+}
+
 function resetCaches() {
     rm -rf "$testingHome"
     mkdir "$testingHome"
@@ -455,5 +668,7 @@ if [ "$excludeOnlineTests" == "false" ]; then
     copyRestoredPackages
     echo "ONLINE RESTORE SOURCE - ALL TESTS PASSED!"
 fi
+
+runXmlDocTests
 
 echo "ALL TESTS PASSED!"

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -7,7 +7,7 @@ VERSION_PREFIX=5.0
 # See https://github.com/dotnet/source-build/issues/579, this version
 # needs to be compatible with the runtime produced from source-build
 DEV_CERTS_VERSION_DEFAULT=5.0.0-preview.3
-__ROOT_REPO=$(cat "$SCRIPT_ROOT/artifacts/obj/rootrepo.txt" | sed 's/\r$//') # remove CR if mounted repo on Windows drive
+__ROOT_REPO=$(sed 's/\r$//' "$SCRIPT_ROOT/artifacts/obj/rootrepo.txt") # remove CR if mounted repo on Windows drive
 executingUserHome=${HOME:-}
 
 echo "RID to test: ${targetRid?not specified. Use ./build.sh --run-smoke-test to detect RID, or specify manually.}"
@@ -91,9 +91,9 @@ while :; do
         break
     fi
 
-    lowerI="$(echo $1 | awk '{print tolower($0)}')"
+    lowerI="$(echo "$1" | awk '{print tolower($0)}')"
     case $lowerI in
-        -?|-h|--help)
+        '-?'|-h|--help)
             usage
             exit 0
             ;;
@@ -215,7 +215,7 @@ function doCommand() {
         elif [[ "$1" == "run" && "$proj" =~ ^(web|mvc|webapi|razor|blazorwasm|blazorserver)$ ]]; then
             # A separate log file that we will over-write all the time.
             exitLogFile="$testingDir/exitLogFile"
-            echo > $exitLogFile
+            echo > "$exitLogFile"
             # Run an application in the background and redirect its
             # stdout+stderr to a separate process (tee). The tee process
             # writes its input to 2 files:
@@ -245,7 +245,7 @@ function doCommand() {
         elif [ "$1" == "multi-rid-publish" ]; then
             runPublishScenarios() {
                 "${dotnetCmd}" publish --self-contained false /bl:"${binlogPrefix}publish-fx-dep.binlog"
-                "${dotnetCmd}" publish --self-contained true -r $targetRid /bl:"${binlogPrefix}publish-self-contained-${targetRid}.binlog"
+                "${dotnetCmd}" publish --self-contained true -r "$targetRid" /bl:"${binlogPrefix}publish-self-contained-${targetRid}.binlog"
                 "${dotnetCmd}" publish --self-contained true -r linux-x64 /bl:"${binlogPrefix}publish-self-contained-portable.binlog"
             }
             if [ "$projectOutput" == "true" ]; then
@@ -396,7 +396,7 @@ echo "<Project />" | tee Directory.Build.props > Directory.Build.targets
 # Unzip dotnet if the dotnetDir is not specified
 if [ "$dotnetDir" == "" ]; then
     OUTPUT_DIR="$SCRIPT_ROOT/artifacts/$buildArch/$configuration/"
-    DOTNET_TARBALL="$(ls ${OUTPUT_DIR}dotnet-sdk-${VERSION_PREFIX}*)"
+    DOTNET_TARBALL="$(ls "${OUTPUT_DIR}${TARBALL_PREFIX}${VERSION_PREFIX}"*)"
 
     mkdir -p "$cliDir"
     tar xzf "$DOTNET_TARBALL" -C "$cliDir"
@@ -415,7 +415,7 @@ export NUGET_PACKAGES="$restoredPackagesDir"
 SOURCE_BUILT_PKGS_PATH="$SCRIPT_ROOT/artifacts/obj/$buildArch/$configuration/blob-feed/packages/"
 export DOTNET_ROOT="$dotnetDir"
 # OSX also requires DOTNET_ROOT to be on the PATH
-if [ `uname` == 'Darwin' ]; then
+if [ "$(uname)" == 'Darwin' ]; then
     export PATH="$dotnetDir:$PATH"
 fi
 


### PR DESCRIPTION
This probably should be reviewed commit by commit. The first commit is a cleanup fixing some warnings pointed out by shellcheck. The second commit is the test.
    
This assumes all the xml docs are only present in the targeting packs, and not anywhere else.
    
I am not sure if the ignore list is correct: do all the packages listed look okay?
    
Fixes: #2127

