### PR TITLE
Use sed in-place to edit Versions.props in release PR

### DIFF
--- a/eng/submit-source-build-release-pr.sh
+++ b/eng/submit-source-build-release-pr.sh
@@ -133,9 +133,7 @@ git checkout -b "${new_branch_name}" "upstream/${pr_target_branch}"
 cat $global_json_path \
     | jq --unbuffered ".tools.dotnet=\"${sdk_version}\"" \
     | tee $global_json_path
-cat $versions_props_path \
-    | sed "s#<PrivateSourceBuiltArtifactsPackageVersion>.*</PrivateSourceBuiltArtifactsPackageVersion>#<PrivateSourceBuiltArtifactsPackageVersion>$sdk_version</PrivateSourceBuiltArtifactsPackageVersion>#" \
-    | tee $versions_props_path
+sed -i "s#<PrivateSourceBuiltArtifactsPackageVersion>.*</PrivateSourceBuiltArtifactsPackageVersion>#<PrivateSourceBuiltArtifactsPackageVersion>$sdk_version</PrivateSourceBuiltArtifactsPackageVersion>#" $versions_props_path
 git add "$global_json_path" "$versions_props_path"
 
 git config --global user.name "dotnet-sb-bot"


### PR DESCRIPTION
Should fix https://github.com/dotnet/source-build/issues/2896. I tested the in-place editing syntax locally and it works, but I did not run a full release pipeline in private repos and such.