### PR TITLE
[release/5.0] Remove dependency on personal repo for Newtonsoft.Json 9.0.1 and 12.0.2

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -107,8 +107,8 @@
     </Dependency>
     <!-- external dependencies, not handled by Maestro/Arcade -->
     <Dependency Name="Newtonsoft.Json" Version="12.0.2">
-      <Uri>https://github.com/adaggarwal/Newtonsoft.Json</Uri>
-      <Sha>cac0690ad133c5e166ce5642dc71175791404fad</Sha>
+      <Uri>https://github.com/JamesNK/Newtonsoft.Json.git</Uri>
+      <Sha>4ab34b0461fb595805d092a46a58f35f66c84d6a</Sha>
       <RepoName>newtonsoft-json</RepoName>
     </Dependency>
     <Dependency Name="Microsoft.DiaSymReader" Version="1.3.0">
@@ -118,8 +118,8 @@
     </Dependency>
     <!-- additional Newtonsoft version to ease out individual repo updates to use current source-build version-->
     <Dependency Name="Newtonsoft.Json" Version="9.0.1">
-      <Uri>https://github.com/adaggarwal/Newtonsoft.Json</Uri>
-      <Sha>e43dae94c26f0c30e9095327a3a9eac87193923d</Sha>
+      <Uri>https://github.com/JamesNK/Newtonsoft.Json.git</Uri>
+      <Sha>e5ac9a8473dfdefb8fe2cddae433a9aaa94a5b37</Sha>
       <RepoName>newtonsoft-json901</RepoName>
     </Dependency>
     <!-- dependencies that will go away soon -->

--- a/patches/newtonsoft-json/0001-Updated-AssemblyVersion-FileVersion-Version-Prefix-a.patch
+++ b/patches/newtonsoft-json/0001-Updated-AssemblyVersion-FileVersion-Version-Prefix-a.patch
@@ -1,0 +1,32 @@
+From 252b0a02a539d144a246267010b91870c86744e8 Mon Sep 17 00:00:00 2001
+From: adaggarwal <aditya.aggarwal@microsoft.com>
+Date: Tue, 28 May 2019 14:48:10 -0500
+Subject: [PATCH 1/2] Updated AssemblyVersion, FileVersion, Version Prefix and
+ Version Suffix
+
+---
+ Src/Newtonsoft.Json/Newtonsoft.Json.csproj | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Src/Newtonsoft.Json/Newtonsoft.Json.csproj b/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
+index 12e589b8..f5264490 100644
+--- a/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
++++ b/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
+@@ -4,10 +4,10 @@
+     <TargetFrameworks Condition="'$(LibraryFrameworks)'!=''">$(LibraryFrameworks)</TargetFrameworks>
+     <LangVersion>latest</LangVersion>
+     <!-- version numbers will be updated by build -->
+-    <AssemblyVersion>11.0.0.0</AssemblyVersion>
+-    <FileVersion>11.0.1</FileVersion>
+-    <VersionPrefix>11.0.1</VersionPrefix>
+-    <VersionSuffix>beta2</VersionSuffix>
++    <AssemblyVersion>12.0.0.0</AssemblyVersion>
++    <FileVersion>12.0.2</FileVersion>
++    <VersionPrefix>12.0.2</VersionPrefix>
++    <VersionSuffix></VersionSuffix>
+     <Authors>James Newton-King</Authors>
+     <Company>Newtonsoft</Company>
+     <Product>Json.NET</Product>
+-- 
+2.30.2
+

