### PR TITLE
Add instructions for building dotnet 6.0 from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ For example, in Fedora 33:
     > sed -i -E 's|<MicrosoftNETHostModelPackageVersion>6.0.0-rtm.21521.1</|> <MicrosoftNETHostModelPackageVersion>6.0.0-rtm.21521.4</|' PackageVersions.props
     > sed -i -E 's|<MicrosoftNETHostModelVersion>6.0.0-rtm.21521.1</|> <MicrosoftNETHostModelVersion>6.0.0-rtm.21521.4</|' PackageVersions.props
     > tar czf ../packages/archive/Private.SourceBuilt.Artifacts.*.tar.gz *
+    > prep.sh --bootstrap
     > ```
     > 
     > This issue is being tracked [here](https://github.com/dotnet/source-build/issues/2599).

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ To build older versions of the .NET SDK from source, pick a specific Git tag wit
 
 > The source-build repository doesn't currently support Windows. See [source-build#1190](https://github.com/dotnet/source-build/issues/1190).
 
-## Source build goals
+## Source-build goals
 
 The key goal of source-build is to satisfy the official packaging rules of commonly used Linux distributions, such as [Fedora](https://fedoraproject.org/wiki/Packaging:Guidelines) and [Debian](https://www.debian.org/doc/manuals/maint-guide/build.en.html). Many Linux distributions have similar rules. These rules tend to have two main principles: consistent reproducibility, and source code for everything.
 
@@ -102,7 +102,7 @@ Source-build solves common challenges that most developers encounter when trying
 * By default, most .NET repositories download prebuilt binary dependencies from online sources. These are forbidden by typical Linux distribution rules, and interfere with build output flow.
 * Nearly all .NET repositories require the .NET SDK to build. This is a circular dependency, which presents a bootstrapping problem.
 
-.NET source-build contains scripts and build logic to help Linux distribution maintainers address these challenges.
+Starting with .NET 6, the core source-build infrastructure is integrated into the [dotnet/installer](https://github.com/dotnet/installer/tree/main/src/SourceBuild) repo. The `main` branch on this repo now contains the tooling needed to build .NET's external dependencies from source.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,14 @@ The steps to build vary slightly depending on your distro.  The following set of
     > On Linux distros other than Fedora 33, an additional bootstrapping step is required.  After running `prep.sh` above, run the following:
     >
     > ```bash
+    > mkdir ./privateSourceBuiltArtifacts
+    > cd ./privateSourceBuiltArtifacts
     > tar xf ../packages/archive/Private.SourceBuilt.Artifacts.*.tar.gz
     > sed -i -E 's|<MicrosoftNETHostModelPackageVersion>6.0.0-rtm.21521.1</|<MicrosoftNETHostModelPackageVersion>6.0.0-rtm.21521.4</|' PackageVersions.props
     > sed -i -E 's|<MicrosoftNETHostModelVersion>6.0.0-rtm.21521.1</|<MicrosoftNETHostModelVersion>6.0.0-rtm.21521.4</|' PackageVersions.props
     > tar czf ../packages/archive/Private.SourceBuilt.Artifacts.*.tar.gz *
+    > cd ..
+    > rm -r ./privateSourceBuiltArtifacts
     > prep.sh --bootstrap
     > ```
     > 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ The steps to build vary slightly depending on your distro.  The following set of
     >
     > ```bash
     > tar xf ../packages/archive/Private.SourceBuilt.Artifacts.*.tar.gz
-    > sed -i -E 's|<MicrosoftNETHostModelPackageVersion>6.0.0-rtm.21521.1</|> <MicrosoftNETHostModelPackageVersion>6.0.0-rtm.21521.4</|' PackageVersions.props
-    > sed -i -E 's|<MicrosoftNETHostModelVersion>6.0.0-rtm.21521.1</|> <MicrosoftNETHostModelVersion>6.0.0-rtm.21521.4</|' PackageVersions.props
+    > sed -i -E 's|<MicrosoftNETHostModelPackageVersion>6.0.0-rtm.21521.1</|<MicrosoftNETHostModelPackageVersion>6.0.0-rtm.21521.4</|' PackageVersions.props
+    > sed -i -E 's|<MicrosoftNETHostModelVersion>6.0.0-rtm.21521.1</|<MicrosoftNETHostModelVersion>6.0.0-rtm.21521.4</|' PackageVersions.props
     > tar czf ../packages/archive/Private.SourceBuilt.Artifacts.*.tar.gz *
     > prep.sh --bootstrap
     > ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The steps to build vary slightly depending on your distro.  The following set of
     ```bash
     git clone https://github.com/dotnet/installer
     cd installer/
-    git checkout v6.0.100-rtm.21527.11
+    git checkout v6.0.100
     ```
 
 3. Create a .NET source tarball.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Join the chat at https://gitter.im/dotnet/source-build](https://badges.gitter.im/dotnet/source-build.svg)](https://gitter.im/dotnet/source-build?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-This repo is the starting point for building .NET from source.
