### PR TITLE
Add MSBuildLocator to source-build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "src/newtonsoft-json901"]
 	path = src/newtonsoft-json901
 	url = https://github.com/JamesNK/Newtonsoft.Json.git
+[submodule "src/MSBuildLocator"]
+	path = src/MSBuildLocator
+	url = https://github.com/microsoft/MSBuildLocator

--- a/patches/MSBuildLocator/0001-Eliminate-prebuilts.patch
+++ b/patches/MSBuildLocator/0001-Eliminate-prebuilts.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "msimons@microsoft.com" <MichaelSimons>
+Date: Fri, 15 Oct 2021 18:10:34 +0000
+Subject: [PATCH] Eliminate prebuilts
+
+* Updated SourceLink reference to pick up the source-build version
+* Removed references that aren't need for source-build which introduce prebuilts
+    * Nerdbank.GitVersioning - used for generating assembly version attributes, instead version property is set as build prop
+    * MicroBuild.Core - only relevant in offical builds
+---
+ Directory.Build.props                             | 3 +--
+ src/MSBuildLocator/Microsoft.Build.Locator.csproj | 3 +--
+ 2 files changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/Directory.Build.props b/Directory.Build.props
+index 27bc1a1..f8ea438 100644
+--- a/Directory.Build.props
++++ b/Directory.Build.props
+@@ -27,7 +27,6 @@
+   </PropertyGroup>
+
+   <ItemGroup>
+-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
++    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkVersion)" PrivateAssets="All"/>
+-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="all" />
+   </ItemGroup>
+ 
+   <ItemGroup>
+diff --git a/src/MSBuildLocator/Microsoft.Build.Locator.csproj b/src/MSBuildLocator/Microsoft.Build.Locator.csproj
+index 712f67c..56b1196 100644
+--- a/src/MSBuildLocator/Microsoft.Build.Locator.csproj
++++ b/src/MSBuildLocator/Microsoft.Build.Locator.csproj
+@@ -2,7 +2,7 @@
+ 
+   <PropertyGroup>
+     <OutputType>Library</OutputType>
+-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
++    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+     <DebugType>full</DebugType>
+ 
+     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+@@ -26,7 +26,6 @@
+   </ItemGroup>
+ 
+   <ItemGroup>
+-    <PackageReference Include="MicroBuild.Core" Version="0.3.0" PrivateAssets="all" />
+     <Content Include="build\Microsoft.Build.Locator.props">
+       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+       <PackagePath>build\</PackagePath>

--- a/patches/MSBuildLocator/0001-Eliminate-prebuilts.patch
+++ b/patches/MSBuildLocator/0001-Eliminate-prebuilts.patch
@@ -4,12 +4,10 @@ Date: Fri, 15 Oct 2021 18:10:34 +0000
 Subject: [PATCH] Eliminate prebuilts
 
 * Updated SourceLink reference to pick up the source-build version
-* Removed references that aren't need for source-build which introduce prebuilts
-    * Nerdbank.GitVersioning - used for generating assembly version attributes, instead version property is set as build prop
-    * MicroBuild.Core - only relevant in offical builds
+* Removed Nerdbank.GitVersioning references because it would introduce a prebuilt. Instead version property is set as build prop
 ---
  Directory.Build.props                             | 3 +--
- src/MSBuildLocator/Microsoft.Build.Locator.csproj | 3 +--
+ src/MSBuildLocator/Microsoft.Build.Locator.csproj | 2 +-
  2 files changed, 1 insertion(+), 3 deletions(-)
 
 diff --git a/Directory.Build.props b/Directory.Build.props
@@ -39,11 +37,4 @@ index 712f67c..56b1196 100644
      <DebugType>full</DebugType>
  
      <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
-@@ -26,7 +26,6 @@
-   </ItemGroup>
- 
-   <ItemGroup>
--    <PackageReference Include="MicroBuild.Core" Version="0.3.0" PrivateAssets="all" />
-     <Content Include="build\Microsoft.Build.Locator.props">
-       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-       <PackagePath>build\</PackagePath>
+

--- a/repos/MSBuildLocator.proj
+++ b/repos/MSBuildLocator.proj
@@ -1,0 +1,38 @@
+<Project>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <PropertyGroup>
+    <PackagesOutput>$(ProjectDirectory)/src/MSBuildLocator/bin/$(Configuration)/</PackagesOutput>
+    <RepoApiImplemented>false</RepoApiImplemented>
+    <DeterministicBuildOptOut>true</DeterministicBuildOptOut>
+  </PropertyGroup>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+  <Target Name="RepoBuild">
+    <PropertyGroup>
+      <BuildCommandArgs>$(ProjectDirectory)/src/MSBuildLocator/Microsoft.Build.Locator.csproj</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /p:Configuration=$(Configuration)</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /v:$(LogVerbosity)</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) $(RedirectRepoOutputToLog)</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /p:MicrosoftSourceLinkVersion=$(MicrosoftSourceLinkVersion)</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /p:Version=1.4.1</BuildCommandArgs>
+    </PropertyGroup>
+
+    <Exec Command="$(DotnetToolCommand) restore /bl:restore.binlog $(BuildCommandArgs)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+
+    <Exec Command="$(DotnetToolCommand) build /bl:build.binlog $(BuildCommandArgs)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+
+    <Exec Command="$(DotnetToolCommand) pack /bl:pack.binlog $(BuildCommandArgs)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/2510

Adding MSBuildLocator in this means is much lower cost than having the MSBuildLocator repo support source-build natively.  Given the low churn in the repo, I think this is the most reasonable solution for .NET 6.0.