--- a/patches/newtonsoft-json/0002-removed-ruleset-and-dependency-on-a-couple-packages.patch
+++ b/patches/newtonsoft-json/0002-removed-ruleset-and-dependency-on-a-couple-packages.patch
@@ -1,0 +1,40 @@
+From cac0690ad133c5e166ce5642dc71175791404fad Mon Sep 17 00:00:00 2001
+From: adaggarw <aditya.aggarwal@microsoft.com>
+Date: Wed, 19 Jun 2019 15:43:39 +0000
+Subject: [PATCH 2/2] removed ruleset and dependency on a couple packages.
+
+---
+ Src/Newtonsoft.Json/Newtonsoft.Json.csproj | 7 +------
+ 1 file changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/Src/Newtonsoft.Json/Newtonsoft.Json.csproj b/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
+index f5264490..bd3b3b11 100644
+--- a/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
++++ b/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
+@@ -28,16 +28,11 @@
+     <MinClientVersion>2.12</MinClientVersion>
+     <IncludeSymbols>true</IncludeSymbols>
+     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+-    <CodeAnalysisRuleset>Newtonsoft.Json.ruleset</CodeAnalysisRuleset>
+   </PropertyGroup>
+   <ItemGroup>
+     <None Remove="**\*.orig" />
+     <None Include="..\..\LICENSE.md" Pack="true" PackagePath="LICENSE.md" />
+   </ItemGroup>
+-  <ItemGroup>
+-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.2" PrivateAssets="All" />
+-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
+-  </ItemGroup> 
+   <PropertyGroup Condition="'$(TargetFramework)'=='net45'">
+     <AssemblyTitle>Json.NET</AssemblyTitle>
+     <DefineConstants>HAVE_ADO_NET;HAVE_APP_DOMAIN;HAVE_ASYNC;HAVE_BIG_INTEGER;HAVE_BINARY_FORMATTER;HAVE_BINARY_SERIALIZATION;HAVE_BINARY_EXCEPTION_SERIALIZATION;HAVE_CAS;HAVE_CHAR_TO_LOWER_WITH_CULTURE;HAVE_CHAR_TO_STRING_WITH_CULTURE;HAVE_COM_ATTRIBUTES;HAVE_COMPONENT_MODEL;HAVE_CONCURRENT_COLLECTIONS;HAVE_COVARIANT_GENERICS;HAVE_DATA_CONTRACTS;HAVE_DATE_TIME_OFFSET;HAVE_DB_NULL_TYPE_CODE;HAVE_DYNAMIC;HAVE_EMPTY_TYPES;HAVE_ENTITY_FRAMEWORK;HAVE_EXPRESSIONS;HAVE_FAST_REVERSE;HAVE_FSHARP_TYPES;HAVE_FULL_REFLECTION;HAVE_GUID_TRY_PARSE;HAVE_HASH_SET;HAVE_ICLONEABLE;HAVE_ICONVERTIBLE;HAVE_IGNORE_DATA_MEMBER_ATTRIBUTE;HAVE_INOTIFY_COLLECTION_CHANGED;HAVE_INOTIFY_PROPERTY_CHANGING;HAVE_ISET;HAVE_LINQ;HAVE_MEMORY_BARRIER;HAVE_METHOD_IMPL_ATTRIBUTE;HAVE_NON_SERIALIZED_ATTRIBUTE;HAVE_READ_ONLY_COLLECTIONS;HAVE_REFLECTION_EMIT;HAVE_SECURITY_SAFE_CRITICAL_ATTRIBUTE;HAVE_SERIALIZATION_BINDER_BIND_TO_NAME;HAVE_STREAM_READER_WRITER_CLOSE;HAVE_STRING_JOIN_WITH_ENUMERABLE;HAVE_TIME_SPAN_PARSE_WITH_CULTURE;HAVE_TIME_SPAN_TO_STRING_WITH_CULTURE;HAVE_TIME_ZONE_INFO;HAVE_TRACE_WRITER;HAVE_TYPE_DESCRIPTOR;HAVE_UNICODE_SURROGATE_DETECTION;HAVE_VARIANT_TYPE_PARAMETERS;HAVE_VERSION_TRY_PARSE;HAVE_XLINQ;HAVE_XML_DOCUMENT;HAVE_XML_DOCUMENT_TYPE;HAVE_CONCURRENT_DICTIONARY;$(AdditionalConstants)</DefineConstants>
+@@ -93,4 +88,4 @@
+     <NugetTargetMoniker>.NETPortable,Version=v0.0,Profile=Profile259</NugetTargetMoniker>
+     <LanguageTargets>$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets</LanguageTargets>
+   </PropertyGroup>
+-</Project>
+\ No newline at end of file
++</Project>
+-- 
+2.30.2
+

