### PR TITLE
Use --work-tree with git apply in onboarding docs

### DIFF
--- a/Documentation/planning/arcade-powered-source-build/onboarding/local-onboarding.md
+++ b/Documentation/planning/arcade-powered-source-build/onboarding/local-onboarding.md
@@ -207,7 +207,7 @@ For each patch that isn't incorporated directly:
     </ItemGroup>
 
     <Exec
-      Command="git apply --ignore-whitespace --whitespace=nowarn &quot;%(SourceBuildPatchFile.FullPath)&quot;"
+      Command="git --work-tree=&quot;$(RepoRoot)&quot; apply --ignore-whitespace --whitespace=nowarn &quot;%(SourceBuildPatchFile.FullPath)&quot;"
       WorkingDirectory="$(RepoRoot)"
       Condition="'@(SourceBuildPatchFile)' != ''" />
   </Target>


### PR DESCRIPTION
The generated (arpow) source-tarball is often built in a context where it's under a subdirectory of an unrelated git repository. In such a situation, `git apply` will try and apply patches to the main git repository instead of the extracted source-tarball contents. That fails (silently), so the patches never get applied. Building that source-tarball eventually fails because of those missing patches.

Use --work-tree to tell git to apply patches to the tarball directory and not to whatever git repo the tarball directory happens to be under.

Fixes: https://github.com/dotnet/source-build/issues/2445