### PR TITLE
[main] Fix several release pipeline PR issues

### DIFF
--- a/eng/source-build-release.yml
+++ b/eng/source-build-release.yml
@@ -49,10 +49,10 @@ stages:
         set -euxo pipefail
         if [ "${{ parameters.useCustomTag }}" = "True" ] ; then
           tag=${{ parameters.customTag }}
-          echo "Using custom tag $(tag)"
+          echo "Using custom tag ${tag}"
         else
           tag=v${{ parameters.sdkVersion }}
-          echo "Using tag $(tag)"
+          echo "Using tag ${tag}"
         fi
         set +x
         echo "##vso[task.setvariable variable=Tag;isOutput=true]${tag}"

--- a/eng/submit-source-build-release-pr.sh
+++ b/eng/submit-source-build-release-pr.sh
@@ -130,13 +130,16 @@ new_branch_name="${sdk_version}-${monthYear}-source-build-${time}"
 git checkout -b "${new_branch_name}" "upstream/${pr_target_branch}"
 
 # make pr changes
-cat "${global_json_path}" \
+cat $global_json_path \
     | jq --unbuffered ".tools.dotnet=\"${sdk_version}\"" \
-    | tee "${global_json_path}"
-cat "$versions_props_path" \
-    | sed "s#<PrivateSourceBuiltArtifactsPackageVersion>.*</PrivateSourceBuiltArtifactsPackageVersion>#<PrivateSourceBuiltArtifactsPackageVersion>${sdk_version}</PrivateSourceBuiltArtifactsPackageVersion>#" \
-    | tee "${versions_props_path}"
-git add "${global_json_path}" "${versions_props_path}"
+    | tee $global_json_path
+cat $versions_props_path \
+    | sed "s#<PrivateSourceBuiltArtifactsPackageVersion>.*</PrivateSourceBuiltArtifactsPackageVersion>#<PrivateSourceBuiltArtifactsPackageVersion>$sdk_version</PrivateSourceBuiltArtifactsPackageVersion>#" \
+    | tee $versions_props_path
+git add "$global_json_path" "$versions_props_path"
+
+git config --global user.name "dotnet-sb-bot"
+git config --global user.email "dotnet-sb-bot@microsoft.com"
 git commit -m "update global.json and Versions.props for .NET SDK ${sdk_version}"
 
 # push changes to fork


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/2836

- Fix an incorrectly referenced variable in SetTag task
- Set git username and email for the source-build update commit
- Adjust formatting of commands that edit files so that Versions.props isn't accidentally deleted. I'm not sure what formatting mistake led to the output being empty, so I reverted to the last known working version from when I tested it (and I re-tested it of course).