### PR TITLE
[main] Introduce Source-Build release pipeline

### DIFF
--- a/eng/source-build-release-announcement.md
+++ b/eng/source-build-release-announcement.md
@@ -2,8 +2,9 @@
 <!-- The line prefixed by 'Title:' will be submitted as the title of the discussion, and the rest of the file will be submitted as the body. -->
 Title: .NET $DOTNET_MAJOR_MINOR_VERSION $DATE Update - .NET $RUNTIME_VERSION and SDK $SDK_VERSION
 
-[Release Notes]($RELEASE_NOTES_URL) | [Tag]($TAG_URL)
-
 Please use the [$TAG tag]($TAG_URL) to source-build .NET version $RUNTIME_VERSION / $SDK_VERSION.
 
-@distro-maintainers
+- Release Notes: $RELEASE_NOTES_URL
+- Tag URL: $TAG_URL
+
+@dotnet/distro-maintainers

--- a/eng/source-build-release-announcement.md
+++ b/eng/source-build-release-announcement.md
@@ -1,5 +1,5 @@
-# This file is a template for a GitHub Discussion. 
-# The line prefixed by 'Title:' will be submitted as the title of the discussion, and the rest of the file will be submitted as the body.
+<!-- This file is a template for a GitHub Discussion. 
+The line prefixed by 'Title:' will be submitted as the title of the discussion, and the rest of the file will be submitted as the body. -->
 Title: .NET $DATE Update - .NET $RUNTIME_VERSION and SDK $SDK_VERSION
 
 [Release Notes]($RELEASE_NOTES_URL) | [Tag]($TAG_URL)

--- a/eng/source-build-release-announcement.md
+++ b/eng/source-build-release-announcement.md
@@ -1,0 +1,9 @@
+# This file is a template for a GitHub Discussion. 
+# The line prefixed by 'Title:' will be submitted as the title of the discussion, and the rest of the file will be submitted as the body.
+Title: .NET $DATE Update - .NET $RUNTIME_VERSION and SDK $SDK_VERSION
+
+[Release Notes]($RELEASE_NOTES_URL) | [Tag]($TAG_URL)
+
+Please use the [$TAG tag]($TAG_URL) to source-build .NET version $RUNTIME_VERSION / $SDK_VERSION.
+
+@distro-maintainers

--- a/eng/source-build-release-announcement.md
+++ b/eng/source-build-release-announcement.md
@@ -1,6 +1,6 @@
-<!-- This file is a template for a GitHub Discussion. 
-The line prefixed by 'Title:' will be submitted as the title of the discussion, and the rest of the file will be submitted as the body. -->
-Title: .NET $DATE Update - .NET $RUNTIME_VERSION and SDK $SDK_VERSION
+<!-- This file is a template for a GitHub Discussion post.  -->
+<!-- The line prefixed by 'Title:' will be submitted as the title of the discussion, and the rest of the file will be submitted as the body. -->
+Title: .NET $DOTNET_MAJOR_MINOR_VERSION $DATE Update - .NET $RUNTIME_VERSION and SDK $SDK_VERSION
 
 [Release Notes]($RELEASE_NOTES_URL) | [Tag]($TAG_URL)
 

