### PR TITLE
[release/3.1] Don't append attempt numbers to tarball artifacts in CI

### DIFF
--- a/.vsts.pipelines/jobs/ci-linux.yml
+++ b/.vsts.pipelines/jobs/ci-linux.yml
@@ -330,7 +330,7 @@ jobs:
     continueOnError: true
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/drop/tarball
-      ArtifactName: Tarball $(artifactName) Attempt $(System.JobAttempt)
+      ArtifactName: Tarball $(artifactName)
       ArtifactType: Container
 
   # Publish prebuilt report data to blob storage.

--- a/.vsts.pipelines/jobs/ci-linux_bootstrap.yml
+++ b/.vsts.pipelines/jobs/ci-linux_bootstrap.yml
@@ -24,7 +24,7 @@ jobs:
     imageName: ${{ parameters.imageName }}
     rootDirectory: $(Build.SourcesDirectory)/..
     stagingDirectory: $(rootDirectory)/bst/staging
-    tarballArtifactName: Tarball centos71_Offline Attempt $(System.JobAttempt)
+    tarballArtifactName: Tarball centos71_Offline
     tarballName: tarball_$(Build.BuildId)
     # Default type, can be overridden by matrix legs.
     type: ${{ coalesce(parameters.type, 'Production') }}

--- a/.vsts.pipelines/jobs/ci-local.yml
+++ b/.vsts.pipelines/jobs/ci-local.yml
@@ -265,7 +265,7 @@ jobs:
     condition: always()
     continueOnError: true
   - publish: $(dropDirectory)/tarball
-    artifact: Tarball $(artifactName) Attempt $(System.JobAttempt)
+    artifact: Tarball $(artifactName)
     displayName: Publish Tarball artifact
     condition: eq(variables['sb.tarball'], true)
     continueOnError: true

--- a/.vsts.pipelines/steps/run-bootstrap.yml
+++ b/.vsts.pipelines/steps/run-bootstrap.yml
@@ -244,7 +244,7 @@ steps:
   continueOnError: true
   inputs:
     PathtoPublish: $(Build.ArtifactStagingDirectory)/drop/logs
-    ArtifactName: Logs $(artifactName) $(System.JobAttempt)
+    ArtifactName: Logs $(artifactName) Attempt $(System.JobAttempt)
     ArtifactType: Container
 
 # Publish tarball artifacts
@@ -254,5 +254,5 @@ steps:
   continueOnError: true
   inputs:
     PathtoPublish: $(Build.ArtifactStagingDirectory)/drop/tarball
-    ArtifactName: Tarball Artifacts $(artifactName) $(System.JobAttempt)
+    ArtifactName: Tarball Artifacts $(artifactName)
     ArtifactType: Container


### PR DESCRIPTION
Fixes #2771 by only appending numbers to logs artifacts. We very rarely have an issue where a build doesn't succeed but it still uploads a tarball. We should still be able to get logs for multiple attempts of things like smoke tests.