### PR TITLE
[release/3.1] Disable RHEL CI

### DIFF
--- a/.vsts.pipelines/builds/matrix.yml
+++ b/.vsts.pipelines/builds/matrix.yml
@@ -88,8 +88,6 @@ stages:
       - job: centos8_Offline
       - job: debian9_Online
       - job: fedora30_Offline
-      - job: rhel7_x64_Offline
-      - job: rhel8_x64_Offline
       - job: rhel8_arm64_Offline
       gatherPortableJob: centos71_Offline_Portable
 
@@ -109,33 +107,4 @@ stages:
         scriptSuffix: .sh
       matrix:
         Production: {}
-        Offline: { type: Offline }
-  - template: ../stages/stage-jobs-matrix.yml
-    parameters:
-      jobTemplateName: ../jobs/ci-local.yml
-      name: rhel7_x64
-      jobParameters:
-        pool:
-          name: DotNet-SourceBuild-Internal
-          demands:
-          - Agent.OSArchitecture -equals X64
-          - rhel -equals 7
-        scriptPrefix: ./
-        scriptSuffix: .sh
-      matrix:
-        Offline: { type: Offline }
-  - template: ../stages/stage-jobs-matrix.yml
-    parameters:
-      jobTemplateName: ../jobs/ci-local.yml
-      name: rhel8_x64
-      jobParameters:
-        pool:
-          name: DotNet-SourceBuild-Internal
-          demands:
-          - Agent.OSArchitecture -equals X64
-          - rhel -equals 8
-        scriptPrefix: ./
-        scriptSuffix: .sh
-        useSystemLibunwind: true
-      matrix:
         Offline: { type: Offline }


### PR DESCRIPTION
See https://github.com/dotnet/arcade/issues/10632 for more context. The machines are being decommissioned and there isn't much value in spending time and effort keeping these legs running, since we already build and test on CentOS 7 and 8.