### PR TITLE
Switch to servicing 1ES Pools in release/2.1

### DIFF
--- a/.vsts.pipelines/builds/ci-internal.yml
+++ b/.vsts.pipelines/builds/ci-internal.yml
@@ -1,5 +1,5 @@
 stages:
 - template: matrix.yml
   parameters:
-    windowsPoolName: NetCoreInternal-Int-Pool
-    windowsQueueName: buildpool.windows.10.amd64.vs2017
+    windowsPoolName: NetCore1ESPool-Svc-Internal
+    windowsQueueName: build.windows.10.amd64.vs2017

--- a/.vsts.pipelines/builds/matrix.yml
+++ b/.vsts.pipelines/builds/matrix.yml
@@ -6,8 +6,8 @@
 #   Offline: The leg produces a tarball then builds it offline. Network disconnected using Docker.
 
 parameters:
-  windowsPoolName: NetCorePublic-Int-Pool
-  windowsQueueName: buildpool.windows.10.amd64.vs2017.open
+  windowsPoolName: NetCore1ESPool-Svc-Public
+  windowsQueueName: build.windows.10.amd64.vs2017.open
 
 stages:
 - template: ../stages/stage-jobs-matrix.yml
@@ -72,7 +72,7 @@ stages:
     jobParameters:
       pool:
         name: ${{ parameters.windowsPoolName }}
-        queue: ${{ parameters.windowsQueueName }}
+        demands: ImageOverride -equals ${{ parameters.windowsQueueName }}
       scriptPrefix: ''
       scriptSuffix: .cmd
       setupWindows: true


### PR DESCRIPTION
Part of https://github.com/dotnet/core-eng/issues/14276

Internal build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1366458&view=results