--- a/eng/source-build-release.yml
+++ b/eng/source-build-release.yml
@@ -1,0 +1,127 @@
+trigger: none
+pr: none
+
+pool:
+  name: NetCore1ESPool-Svc-Internal
+  demands: ImageOverride -equals 1es-ubuntu-2004
+
+parameters:
+  - name: sdkVersion
+    displayName: SDK Version
+    type: string
+    default: 6.0.XYY
+  - name: useCustomTag
+    displayName: Use custom tag?
+    type: boolean
+    default: false
+  - name: customTag
+    displayName: Installer custom tag
+    type: string
+    default: v6.0.XYY-source-build
+
+variables:
+  repoId: ''
+  discussionCategoryId: ''
+  announcementOrg: 'dotnet'
+  announcementRepo: 'source-build'
+  sourceRepoUrl: 'https://github.com/dotnet/installer.git'
+
+stages:
+
+- stage: Setup
+  jobs:
+  - job: SetupJob
+    displayName: Setup
+    steps:
+    - script: |
+        set -euxo pipefail
+        if [ "${{ parameters.useCustomTag }}" = "True" ] ; then
+          tag=${{ parameters.customTag }}
+          echo "Using custom tag $(tag)"
+        else
+          tag=v${{ parameters.sdkVersion }}
+          echo "Using tag $(tag)"
+        fi
+        echo "##vso[task.setvariable variable=Tag;isOutput=true]${tag}"
+      name: SetTag
+      displayName: Set tag
+    - script: |
+        set -euxo pipefail
+        tag="$(SetTag.Tag)"
+        git clone ${{ variables.sourceRepoUrl }} source
+        cd source
+        git show-ref --tags
+        if git rev-parse "$tag" >/dev/null 2>&1; then
+          echo "Tag $tag exists.";
+        else
+          echo "Tag $tag does not exist."
+          exit 1
+        fi
+      displayName: Ensure tag exists
+
+- stage: CreateReleaseAnnouncement
+  displayName: Create Release Announcement
+  dependsOn: Setup
+  jobs:
+  - job: CreateReleaseAnnouncementJob
+    displayName: Create Release Announcement
+    variables:
+    - name: Tag
+      value: $[ stageDependencies.Setup.SetupJob.outputs['SetTag.Tag'] ]
+    steps:
+
+    - script: |
+        set -euxo pipefail
+        query='query { repository(owner: "${{ variables.announcementOrg }}", name: "${{ variables.announcementRepo }}") { id } }'
+        repo_id=$( gh api graphql -f query="$query" --template '{{.data.repository.id}}' )
+        echo ${{ variables.announcementOrg }}/${{ variables.announcementRepo }} repo ID is ${repo_id}
+        echo "##vso[task.setvariable variable=repoId;]${repo_id}"
+      displayName: Get repo ID
+      env:
+        GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
+
+    - script: |
+        set -euxo pipefail
+        query='query { repository(name: "${{ variables.announcementRepo }}", owner: "${{ variables.announcementOrg }}") { discussionCategories(first: 10) { edges { node { id, name } } } } }'
+        category_id=$( gh api graphql -f query="$query" --template '{{range .data.repository.discussionCategories.edges}}{{if eq .node.name "Announcements"}}{{.node.id}}{{end}}{{end}}' )
+        echo Discussion Category ID is ${category_id}
+        echo "##vso[task.setvariable variable=discussionCategoryId;]${category_id}"
+      displayName: Get announcement discussion category ID
+      env:
+        GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
+
+    - script: |
+        set -euxo pipefail
+        echo Repo ID is $(repoId)
+        echo Discussion Category ID is $(discussionCategoryId)
+
+        # Read runtime version from installer's release commit
+        git clone ${{ variables.sourceRepoUrl }} source
+        cd source
+        git checkout $(Tag)
+        runtime_version=$(cat eng/Version.Details.xml | grep 'Microsoft.NETCore.App.Runtime.win-x64' | grep -P -o -e '(?<=Version=").*?(?=")')
+        dotnet_version=$(echo "$runtime_version" | head -c 3)
+
+        # Set environment variables that go in the announcement template
+        export TAG=$(Tag)
+        export RUNTIME_VERSION="$runtime_version"
+        export SDK_VERSION="${{ parameters.sdkVersion }}"
+        export TAG_URL="https://github.com/dotnet/installer/releases/tag/$TAG"
+        export RELEASE_NOTES_URL="https://github.com/dotnet/core/blob/main/release-notes/$dotnet_version/$runtime_version/${{ parameters.sdkVersion }}.md"
+        export DATE=$(date +"%B %Y") # e.g. "March 2022"
+
+        template="$(envsubst < $(Build.SourcesDirectory)/eng/source-build-release-announcement.md)"
+        # Get the line in the template that is prefixed with "Title:" and remove the prefix
+        title=$(echo "$template" | grep "^Title:" | cut -d " " -f2-)
+        # Get the inverse of the above selection
+        body=$(echo "$template" | grep -v "^Title:")
+
+        query='mutation($repoId: ID!, $categoryId: ID!, $body: String!, $title: String!) { createDiscussion(input: {repositoryId: $repoId, categoryId: $categoryId, body: $body, title: $title}) { discussion { url } } }'
+        announcement_url=$( gh api graphql -F repoId=$(repoId) -F categoryId=$(discussionCategoryId) -F body="${body}" -F title="${title}" -f query="$query" --template '{{.data.createDiscussion.discussion.url}}' )
+
+        echo "Announcement URL: $announcement_url"
+        echo "Tag URL: $TAG_URL"
+        echo "Release Notes URL: $RELEASE_NOTES_URL"
+      displayName: Submit announcement discussion
+      env:
+        GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)

