### PR TITLE
[release/5.0] Print and store versions at end of every build

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -5,6 +5,7 @@
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="WriteUsageBurndownData" />
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="ReplaceTextInFile" />
   <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="DownloadFileSB" />
+  <UsingTask AssemblyFile="$(XPlatSourceBuildTasksAssembly)" TaskName="ParseDotNetVersions" />
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
@@ -135,6 +136,45 @@
                     PoisonReportOutputFilePath="$(PoisonUsageReportFile)" />
 
     <WriteLinesToFile File="$(CompletedSemaphorePath)ReportPoisonUsage.complete" Overwrite="true" />
+  </Target>
+
+  <Target Name="WriteVersionsToFile"
+          AfterTargets="Build">
+
+    <ItemGroup>
+      <FinalSdkTarball Include="$(OutputPath)\dotnet-sdk-$(MajorVersion)*$(TarBallExtension)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <ExtractedPath>$(BaseOutputPath)\extracted-sdk\</ExtractedPath>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(ExtractedPath)" />
+
+    <Exec Command="tar xf @(FinalSdkTarball) -C $(ExtractedPath)" />
+
+    <ParseDotNetVersions SdkRootDirectory="$(ExtractedPath)">
+      <Output TaskParameter="SdkVersion" PropertyName="BuiltSdkVersion" />
+      <Output TaskParameter="AspNetCoreVersion" PropertyName="BuiltAspNetCoreVersion" />
+      <Output TaskParameter="RuntimeVersion" PropertyName="BuiltRuntimeVersion" />
+    </ParseDotNetVersions>
+
+    <Message Text="Build Info:" Importance="High"/>
+    <Message Text="  SDK Version: $(BuiltSdkVersion)" Importance="High"/>
+    <Message Text="  ASP.NET Core Version: $(BuiltAspNetCoreVersion)" Importance="High"/>
+    <Message Text="  Runtime Version: $(BuiltRuntimeVersion)" Importance="High"/>
+
+    <WriteLinesToFile Lines="$(BuiltSdkVersion)" File="$(BaseOutputPath)\build-info\SdkVersion.txt" Overwrite="True" />
+    <WriteLinesToFile Lines="$(BuiltAspNetCoreVersion)" File="$(BaseOutputPath)\build-info\AspNetCoreVersion.txt" Overwrite="True" />
+    <WriteLinesToFile Lines="$(BuiltRuntimeVersion)" File="$(BaseOutputPath)\build-info\RuntimeVersion.txt" Overwrite="True" />
+
+    <Error Text="Mismatch in SDK version between what was built ($(BuiltSdkVersion)) and what's in Version.props ($(SdkProductVersion))"
+           Condition="'$(BuiltSdkVersion)' != '$(SdkProductVersion)'" />
+    <Error Text="Mismatch in ASP.NET Core version between what was built ($(BuiltAspNetCoreVersion)) and what's in Version.props ($(AspNetCoreProductVersion))"
+           Condition="'$(BuiltAspNetCoreVersion)' != '$(AspNetCoreProductVersion)'" />
+    <Error Text="Mismatch in Runtime version between what was built ($(BuiltRuntimeVersion)) and what's in Version.props ($(RuntimeProductVersion))"
+           Condition="'$(BuiltRuntimeVersion)' != '$(RuntimeProductVersion)'" />
+
   </Target>
 
   <Target Name="GeneratePrebuiltBurndownData"

--- a/build.proj
+++ b/build.proj
@@ -138,7 +138,7 @@
     <WriteLinesToFile File="$(CompletedSemaphorePath)ReportPoisonUsage.complete" Overwrite="true" />
   </Target>
 
-  <Target Name="WriteVersionsToFile"
+  <Target Name="VerifyAndWriteVersionsToFile"
           AfterTargets="Build">
 
     <ItemGroup>
@@ -146,7 +146,8 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <ExtractedPath>$(BaseOutputPath)\extracted-sdk\</ExtractedPath>
+      <!-- Shared path with smoke-test.sh -->
+      <ExtractedPath>$(BaseOutputPath)\builtCli\</ExtractedPath>
     </PropertyGroup>
 
     <MakeDir Directories="$(ExtractedPath)" />

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -51,7 +51,8 @@ excludeLocalTests=false
 excludeOnlineTests=false
 devCertsVersion="$DEV_CERTS_VERSION_DEFAULT"
 testingDir="$SCRIPT_ROOT/testing-smoke"