--- a/patches/newtonsoft-json901/0001-Run-dotnet-migrate-to-generate-Newtonsoft.Json.Dotne.patch
+++ b/patches/newtonsoft-json901/0001-Run-dotnet-migrate-to-generate-Newtonsoft.Json.Dotne.patch
@@ -1,0 +1,327 @@
+From 6f0457994ec9c172691c5b4639573b2cdbc95b51 Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Thu, 31 May 2018 18:50:54 +0000
+Subject: [PATCH 1/3] Run `dotnet migrate` to generate
+ Newtonsoft.Json.Dotnet.csproj
+
+---
+ .../Newtonsoft.Json.Dotnet.csproj             | 137 ++++++++++++++++++
+ .../Newtonsoft.Json.Dotnet.xproj              |  18 ---
+ Src/Newtonsoft.Json/project.json              | 134 -----------------
+ 3 files changed, 137 insertions(+), 152 deletions(-)
+ create mode 100644 Src/Newtonsoft.Json/Newtonsoft.Json.Dotnet.csproj
+ delete mode 100644 Src/Newtonsoft.Json/Newtonsoft.Json.Dotnet.xproj
+ delete mode 100644 Src/Newtonsoft.Json/project.json
+
+diff --git a/Src/Newtonsoft.Json/Newtonsoft.Json.Dotnet.csproj b/Src/Newtonsoft.Json/Newtonsoft.Json.Dotnet.csproj
+new file mode 100644
+index 00000000..797f6371
+--- /dev/null
++++ b/Src/Newtonsoft.Json/Newtonsoft.Json.Dotnet.csproj
+@@ -0,0 +1,137 @@
++<Project Sdk="Microsoft.NET.Sdk">
++
++  <PropertyGroup>
++    <Description>Json.NET is a popular high-performance JSON framework for .NET</Description>
++    <AssemblyTitle>Json.NET</AssemblyTitle>
++    <NeutralLanguage>en-US</NeutralLanguage>
++    <Authors>James Newton-King</Authors>
++    <TargetFrameworks>net45;net40;net35;net20;portable45-net45+win8+wp8+wpa81;portable40-net40+sl5+win8+wp8+wpa81;netstandard1.0</TargetFrameworks>
++    <AssemblyName>Newtonsoft.Json</AssemblyName>
++    <PackageId>Newtonsoft.Json</PackageId>
++    <PackageTags>json</PackageTags>
++    <PackageIconUrl>http://www.newtonsoft.com/content/images/nugeticon.png</PackageIconUrl>
++    <PackageProjectUrl>http://www.newtonsoft.com/json</PackageProjectUrl>
++    <PackageLicenseUrl>https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md</PackageLicenseUrl>
++    <RepositoryType>git</RepositoryType>
++    <RepositoryUrl>git://github.com/JamesNK/Newtonsoft.Json</RepositoryUrl>
++    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
++    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
++    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
++    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
++    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
++    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
++    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
++    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
++  </PropertyGroup>
++
++  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
++    <Reference Include="System.Data" />
++    <Reference Include="System.Numerics" />
++    <Reference Include="System.Runtime.Serialization" />
++    <Reference Include="System.Xml" />
++    <Reference Include="System.Xml.Linq" />
++    <Reference Include="System" />
++    <Reference Include="Microsoft.CSharp" />
++  </ItemGroup>
++
++  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
++    <Reference Include="System.Data" />
++    <Reference Include="System.Numerics" />
++    <Reference Include="System.Runtime.Serialization" />
++    <Reference Include="System.Xml" />
++    <Reference Include="System.Xml.Linq" />
++    <Reference Include="System" />
++    <Reference Include="Microsoft.CSharp" />
++  </ItemGroup>
++
++  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
++    <Reference Include="System.Core" />
++    <Reference Include="System.Data" />
++    <Reference Include="System.Runtime.Serialization" />
++    <Reference Include="System.Xml" />
++    <Reference Include="System.Xml.Linq" />
++    <Reference Include="System" />
++  </ItemGroup>
++
++  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
++    <Reference Include="System.Data" />
++    <Reference Include="System.Xml" />
++    <Reference Include="System" />
++  </ItemGroup>
++
++  <ItemGroup Condition=" '$(TargetFramework)' == 'portable45-net45+win8+wp8+wpa81' ">
++    <Reference Include="Microsoft.CSharp" />
++    <Reference Include="System" />
++    <Reference Include="System.Collections" />
++    <Reference Include="System.Core" />
++    <Reference Include="System.Diagnostics.Debug" />
++    <Reference Include="System.Dynamic.Runtime" />
++    <Reference Include="System.Globalization" />
++    <Reference Include="System.IO" />
++    <Reference Include="System.Linq" />
++    <Reference Include="System.Linq.Expressions" />
++    <Reference Include="System.ObjectModel" />
++    <Reference Include="System.Reflection" />
++    <Reference Include="System.Reflection.Extensions" />
++    <Reference Include="System.Resources.ResourceManager" />
++    <Reference Include="System.Runtime" />
++    <Reference Include="System.Runtime.Extensions" />
++    <Reference Include="System.Runtime.Serialization" />
++    <Reference Include="System.Runtime.Serialization.Primitives" />
++    <Reference Include="System.Text.Encoding" />
++    <Reference Include="System.Text.Encoding.Extensions" />
++    <Reference Include="System.Text.RegularExpressions" />
++    <Reference Include="System.Threading" />
++    <Reference Include="System.Threading.Tasks" />
++    <Reference Include="System.Xml" />
++    <Reference Include="System.Xml.Linq" />
++    <Reference Include="System.Xml.ReaderWriter" />
++    <Reference Include="System.Xml.XDocument" />
++  </ItemGroup>
++
++  <ItemGroup Condition=" '$(TargetFramework)' == 'portable40-net40+sl5+win8+wp8+wpa81' ">
++    <Reference Include="mscorlib" />
++    <Reference Include="System" />
++    <Reference Include="System.Core" />
++    <Reference Include="System.Runtime.Serialization" />
++    <Reference Include="System.Xml" />
++  </ItemGroup>
++
++  <PropertyGroup Condition=" '$(TargetFramework)' == 'portable45-net45+win8+wp8+wpa81' ">
++    <DefineConstants>$(DefineConstants);PORTABLE</DefineConstants>
++  </PropertyGroup>
++
++  <PropertyGroup Condition=" '$(TargetFramework)' == 'portable40-net40+sl5+win8+wp8+wpa81' ">
++    <DefineConstants>$(DefineConstants);PORTABLE40</DefineConstants>
++  </PropertyGroup>
++
++  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
++    <DefineConstants>$(DefineConstants);NETSTANDARD10</DefineConstants>
++  </PropertyGroup>
++
++  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
++    <PackageReference Include="Microsoft.CSharp" Version="4.0.1" />
++    <PackageReference Include="System.Collections" Version="4.0.11" />
++    <PackageReference Include="System.Diagnostics.Debug" Version="4.0.11" />
++    <PackageReference Include="System.Dynamic.Runtime" Version="4.0.11" />
++    <PackageReference Include="System.Globalization" Version="4.0.11" />
++    <PackageReference Include="System.IO" Version="4.1.0" />
++    <PackageReference Include="System.Linq" Version="4.1.0" />
++    <PackageReference Include="System.Linq.Expressions" Version="4.1.0" />
++    <PackageReference Include="System.ObjectModel" Version="4.0.12" />
++    <PackageReference Include="System.Reflection" Version="4.1.0" />
++    <PackageReference Include="System.Reflection.Extensions" Version="4.0.1" />
++    <PackageReference Include="System.Resources.ResourceManager" Version="4.0.1" />
++    <PackageReference Include="System.Runtime" Version="4.1.0" />
++    <PackageReference Include="System.Runtime.Extensions" Version="4.1.0" />
++    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />
++    <PackageReference Include="System.Text.Encoding" Version="4.0.11" />
++    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.0.11" />
++    <PackageReference Include="System.Text.RegularExpressions" Version="4.1.0" />
++    <PackageReference Include="System.Threading" Version="4.0.11" />
++    <PackageReference Include="System.Threading.Tasks" Version="4.0.11" />
++    <PackageReference Include="System.Xml.ReaderWriter" Version="4.0.11" />
++    <PackageReference Include="System.Xml.XDocument" Version="4.0.11" />
++  </ItemGroup>
++
++</Project>
+diff --git a/Src/Newtonsoft.Json/Newtonsoft.Json.Dotnet.xproj b/Src/Newtonsoft.Json/Newtonsoft.Json.Dotnet.xproj
+deleted file mode 100644
+index 07d8d0ba..00000000
+--- a/Src/Newtonsoft.Json/Newtonsoft.Json.Dotnet.xproj
++++ /dev/null
+@@ -1,18 +0,0 @@
+-﻿<?xml version="1.0" encoding="utf-8"?>
+-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+-  <PropertyGroup>
+-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+-  </PropertyGroup>
+-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+-  <PropertyGroup Label="Globals">
+-    <ProjectGuid>779e052e-7218-4da3-b419-ffb0f4c95081</ProjectGuid>
+-    <RootNamespace>Newtonsoft.Json</RootNamespace>
+-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+-    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+-  </PropertyGroup>
+-  <PropertyGroup>
+-    <SchemaVersion>2.0</SchemaVersion>
+-  </PropertyGroup>
+-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+-</Project>
+\ No newline at end of file
+diff --git a/Src/Newtonsoft.Json/project.json b/Src/Newtonsoft.Json/project.json
+deleted file mode 100644
+index 4be92250..00000000
+--- a/Src/Newtonsoft.Json/project.json
++++ /dev/null
+@@ -1,134 +0,0 @@
+-﻿{
+-  "version": "1.0.0-*",
+-  "title": "Json.NET",
+-  "description": "Json.NET is a popular high-performance JSON framework for .NET",
+-  "language": "en-US",
+-  "authors": [ "James Newton-King" ],
+-  "packOptions": {
+-    "projectUrl": "http://www.newtonsoft.com/json",
+-    "tags": [ "json" ],
+-    "licenseUrl": "https://raw.github.com/JamesNK/Newtonsoft.Json/master/LICENSE.md",
+-    "iconUrl": "http://www.newtonsoft.com/content/images/nugeticon.png",
+-    "repository": {
+-      "type": "git",
+-      "url": "git://github.com/JamesNK/Newtonsoft.Json"
+-    }
+-  },
+-  "frameworks": {
+-    "net45": {
+-      "frameworkAssemblies": {
+-        "System.Data": "",
+-        "System.Numerics": "",
+-        "System.Runtime.Serialization": "",
+-        "System.Xml": "",
+-        "System.Xml.Linq": ""
+-      }
+-    },
+-    "net40": {
+-      "frameworkAssemblies": {
+-        "System.Data": "",
+-        "System.Numerics": "",
+-        "System.Runtime.Serialization": "",
+-        "System.Xml": "",
+-        "System.Xml.Linq": ""
+-      }
+-    },
+-    "net35": {
+-      "frameworkAssemblies": {
+-        "System.Core": "",
+-        "System.Data": "",
+-        "System.Runtime.Serialization": "",
+-        "System.Xml": "",
+-        "System.Xml.Linq": ""
+-      }
+-    },
+-    "net20": {
+-      "frameworkAssemblies": {
+-        "System.Data": "",
+-        "System.Xml": ""
+-      }
+-    },
+-    ".NETPortable,Version=v4.5,Profile=Profile259": {
+-      "buildOptions": {
+-        "define": [
+-          "PORTABLE"
+-        ]
+-      },
+-      "frameworkAssemblies": {
+-        "Microsoft.CSharp": "",
+-        "System": "",
+-        "System.Collections": "",
+-        "System.Core": "",
+-        "System.Diagnostics.Debug": "",
+-        "System.Dynamic.Runtime": "",
+-        "System.Globalization": "",
+-        "System.IO": "",
+-        "System.Linq": "",
+-        "System.Linq.Expressions": "",
+-        "System.ObjectModel": "",
+-        "System.Reflection": "",
+-        "System.Reflection.Extensions": "",
+-        "System.Resources.ResourceManager": "",
+-        "System.Runtime": "",
+-        "System.Runtime.Extensions": "",
+-        "System.Runtime.Serialization": "",
+-        "System.Runtime.Serialization.Primitives": "",
+-        "System.Text.Encoding": "",
+-        "System.Text.Encoding.Extensions": "",
+-        "System.Text.RegularExpressions": "",
+-        "System.Threading": "",
+-        "System.Threading.Tasks": "",
+-        "System.Xml": "",
+-        "System.Xml.Linq": "",
+-        "System.Xml.ReaderWriter": "",
+-        "System.Xml.XDocument": ""
+-      }
+-    },
+-    ".NETPortable,Version=v4.0,Profile=Profile328": {
+-      "buildOptions": {
+-        "define": [
+-          "PORTABLE40"
+-        ]
+-      },
+-      "frameworkAssemblies": {
+-        "mscorlib": "",
+-        "System": "",
+-        "System.Core": "",
+-        "System.Runtime.Serialization": "",
+-        "System.Xml": ""
+-      }
+-    },
+-    "netstandard1.0": {
+-      "buildOptions": {
+-        "define": [
+-          "NETSTANDARD10",
+-          "PORTABLE"
+-        ]
+-      },
+-      "dependencies": {
+-        "Microsoft.CSharp": "4.0.1",
+-        "System.Collections": "4.0.11",
+-        "System.Diagnostics.Debug": "4.0.11",
+-        "System.Dynamic.Runtime": "4.0.11",
+-        "System.Globalization": "4.0.11",
+-        "System.IO": "4.1.0",
+-        "System.Linq": "4.1.0",
+-        "System.Linq.Expressions": "4.1.0",
+-        "System.ObjectModel": "4.0.12",
+-        "System.Reflection": "4.1.0",
+-        "System.Reflection.Extensions": "4.0.1",
+-        "System.Resources.ResourceManager": "4.0.1",
+-        "System.Runtime": "4.1.0",
+-        "System.Runtime.Extensions": "4.1.0",
+-        "System.Runtime.Serialization.Primitives": "4.1.1",
+-        "System.Text.Encoding": "4.0.11",
+-        "System.Text.Encoding.Extensions": "4.0.11",
+-        "System.Text.RegularExpressions": "4.1.0",
+-        "System.Threading": "4.0.11",
+-        "System.Threading.Tasks": "4.0.11",
+-        "System.Xml.ReaderWriter": "4.0.11",
+-        "System.Xml.XDocument": "4.0.11"
+-      }
+-    }
+-  }
+-}
+\ No newline at end of file
+-- 
+2.30.2
+