--- a/eng/source-build-release.yml
+++ b/eng/source-build-release.yml
@@ -5,15 +5,24 @@ pool:
   name: NetCore1ESPool-Svc-Internal
   demands: ImageOverride -equals 1es-ubuntu-2004
 
+resources:
+  repositories:
+    - repository: installer
+      type: github
+      endpoint: dotnet
+      name: dotnet/installer
+
 parameters:
   - name: sdkVersion
     displayName: SDK Version
     type: string
     default: 6.0.XYY
+
   - name: useCustomTag
     displayName: Use custom tag?
     type: boolean
     default: false
+
   - name: customTag
     displayName: Installer custom tag
     type: string
@@ -24,7 +33,6 @@ variables:
   discussionCategoryId: ''
   announcementOrg: 'dotnet'
   announcementRepo: 'source-build'
-  sourceRepoUrl: 'https://github.com/dotnet/installer.git'
 
 stages:
 
@@ -33,6 +41,8 @@ stages:
   - job: SetupJob
     displayName: Setup
     steps:
+    - checkout: installer
+
     - script: |
         set -euxo pipefail
         if [ "${{ parameters.useCustomTag }}" = "True" ] ; then
@@ -42,14 +52,15 @@ stages:
           tag=v${{ parameters.sdkVersion }}
           echo "Using tag $(tag)"
         fi
+        set +x
         echo "##vso[task.setvariable variable=Tag;isOutput=true]${tag}"
       name: SetTag
       displayName: Set tag
+
     - script: |
         set -euxo pipefail
         tag="$(SetTag.Tag)"
-        git clone ${{ variables.sourceRepoUrl }} source
-        cd source
+        cd $(Build.SourcesDirectory)
         git show-ref --tags
         if git rev-parse "$tag" >/dev/null 2>&1; then
           echo "Tag $tag exists.";
@@ -58,6 +69,19 @@ stages:
           exit 1
         fi
       displayName: Ensure tag exists
+
+    - script: |
+        set -euxo pipefail
+        cd $(Build.SourcesDirectory)
+        git checkout $(SetTag.Tag)
+        runtime_version=$(cat eng/Version.Details.xml | grep 'Microsoft.NETCore.App.Runtime.win-x64' | grep -P -o -e '(?<=Version=").*?(?=")') # e.g. 6.0.3
+        dotnet_major_minor_version=$(echo "$runtime_version" | head -c 3) # e.g. 6.0
+        set +x
+        echo "##vso[task.setvariable variable=RuntimeVersion;isOutput=true]${runtime_version}"
+        echo "##vso[task.setvariable variable=DotNetMajorMinorVersion;isOutput=true]${dotnet_major_minor_version}"
+      name: SetVersions
+      displayName: Read runtime version from installer
+
 
 - stage: CreateReleaseAnnouncement
   displayName: Create Release Announcement
@@ -68,6 +92,10 @@ stages:
     variables:
     - name: Tag
       value: $[ stageDependencies.Setup.SetupJob.outputs['SetTag.Tag'] ]
+    - name: DotNetMajorMinorVersion
+      value: $[ stageDependencies.Setup.SetupJob.outputs['SetVersions.DotNetMajorMinorVersion'] ]
+    - name: RuntimeVersion
+      value: $[ stageDependencies.Setup.SetupJob.outputs['SetVersions.RuntimeVersion'] ]
     steps:
 
     - script: |
@@ -95,19 +123,13 @@ stages:
         echo Repo ID is $(repoId)
         echo Discussion Category ID is $(discussionCategoryId)
 
