### PR TITLE
Update documentation with notes from June servicing.

### DIFF
--- a/.github/ISSUE_TEMPLATE/releases/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/releases/release_checklist.md
@@ -13,6 +13,10 @@
 -->
 # {runtime-version} / {sdk-version}
 
+1. - [ ] First-time setup
+      - [ ] Request access to the "DNC Internal" and "DevDiv Source - FTE – Code-Read-only" or "DevDiv Source – Vendors – Code-Read-only" projects in <http://myaccess>.
+      - [ ] Join the [arcade-contrib](https://github.com/orgs/dotnet/teams/arcade-contrib) team on GitHub.
+      - [ ] Set up a VM or Docker container with at least 300GB of disk space.  [This](https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/main/src/fedora/34/amd64/Dockerfile) or [this](https://github.com/dotnet/dotnet-buildtools-prereqs-docker/tree/main/src/ubuntu) Dockerfile are good guides to the packages you will need.
 1. - [ ] Create a OneNote page in the NET Core Acquisition and Deployment
     OneNote > source-build > Servicing > Retrospective > "May 2022"
     (for example) to take ongoing notes on problems with the process,
@@ -78,7 +82,7 @@
         - VSTest (except for feature band updates)
       - [ ] Update `<SourceDirectory>` tags in the `repo/*.proj` files to match the directory that is being cloned.  Usually this means that each repo that changed in servicing needs to have its `<SourceDirectory>` updated to `dotnet-<reponame>`.
 1. - [ ] [Generate a PAT for AzDo](https://dev.azure.com/dnceng/_usersSettings/tokens).
-      - This should include the `dnceng` organization.
+      - This should include the `dnceng` organization.  If your account is not allowed to do this, you can use Arcade's [PatGeneratorTool](https://github.com/dotnet/arcade-services/tree/main/src/Microsoft.DncEng.PatGeneratorTool) to do it programmatically.
       - Scope should include Read for Code and Packages.
 1. - [ ] Iterate towards a green build.
       - For local builds:
@@ -134,6 +138,7 @@
         This will include where each prebuilt is coming from.
       - Find an explanation for each change in each (online/offline) baseline.
         - If possible, figure out the cause and fix.
+          - See [/Documentation/servicing/common-prebuilt-issues.md](here) for docs on issues we see regularly.
           - One typical case is just an update from the previous-previous
             version to the previous version.  For instance, when building
             3.1.25 some templates will go from 3.1.23 to 3.1.24.  These are

--- a/Documentation/servicing/common-prebuilt-issues.md
+++ b/Documentation/servicing/common-prebuilt-issues.md
@@ -1,0 +1,41 @@
+# Common prebuilt issues and how to resolve them
+
+### Old Microsoft.NETCore.Targets versions
+
+These will show up like:
+
+```
+runtime.placeholder-rid.System.Collections.4.3.0
+runtime.placeholder-rid.System.Diagnostics.Tracing.4.3.0
+runtime.placeholder-rid.System.Globalization.4.3.0
+runtime.placeholder-rid.System.Globalization.Calendars.4.3.0
+runtime.placeholder-rid.System.IO.4.3.0
+runtime.placeholder-rid.System.Reflection.4.3.0
+runtime.placeholder-rid.System.Reflection.Primitives.4.3.0
+runtime.placeholder-rid.System.Resources.ResourceManager.4.3.0
+runtime.placeholder-rid.System.Runtime.4.3.0
+runtime.placeholder-rid.System.Runtime.Handles.4.3.0
+runtime.placeholder-rid.System.Runtime.InteropServices.4.3.0
+runtime.placeholder-rid.System.Text.Encoding.4.3.0
+runtime.placeholder-rid.System.Text.Encoding.Extensions.4.3.0
+runtime.placeholder-rid.System.Threading.Tasks.4.3.0
+runtime.placeholder-rid.System.Diagnostics.Debug.4.3.0
+runtime.placeholder-rid.System.IO.FileSystem.4.3.0
+runtime.placeholder-rid.System.Private.Uri.4.3.0
+runtime.placeholder-rid.System.Runtime.Extensions.4.3.0
+```
+
+Typically this means someone solved a component governance issue by adding a new reference to an older System package that brought in an old version if MS.NETCore.Targets, which in turn brings in all of these old runtime packages.  The solution is to add a reference to a newer MS.NETCore.Targets version as [was done in ASP.NET](https://github.com/dotnet/source-build/blob/82416e7d9b7551a4d975505e1f561bb192112050/patches/aspnetcore/0018-Add-Microsoft.NETCore.Targets-explicit-reference-to-.patch).
+
+### WinForms or WPF templates
+
+```
+Microsoft.Dotnet.Wpf.ProjectTemplates
+Microsoft.Dotnet.Wpf.ProjectTemplates
+```
+
+core-sdk has changed the way they reference these a couple times.  Likely a change is needed in [this patch](https://github.com/dotnet/source-build/blob/82416e7d9b7551a4d975505e1f561bb192112050/patches/core-sdk/0008-don-t-restore-winforms-and-wpf-templates.patch) to exclude these templates that source-build doesn't need.
+
+### NuGet/MSBuild/Roslyn/other tooling
+
+Likely this is a new reference that needs to be pinned to a version of the reference package that we have.  See [this Arcade patch](https://github.com/dotnet/source-build/blob/82416e7d9b7551a4d975505e1f561bb192112050/patches/arcade/0007-Update-NuGetVersion-to-Reference-Package-version.patch) for an example.

--- a/Documentation/servicing/update-3.1.md
+++ b/Documentation/servicing/update-3.1.md
@@ -15,6 +15,7 @@
       discussion about using channel vs. build ID.
     * If darc fails on XliffTasks, comment out its `/eng/Version.Details.xml`
       entry temporarily and try again.
+    * This command takes about 20-30 minutes on a good corpnet connection, or up to four hours on a home or VPN connection.
 1. If authenticated feeds were added to `/NuGet.config`, copy them into `/smoke-testNuGet.config`.
 1. Commit changes.
 1. Verify the final state of the repos in `/eng/Version.Details.xml` matches `manifest.json`.


### PR DESCRIPTION
Update our 3.1 servicing checklist with things we learned from June's servicing.  Also start centralizing knowledge about common prebuilt patterns.