### PR TITLE
[release/5.0] CI improvements

### DIFF
--- a/.vsts.pipelines/jobs/ci-linux.yml
+++ b/.vsts.pipelines/jobs/ci-linux.yml
@@ -343,7 +343,7 @@ jobs:
     continueOnError: true
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/drop/logs
-      ArtifactName: Logs $(artifactName)
+      ArtifactName: Logs $(artifactName) Attempt $(System.JobAttempt)
       ArtifactType: Container
   - task: PublishBuildArtifacts@1
     displayName: Publish Tarball artifact

--- a/.vsts.pipelines/jobs/ci-local.yml
+++ b/.vsts.pipelines/jobs/ci-local.yml
@@ -274,7 +274,7 @@ jobs:
 
   # Publish artifacts.
   - publish: $(logsDirectory)
-    artifact: Logs $(artifactName)
+    artifact: Logs $(artifactName) Attempt $(System.JobAttempt)
     displayName: Publish Logs artifact
     condition: always()
     continueOnError: true

--- a/.vsts.pipelines/steps/run-bootstrap.yml
+++ b/.vsts.pipelines/steps/run-bootstrap.yml
@@ -247,7 +247,7 @@ steps:
   continueOnError: true
   inputs:
     PathtoPublish: $(Build.ArtifactStagingDirectory)/drop/logs
-    ArtifactName: Logs $(artifactName)
+    ArtifactName: Logs $(artifactName) Attempt $(System.JobAttempt)
     ArtifactType: Container
 
 # Publish tarball artifacts

--- a/repos/Directory.Build.targets
+++ b/repos/Directory.Build.targets
@@ -632,7 +632,7 @@
                        OutputDirectory="$(PackageReportDir)" />
 
     <PropertyGroup Condition="'$(ContinueOnPrebuiltBaselineError)' == ''">
-      <ContinueOnPrebuiltBaselineError>false</ContinueOnPrebuiltBaselineError>
+      <ContinueOnPrebuiltBaselineError>true</ContinueOnPrebuiltBaselineError>
       <ContinueOnPrebuiltBaselineError Condition="'$(FailOnPrebuiltBaselineError)' != 'true'">true</ContinueOnPrebuiltBaselineError>
     </PropertyGroup>
 

--- a/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/ValidateUsageAgainstBaseline.cs
+++ b/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/UsageReport/ValidateUsageAgainstBaseline.cs
@@ -44,10 +44,16 @@ namespace Microsoft.DotNet.SourceBuild.Tasks.UsageReport
             if (diff.Added.Any())
             {
                 tellUserToUpdateBaseline = true;
-                Log.LogError(
-                    $"{diff.Added.Length} new packages used not in baseline! See report " +
+
+                string BaselineErrorMessage = $"{diff.Added.Length} new packages used not in baseline! See report " +
                     $"at {OutputReportFile} for more information. Package IDs are:\n" +
-                    string.Join("\n", diff.Added.Select(u => u.ToString())));
+                    string.Join("\n", diff.Added.Select(u => u.ToString()));
+
+                Log.LogError(BaselineErrorMessage);
+
+                Log.LogMessage(
+                    MessageImportance.High,
+                    "##vso[task.complete result=SucceededWithIssues;]" + BaselineErrorMessage);
 
                 // In the report, list full usage info, not only identity.
                 report.Add(


### PR DESCRIPTION
* continue the build with a warning when there are new prebuilts
* append job attempt number to log artifacts so we keep artifacts from multiple attempts

Includes changes from https://github.com/dotnet/source-build/pull/2742 and the fix for https://github.com/dotnet/source-build/issues/2771