+This repo is the starting point for building .NET 6 from source. Instructions for building other .NET versions are provided near the end of this document.
 
 ## .NET 6.0
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@
 
 This repo is the starting point for building .NET 6 from source. Instructions for building other .NET versions are provided near the end of this document.
 
-## .NET 6.0
-
-### Prerequisites
+## Prerequisites
 
 The dependencies for building .NET 6.0 from source can be found [here](https://github.com/dotnet/runtime/blob/main/docs/workflow/requirements/linux-requirements.md).
 
-### Building
+## Building
 
 .NET 6.0 is built from source using the [dotnet/installer](https://github.com/dotnet/installer) repo.
 The steps to build vary slightly depending on your distro.  The following set of instructions walk through how to build on Fedora 33.  
@@ -80,6 +78,7 @@ The steps to build vary slightly depending on your distro.  The following set of
     ```
 
 ## .NET 5.0 and .NET Core 3.1
+
 To build older versions of the .NET SDK from source, pick a specific Git tag with your desired version, or use a release branch to build the latest servicing release of that version. Refer to the tag/branch's README for build instructions:
 
 * [`release/5.0`](https://github.com/dotnet/source-build/tree/release/5.0)
@@ -88,7 +87,7 @@ To build older versions of the .NET SDK from source, pick a specific Git tag wit
 
 > The source-build repository doesn't currently support Windows. See [source-build#1190](https://github.com/dotnet/source-build/issues/1190).
 
-# Source build goals
+## Source build goals
 
 The key goal of source-build is to satisfy the official packaging rules of commonly used Linux distributions, such as [Fedora](https://fedoraproject.org/wiki/Packaging:Guidelines) and [Debian](https://www.debian.org/doc/manuals/maint-guide/build.en.html). Many Linux distributions have similar rules. These rules tend to have two main principles: consistent reproducibility, and source code for everything.
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ The dependencies for building .NET 6.0 from source can be found [here](https://g
 ### Building
 
 .NET 6.0 is built from source using the [dotnet/installer](https://github.com/dotnet/installer) repo.
-...
-For example, in Fedora 33:
+The steps to build vary slightly depending on your distro.  The following set of instructions walk through how to build on Fedora.33.  
 
 1. Clone the repo and check out the tag for the desired release.
     ```bash
@@ -31,7 +30,7 @@ For example, in Fedora 33:
 
    This fetches the complete .NET source code and creates a tarball at `artifacts/packages/<Release|Debug>/Shipping/`.
    The extracted source code is also placed at `/path/to/place/complete/dotnet/sources`.
-   The source directory should be outside (and not somewhere under) this repository.
+   The source directory should be outside (and not somewhere under) the installer directory.
 
 3. Prep the source to build on your distro.
 
@@ -65,7 +64,8 @@ For example, in Fedora 33:
 5. (Optional) Unpack and install the .NET SDK
 
     ```bash
-    mkdir -p $HOME/dotnet && tar zxf artifacts/x64/Release/dotnet-sdk-6.0.100-fedora.33-x64.tar.gz -C $HOME/dotnet
+    mkdir -p $HOME/dotnet
+    tar zxf artifacts/x64/Release/dotnet-sdk-6.0.100-fedora.33-x64.tar.gz -C $HOME/dotnet
     ln -s $HOME/dotnet/dotnet /usr/bin/dotnet
     ```
     
@@ -81,7 +81,6 @@ To build older versions of the .NET SDK from source, pick a specific Git tag wit
 * [`release/5.0`](https://github.com/dotnet/source-build/tree/release/5.0)
 * [`release/3.1`](https://github.com/dotnet/source-build/tree/release/3.1)
 
-The scripts are written for Bash and supported on macOS and Linux.
 
 > The source-build repository doesn't currently support Windows. See [source-build#1190](https://github.com/dotnet/source-build/issues/1190).
 
@@ -100,7 +99,7 @@ Source-build solves common challenges that most developers encounter when trying
 * By default, most .NET repositories download prebuilt binary dependencies from online sources. These are forbidden by typical Linux distribution rules, and interfere with build output flow.
 * Nearly all .NET repositories require the .NET SDK to build. This is a circular dependency, which presents a bootstrapping problem.
 
-The source-build repository contains scripts and build logic to help Linux distribution maintainers address these challenges.
+.NET source-build contains scripts and build logic to help Linux distribution maintainers address these challenges.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ For example, in Fedora 33:
 
 4. Build the .NET SDK
 
-    `./build.sh`
+    ```bash
+    ./build.sh
+    ```
 
     This builds the entire .NET SDK from source. The resulting SDK is placed at `artifacts/x64/Release/dotnet-sdk-6.0.100-fedora.33-x64.tar.gz`.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The dependencies for building .NET 6.0 from source can be found [here](https://g
 ### Building
 
 .NET 6.0 is built from source using the [dotnet/installer](https://github.com/dotnet/installer) repo.
-The steps to build vary slightly depending on your distro.  The following set of instructions walk through how to build on Fedora.33.  
+The steps to build vary slightly depending on your distro.  The following set of instructions walk through how to build on Fedora 33.  
 
 1. Clone the repo and check out the tag for the desired release.
     ```bash

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The steps to build vary slightly depending on your distro.  The following set of
     ./prep.sh
     ```
 
-    This downloads a .NET SDK and a number of .NET packages and other prebuilts needed to build .NET from source.
+    This downloads a .NET SDK and a number of .NET packages needed to build .NET from source.
 
     > On Linux distros other than Fedora 33, an additional bootstrapping step is required.  After running `prep.sh` above, run the following:
     >

--- a/README.md
+++ b/README.md
@@ -1,48 +1,101 @@
-# .NET Core Source-Build
+# .NET Source-Build
 
-[![Build Status](https://dev.azure.com/dnceng/internal/_apis/build/status/dotnet/source-build/source-build-rolling-CI?branchName=master)](https://dev.azure.com/dnceng/internal/_build/latest?definitionId=114&branchName=master)
 [![Join the chat at https://gitter.im/dotnet/source-build](https://badges.gitter.im/dotnet/source-build.svg)](https://gitter.im/dotnet/source-build?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 This repository helps .NET SDK and .NET Runtime package maintainers comply with common Linux distribution guidelines.
 
-To build the full .NET SDK from source, pick a specific Git tag with your desired version, or use a release branch to build the latest servicing release of that version. Refer to the tag/branch's README for build instructions:
+## .NET 6.0
+
+### Prerequisites
+
+The dependencies for building .NET 6.0 from source can be found [here](https://github.com/dotnet/runtime/blob/main/docs/workflow/requirements/linux-requirements.md).
+
+### Building
+
+.NET 6.0 is built from source using the [dotnet/installer](https://github.com/dotnet/installer) repo.
+...
+For example, in Fedora 33:
+
+1. Clone the repo and check out the tag for the desired release.
+    ```bash
+    git clone https://github.com/dotnet/installer
+    cd installer/
+    git checkout v6.0.100-rtm.21527.11
+    ```
+
+3. Create a .NET source tarball.
+
+   ```bash
+   ./build.sh /p:ArcadeBuildTarball=true /p:TarballDir=/path/to/place/complete/dotnet/sources
+   ```
+
+   This fetches the complete .NET source code and creates a tarball at `artifacts/packages/<Release|Debug>/Shipping/`.
+   The extracted source code is also placed at `/path/to/place/complete/dotnet/sources`.
+   The source directory should be outside (and not somewhere under) this repository.
+
+3. Prep the source to build on your distro.
+
+    ```bash
+    cd /path/to/complete/dotnet/sources
+    ./prep.sh
+    ```
+
+    This downloads a .NET SDK and a number of .NET packages and other prebuilts needed to build .NET from source.
+
+    > On Linux distros other than Fedora 33, an additional bootstrapping step is required.  After running `prep.sh` above, run the following:
+    >
+    > ```bash
+    > tar xf ../packages/archive/Private.SourceBuilt.Artifacts.*.tar.gz
+    > sed -i -E 's|<MicrosoftNETHostModelPackageVersion>6.0.0-rtm.21521.1</|> <MicrosoftNETHostModelPackageVersion>6.0.0-rtm.21521.4</|' PackageVersions.props
+    > sed -i -E 's|<MicrosoftNETHostModelVersion>6.0.0-rtm.21521.1</|> <MicrosoftNETHostModelVersion>6.0.0-rtm.21521.4</|' PackageVersions.props
+    > tar czf ../packages/archive/Private.SourceBuilt.Artifacts.*.tar.gz *
+    > ```
+    > 
+    > This issue is being tracked [here](https://github.com/dotnet/source-build/issues/2599).
+
+4. Build the .NET SDK
+
+    `./build.sh`
+
+    This builds the entire .NET SDK from source. The resulting SDK is placed at `artifacts/x64/Release/dotnet-sdk-6.0.100-fedora.33-x64.tar.gz`.
+
+5. (Optional) Unpack and install the .NET SDK
+
+    ```bash
+    mkdir -p $HOME/dotnet && tar zxf artifacts/x64/Release/dotnet-sdk-6.0.100-fedora.33-x64.tar.gz -C $HOME/dotnet
+    ln -s $HOME/dotnet/dotnet /usr/bin/dotnet
+    ```
+    
+    To test your source-built SDK, run the following:
+
+    ```bash
+    dotnet --info
+    ```
+
+## .NET 5.0 and .NET Core 3.1
+To build older versions of the .NET SDK from source, pick a specific Git tag with your desired version, or use a release branch to build the latest servicing release of that version. Refer to the tag/branch's README for build instructions:
 
 * [`release/5.0`](https://github.com/dotnet/source-build/tree/release/5.0)
 * [`release/3.1`](https://github.com/dotnet/source-build/tree/release/3.1)
-* [`release/2.1`](https://github.com/dotnet/source-build/tree/release/2.1)
-
-The current branch is a work in progress that produces several .NET SDK components for [Arcade-powered source-build](Documentation/planning/arcade-powered-source-build). Once Arcade-powered source-build is complete, it will allow building a .NET SDK from source directly from the [dotnet/installer](https://github.com/dotnet/installer) repository.
-
-## Using this repository
 
 The scripts are written for Bash and supported on macOS and Linux.
 
 > The source-build repository doesn't currently support Windows. See [source-build#1190](https://github.com/dotnet/source-build/issues/1190).
 
-### Build on Linux or macOS
-
-Optionally, run `./check-submodules.sh` to ensure the submodules are set up and synchronized. Then, run the build command:
-
-```console
-./build.sh
-```
-
-Once the build is successful, the outputs are placed in `artifacts/packages/Debug/`.
-
-## Goals
+# Source build goals
 
 The key goal of source-build is to satisfy the official packaging rules of commonly used Linux distributions, such as [Fedora](https://fedoraproject.org/wiki/Packaging:Guidelines) and [Debian](https://www.debian.org/doc/manuals/maint-guide/build.en.html). Many Linux distributions have similar rules. These rules tend to have two main principles: consistent reproducibility, and source code for everything.
 
-A secondary goal of source-build is to allow .NET Core contributors to build a .NET Core SDK with coordinated changes in multiple repositories. However, the developer experience is significantly better in individual repositories and, if possible, contributors should make and test changes in the target repo, not source-build.
+A secondary goal of source-build is to allow .NET contributors to build a .NET SDK with coordinated changes in multiple repositories. However, the developer experience is significantly better in individual repositories and, if possible, contributors should make and test changes in the target repo, not source-build.
 
 ## What does the source-build infrastructure do?
 
-Source-build solves common challenges that most developers encounter when trying to build the whole .NET Core SDK from source.
+Source-build solves common challenges that most developers encounter when trying to build the whole .NET SDK from source.
 
-* .NET Core is composed of many repositories that need to be built at a specific combination of commits.
+* .NET is composed of many repositories that need to be built at a specific combination of commits.
 * Each repository's build output needs to flow into the next repository's build.
-* By default, most .NET Core repositories download prebuilt binary dependencies from online sources. These are forbidden by typical Linux distribution rules, and interfere with build output flow.
-* Nearly all .NET Core repositories require the .NET Core SDK to build. This is a circular dependency, which presents a bootstrapping problem.
+* By default, most .NET repositories download prebuilt binary dependencies from online sources. These are forbidden by typical Linux distribution rules, and interfere with build output flow.
+* Nearly all .NET repositories require the .NET SDK to build. This is a circular dependency, which presents a bootstrapping problem.
 
 The source-build repository contains scripts and build logic to help Linux distribution maintainers address these challenges.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Join the chat at https://gitter.im/dotnet/source-build](https://badges.gitter.im/dotnet/source-build.svg)](https://gitter.im/dotnet/source-build?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-This repository helps .NET SDK and .NET Runtime package maintainers comply with common Linux distribution guidelines.
+This repo is the starting point for building .NET from source.
 
 ## .NET 6.0
 


### PR DESCRIPTION
See https://github.com/dotnet/source-build/issues/2602 for more information.