-cliDir="$testingDir/builtCli"
+# Shared path with build.proj
+cliDir="$SCRIPT_ROOT/artifacts/builtCli"
 logFile="$testingDir/smoke-test.log"
 restoredPackagesDir="$testingDir/packages"
 testingHome="$testingDir/home"
@@ -611,11 +612,14 @@ echo "<Project />" | tee Directory.Build.props > Directory.Build.targets
 
 # Unzip dotnet if the dotnetDir is not specified
 if [ "$dotnetDir" == "" ]; then
-    OUTPUT_DIR="$SCRIPT_ROOT/artifacts/$buildArch/$configuration/"
-    DOTNET_TARBALL="$(ls "${OUTPUT_DIR}${TARBALL_PREFIX}${VERSION_PREFIX}"*)"
+    # It's possible that build.proj extracted the just-built dotnet tarball for other processing already
+    if [ ! -d "$cliDir" ]; then
+        OUTPUT_DIR="$SCRIPT_ROOT/artifacts/$buildArch/$configuration/"
+        DOTNET_TARBALL="$(ls "${OUTPUT_DIR}${TARBALL_PREFIX}${VERSION_PREFIX}"*)"
 
-    mkdir -p "$cliDir"
-    tar xzf "$DOTNET_TARBALL" -C "$cliDir"
+        mkdir -p "$cliDir"
+        tar xzf "$DOTNET_TARBALL" -C "$cliDir"
+    fi
     dotnetDir="$cliDir"
 else
     if ! [[ "$dotnetDir" = /* ]]; then

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/ParseDotNetVersions.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/ParseDotNetVersions.cs
@@ -30,30 +30,28 @@ namespace Microsoft.DotNet.Build.Tasks
 
         public override bool Execute()
         {
-
             var pathToDotNet = Path.Join(SdkRootDirectory, "dotnet");
+
             SdkVersion = ExecuteDotNetCommand(SdkRootDirectory,
                                               pathToDotNet,
                                               new List<string> { "--list-sdks" })
                             .First()
                             .Split(" ")
                             .First();
-            AspNetCoreVersion = ExecuteDotNetCommand(SdkRootDirectory,
-                                                     pathToDotNet,
-                                                     new List<string> { "--list-runtimes" })
-                                    .Where(line => line.Contains("Microsoft.AspNetCore.App"))
-                                    .First()
-                                    .Split(" ")
-                                    .Skip(1)
-                                    .First();
-            RuntimeVersion = ExecuteDotNetCommand(SdkRootDirectory,
-                                                  pathToDotNet,
-                                                  new List<string> { "--list-runtimes"})
-                                .Where(line => line.Contains("Microsoft.NETCore.App"))
-                                .First()
-                                .Split(" ")
-                                .Skip(1)
-                                .First();
+
+            var runtimesOutput = ExecuteDotNetCommand(SdkRootDirectory,
+                                                      pathToDotNet,
+                                                      new List<string> { "--list-runtimes" });
+
+            AspNetCoreVersion = runtimesOutput
+                .First(line => line.Contains("Microsoft.AspNetCore.App"))
+                .Split(" ")
+                .ElementAt(1);
+
+            RuntimeVersion = runtimesOutput
+                .First(line => line.Contains("Microsoft.NETCore.App"))
+                .Split(" ")
+                .ElementAt(1);
 
             return true;
         }

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/ParseDotNetVersions.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/ParseDotNetVersions.cs
@@ -78,7 +78,7 @@ namespace Microsoft.DotNet.Build.Tasks
             _process.StartInfo.RedirectStandardOutput = true;
             _process.StartInfo.UseShellExecute = false;
             _process.Start();
-            returnData = _process.StandardOutput.ReadToEnd().Split('\n');
+            returnData = _process.StandardOutput.ReadToEnd().Split(Environment.NewLine);
             _process.WaitForExit();
             return returnData;
         }

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/ParseDotNetVersions.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/ParseDotNetVersions.cs
@@ -1,0 +1,87 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    /*
+     * This task parses the versions in a .NET SDK
+     */
+    public class ParseDotNetVersions : Task
+    {
+        [Required]
+        public string SdkRootDirectory { get; set; }
+
+        [Output]
+        public string SdkVersion { get; set; }
+        [Output]
+        public string AspNetCoreVersion { get; set; }
+        [Output]
+        public string RuntimeVersion { get; set; }
+
+        public override bool Execute()
+        {
+
+            var pathToDotNet = Path.Join(SdkRootDirectory, "dotnet");
+            SdkVersion = ExecuteDotNetCommand(SdkRootDirectory,
+                                              pathToDotNet,
+                                              new List<string> { "--list-sdks" })
+                            .First()
+                            .Split(" ")
+                            .First();
+            AspNetCoreVersion = ExecuteDotNetCommand(SdkRootDirectory,
+                                                     pathToDotNet,
+                                                     new List<string> { "--list-runtimes" })
+                                    .Where(line => line.Contains("Microsoft.AspNetCore.App"))
+                                    .First()
+                                    .Split(" ")
+                                    .Skip(1)
+                                    .First();
+            RuntimeVersion = ExecuteDotNetCommand(SdkRootDirectory,
+                                                  pathToDotNet,
+                                                  new List<string> { "--list-runtimes"})
+                                .Where(line => line.Contains("Microsoft.NETCore.App"))
+                                .First()
+                                .Split(" ")
+                                .Skip(1)
+                                .First();
+
+            return true;
+        }
+
+        /// <summary>
+        /// Executes a dotnet command and returns the result.
+        /// </summary>
+        /// <param name="workingDirectory">The working directory for the dotnet command.</param>
+        /// <param name="command">The complete path to the dotnet command to execute.</param>
+        /// <param name="argumentList">The arguments to the dotnet command to execute.</param>
+        /// <returns>An array of the output lines of the dotnet command.</returns>
+        private string[] ExecuteDotNetCommand(string workingDirectory, string command, List<string> argumentList)
+        {
+            string[] returnData;
+            Process _process = new Process();
+            _process.StartInfo.FileName = command;
+            foreach (string argument in argumentList)
+            {
+                _process.StartInfo.ArgumentList.Add(argument);
+            }
+            _process.StartInfo.WorkingDirectory = workingDirectory;
+            _process.StartInfo.RedirectStandardOutput = true;
+            _process.StartInfo.UseShellExecute = false;
+            _process.Start();
+            returnData = _process.StandardOutput.ReadToEnd().Split('\n');
+            _process.WaitForExit();
+            return returnData;
+        }
+
+    }
+}


### PR DESCRIPTION
This makes it easier to visually confirm what was built:

    Build Info:
      SDK Version: 5.0.202
      ASP.NET Core Version: 5.0.5
      Runtime Version: 5.0.5

And also stores these values in named version files for later use.

The build output on the console looks like this:

```
  Build Info:
    SDK Version: 5.0.202
    ASP.NET Core Version: 5.0.5
    Runtime Version: 5.0.5

Build succeeded.

/home/omajid/devel/dotnet/source-build/packages/restored/microsoft.dotnet.arcade.sdk/5.0.0-beta.20426.4/tools/ProjectLayout.props(8,3): warning MSB4011: "/home/omajid/devel/dotnet/source-build/packages/restored/microsoft.dotnet.arcade.sdk/5.0.0-beta.20426.4/tools/RepoLayout.props" cannot be imported again. It was already imported at "/home/omajid/devel/dotnet/source-build/packages/restored/microsoft.dotnet.arcade.sdk/5.0.0-beta.20426.4/tools/Build.proj (49,3)". This is most likely a build authoring error. This subsequent import will be ignored.
<Lots of warnings
/home/omajid/devel/dotnet/source-build/repos/Directory.Build.targets(639,5): warning MSB4181: The "ValidateUsageAgainstBaseline" task returned false but did not log an error. [/home/omajid/devel/dotnet/source-build/repos/known-good.proj]
    7 Warning(s)
    0 Error(s)

Time Elapsed 00:47:44.01
```

And the files look like this:

```
$ find artifacts/build-info/ -iname '*.txt' -exec echo {} \; -exec cat {} \;
artifacts/build-info/SdkVersion.txt
5.0.202
artifacts/build-info/RuntimeVersion.txt
5.0.5
artifacts/build-info/AspNetCoreVersion.txt
5.0.5
```

Fixes: #600