### PR TITLE
Exclude locally-built packages from smoke-test-prereqs.

### DIFF
--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -560,6 +560,8 @@ function resetCaches() {
     # Copy NuGet plugins if running user has HOME and we have auth. In particular, the auth plugin.
     if [ "${internalPackageFeedPat:-}" ] && [ "${executingUserHome:-}" ]; then
         cp -r "$executingUserHome/.nuget/" "$HOME/.nuget/" || :
+        # remove cached packages if there were any
+        rm -rf "$HOME/.nuget/packages"
     fi
 }
 
@@ -650,7 +652,6 @@ if [ "$excludeLocalTests" == "false" ]; then
     fi
     echo "RUN ALL TESTS - LOCAL RESTORE SOURCE"
     runAllTests
-    copyRestoredPackages
     echo "LOCAL RESTORE SOURCE - ALL TESTS PASSED!"
 fi
 


### PR DESCRIPTION
This makes two changes to prevent our locally-built packages from making it into the smoke-test-prereqs tarball:
- Remove any packages cached in the system cache after we copy it to our local NuGet cache (so we get the credential plugin).
- Don't copy packages to the prereqs directory after the local tests (which can restore locally-built packages).

This accomplishes two things:
- Smoke-testing will be more true to the partner and user experience (using the official packages that a developer would restore when actually using the product).
- The official packages will include all TFMs and runtimes so the smoke-test-prereqs tarball will be universal across all of our builds.