--- a/patches/newtonsoft-json901/0002-Fixup-result-of-migration.patch
+++ b/patches/newtonsoft-json901/0002-Fixup-result-of-migration.patch
@@ -1,0 +1,35 @@
+From 0a7ebea7ab8437642ec1cfc56dd322c1a83b824f Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Thu, 31 May 2018 18:51:56 +0000
+Subject: [PATCH 2/3] Fixup result of migration
+
+---
+ Src/Newtonsoft.Json/Newtonsoft.Json.Dotnet.csproj | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/Src/Newtonsoft.Json/Newtonsoft.Json.Dotnet.csproj b/Src/Newtonsoft.Json/Newtonsoft.Json.Dotnet.csproj
+index 797f6371..3bc9a781 100644
+--- a/Src/Newtonsoft.Json/Newtonsoft.Json.Dotnet.csproj
++++ b/Src/Newtonsoft.Json/Newtonsoft.Json.Dotnet.csproj
+@@ -6,6 +6,8 @@
+     <NeutralLanguage>en-US</NeutralLanguage>
+     <Authors>James Newton-King</Authors>
+     <TargetFrameworks>net45;net40;net35;net20;portable45-net45+win8+wp8+wpa81;portable40-net40+sl5+win8+wp8+wpa81;netstandard1.0</TargetFrameworks>
++    <TargetFrameworks Condition="'$(DotnetOnly)' == 'true'">netstandard1.0</TargetFrameworks>
++    <Version>9.0.1</Version>
+     <AssemblyName>Newtonsoft.Json</AssemblyName>
+     <PackageId>Newtonsoft.Json</PackageId>
+     <PackageTags>json</PackageTags>
+@@ -106,7 +108,8 @@
+   </PropertyGroup>
+ 
+   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+-    <DefineConstants>$(DefineConstants);NETSTANDARD10</DefineConstants>
++    <DefineConstants>$(DefineConstants);PORTABLE;NETSTANDARD10;$(AdditionalConstants)</DefineConstants>
++    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+   </PropertyGroup>
+ 
+   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+-- 
+2.30.2
+

