### PR TITLE
[release/3.1] Fix use of a simple directory name with build-source-tarball.sh

### DIFF
--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -14,6 +14,15 @@ usage() {
     echo "use -- to send the remaining arguments to build.sh"
 }
 
+getrealpath()
+{
+    if command -v realpath > /dev/null; then
+        realpath $1
+    else
+        readlink -f $1
+    fi
+}
+
 if [ -z "${1:-}" ]; then
     usage
     exit 1
@@ -117,7 +126,7 @@ while [[ -h $fullTarballRoot ]]; do
   # symlink file was located
   [[ $fullTarballRoot != /* ]] && fullTarballRoot="$SCRIPT_ROOT/$fullTarballRoot"
 done
-export FULL_TARBALL_ROOT="$fullTarballRoot"
+export FULL_TARBALL_ROOT="$(getrealpath "$fullTarballRoot")"
 
 if [ -e "$TARBALL_ROOT" ]; then
     echo "info: '$TARBALL_ROOT' already exists"


### PR DESCRIPTION
Running

    ./build-source-tarball.sh dotnet-v3.1.114-SDK-original

Leads to source-build trying to use
source-build/packages/restored/microsoft.dotnet.arcade.sdk/1.0.0-beta.20113.5/tools/dotnet-v3.1.114-SDK-original
instead of a top-level dotnet-v3.1.114-SDK-original directory.

Fix that.

Fixes: #2130