-        # Read runtime version from installer's release commit
-        git clone ${{ variables.sourceRepoUrl }} source
-        cd source
-        git checkout $(Tag)
-        runtime_version=$(cat eng/Version.Details.xml | grep 'Microsoft.NETCore.App.Runtime.win-x64' | grep -P -o -e '(?<=Version=").*?(?=")')
-        dotnet_version=$(echo "$runtime_version" | head -c 3)
-
         # Set environment variables that go in the announcement template
         export TAG=$(Tag)
-        export RUNTIME_VERSION="$runtime_version"
+        export RUNTIME_VERSION="$(RuntimeVersion)"
+        export DOTNET_MAJOR_MINOR_VERSION="$(DotNetMajorMinorVersion)"
         export SDK_VERSION="${{ parameters.sdkVersion }}"
         export TAG_URL="https://github.com/dotnet/installer/releases/tag/$TAG"
-        export RELEASE_NOTES_URL="https://github.com/dotnet/core/blob/main/release-notes/$dotnet_version/$runtime_version/${{ parameters.sdkVersion }}.md"
+        export RELEASE_NOTES_URL="https://github.com/dotnet/core/blob/main/release-notes/$DOTNET_MAJOR_MINOR_VERSION/$RUNTIME_VERSION/$SDK_VERSION.md"
         export DATE=$(date +"%B %Y") # e.g. "March 2022"
 
         template="$(envsubst < $(Build.SourcesDirectory)/eng/source-build-release-announcement.md)"

--- a/eng/source-build-release.yml
+++ b/eng/source-build-release.yml
@@ -29,10 +29,12 @@ parameters:
     default: v6.0.XYY-source-build
 
 variables:
-  repoId: ''
-  discussionCategoryId: ''
-  announcementOrg: 'dotnet'
-  announcementRepo: 'source-build'
+- group: DotNet-Source-Build-Bot-Secrets
+- name: announcementOrg
+  value: 'lbussell'
+- name: announcementRepo
+  value: 'discussion-test'
+
 
 stages:
 
@@ -75,7 +77,8 @@ stages:
         cd $(Build.SourcesDirectory)
         git checkout $(SetTag.Tag)
         runtime_version=$(cat eng/Version.Details.xml | grep 'Microsoft.NETCore.App.Runtime.win-x64' | grep -P -o -e '(?<=Version=").*?(?=")') # e.g. 6.0.3
-        dotnet_major_minor_version=$(echo "$runtime_version" | head -c 3) # e.g. 6.0
+        readarray -d '.' -t version_parts <<< $runtime_version  # split version on dots
+        dotnet_major_minor_version=$(echo "${version_parts[0]}.${version_parts[1]}")
         set +x
         echo "##vso[task.setvariable variable=RuntimeVersion;isOutput=true]${runtime_version}"
         echo "##vso[task.setvariable variable=DotNetMajorMinorVersion;isOutput=true]${dotnet_major_minor_version}"


### PR DESCRIPTION
Moving https://github.com/dotnet/installer/pull/13498 to here.

fixes https://github.com/dotnet/source-build/issues/2776

This is the baseline for the source-build release pipeline that will automate our release day tasks for 6.0-onwards. The pipeline will always live in `main` and (when we have multiple post-6.0 releases) we will trigger it once for each release with the corresponding inputs.

Basic flow of the pipeline:

Inputs: SDK Version, Optional tag override

1. Detect tag from SDK version, or use the optional tag override. For example, if the SDK version `6.0.103` is provided, we will try to find the release tag `v6.0.103` since that is the current naming scheme. The optional tag override is for when we need to make a source-build specific tag, like [v6.0.103-source-build](https://github.com/dotnet/installer/releases/tag/v6.0.103-source-build). In this case you should still submit the correct SDK version because it is used in the announcement post.
2. Determine that the tag actually exists.
3. Find the correct repo and discussion category IDs to give to the GitHub API.
4. Submit the announcement discussion using the template in `source-build-release-announcement.md`. Discussion will be submitted by our [bot](https://github.com/dotnet-sb-bot).

In the future we can submit PRs to update `global.json` in dotnet/installer and automatically let our distro maintainers know about new .NET versions.