### PR TITLE
Add new issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,35 @@
+---
+name: 🐞 Bug report
+about: Create a report about something that is not working
+labels: 'bug'
+---
+
+<!--
+Please keep in mind that the GitHub issue tracker is not intended as a general support forum, but for reporting **non-security** bugs and feature requests.
+
+If you believe you have an issue that affects the SECURITY of the platform, please do NOT create an issue and instead email your issue details to secure@microsoft.com. Your report may be eligible for our [bug bounty](https://www.microsoft.com/en-us/msrc/bounty-dot-net-core) but ONLY if it is reported through email.
+
+For discussion or question, consider creating a new [discussion](https://github.com/dotnet/source-build/discussions).
+-->
+
+### Describe the Bug
+
+<!-- A clear and concise description of what the bug is. -->
+
+### Steps to Reproduce
+
+<!--
+We ❤ code! Include minimal steps to reproduce the problem if possible or point us to a simple repro project hosted in a GitHub repo.
+
+We will close this issue if:
+- the repro project you share with us is complex. We can't investigate complex projects, so don't point us to such, please.
+- if we are not able to repro the behavior you're reporting
+-->
+
+### Other Information
+
+<!--
+* Please include any relevant error messages. If possible please include text rather than images (so it shows up in searches).
+* Does this issue consistently happen?  Include the conditions which cause the problem to occur.
+* Do you know of any workarounds?
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,20 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussions
+    url: https://github.com/dotnet/source-build/discussions
+    about: Is your issue perhaps more of a discussion or question? Please start a new discussion.
+  - name: Issue with .NET runtime or core .NET libraries
+    url: https://github.com/dotnet/runtime/issues/new/choose
+    about: Please open issues relating to the .NET runtime or core .NET libraries in dotnet/runtime.
+  - name: Issue with ASP.NET Core
+    url: https://github.com/dotnet/efcore/issues/new/choose
+    about: Please open issues relating to ASP.NET Core in dotnet/aspnetcore.
+  - name: Issue with .NET SDK
+    url: https://github.com/dotnet/sdk/issues/new/choose
+    about: Please open issues relating to the .NET SDK itself in dotnet/sdk.
+  - name: Issue with Roslyn compiler
+    url: https://github.com/dotnet/roslyn/issues/new/choose
+    about: Please open issues relating to the Roslyn .NET compiler in dotnet/roslyn.
+  - name: Issue with other .NET components
+    url: https://github.com/dotnet/core/blob/master/Documentation/core-repos.md
+    about: Having issues with other .NET components? Please find the correct location where to open an issue.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,22 @@
+---
+name: 💡 Feature request
+about: Suggest an idea for this project
+labels: 'enhancement'
+---
+
+### Describe the Problem
+
+<!--
+A clear and concise description of what the problem is.
+Example: I am trying to do [...] but [...]
+-->
+
+### Describe the Solution
+
+<!-- A clear and concise description of what you want to happen. Include any alternative solutions you've considered. -->
+
+### Additional Context
+
+<!-- Add any other context or screenshots about the feature request here. -->
+
+<!-- Thanks for taking the time to suggest this! -->


### PR DESCRIPTION
Motivation behind this is to enhance the new issue experience.  Direct issues/questions/discussions to the correct places in order to get quicker responses.

Related to https://github.com/dotnet/source-build/issues/2625