--- a/patches/newtonsoft-json901/0003-Use-correct-version-number.patch
+++ b/patches/newtonsoft-json901/0003-Use-correct-version-number.patch
@@ -1,0 +1,27 @@
+From e43dae94c26f0c30e9095327a3a9eac87193923d Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Thu, 31 May 2018 18:52:31 +0000
+Subject: [PATCH 3/3] Use correct version number
+
+---
+ Src/Newtonsoft.Json/Properties/AssemblyInfo.cs | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Src/Newtonsoft.Json/Properties/AssemblyInfo.cs b/Src/Newtonsoft.Json/Properties/AssemblyInfo.cs
+index 62cc370e..3abbf8b1 100644
+--- a/Src/Newtonsoft.Json/Properties/AssemblyInfo.cs
++++ b/Src/Newtonsoft.Json/Properties/AssemblyInfo.cs
+@@ -94,6 +94,6 @@
+ // You can specify all the values or you can default the Revision and Build Numbers 
+ // by using the '*' as shown below:
+ 
+-[assembly: AssemblyVersion("7.0.0.0")]
+-[assembly: AssemblyFileVersion("7.0.2.18802")]
+-[assembly: CLSCompliant(true)]
+\ No newline at end of file
++[assembly: AssemblyVersion("9.0.0.0")]
++[assembly: AssemblyFileVersion("9.0.1.19813")]
++[assembly: CLSCompliant(true)]
+-- 
+2.30.2
+


### PR DESCRIPTION
https://github.com/dotnet/source-build/issues/2185

Currently, .NET 5.0 builds Newtonsoft.Json from a personal repo: https://github.com/adaggarwal/Newtonsoft.Json

This PR adds patches for the changes on that personal repo and builds from the official Newtonsoft.Json repo instead (https://github.com/JamesNK/Newtonsoft.Json), for both Newtonsoft.Json 9.0.1 and 12.0.2.