### PR TITLE
Add GatherPackages to grab smoke-test prereqs.

### DIFF
--- a/.github/ISSUE_TEMPLATE/releases/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/releases/release_checklist.md
@@ -25,7 +25,7 @@
      - [ ] Retrieve smoke-test prereqs artifact for each architecture (e.g. x64 and arm64) from [tarball build](https://dev.azure.com/dnceng/internal/_build?definitionId=1011) (internal link)
        - [ ] x64 - `Build Tarball CentOS7-Offline_Artifacts/dotnet-smoke-test-prereqs.6.0.xxx.tar.gz`
        - [ ] arm64 - `Build Tarball Debian9-Offline_Artifacts/dotnet-smoke-test-prereqs.6.0.xxx.tar.gz`
-     - [ ] Retrieve additional packages from internal MSFT feed using [this project](../../test/GatherPackages.csproj).
+     - [ ] Retrieve additional packages from internal MSFT feed using [this project](../../../test/GatherPackages.csproj).
      - [ ] Create a new tarball of unique packages using [this script](https://gist.github.com/lbussell/5789974491e3d3ed737aac0e8b97b594).
      - [ ] Upload smoke-test-prereqs tarball to dotnetclimsrc storage account, following the pattern of previous releases for directory and filename.
          - Never overwrite a tarball. At least change the blob storage virtual dir to represent a new build. This can help avoid timing issues and make it more obvious if stale links were accidentally re-sent rather than new ones.

--- a/.github/ISSUE_TEMPLATE/releases/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/releases/release_checklist.md
@@ -25,7 +25,7 @@
      - [ ] Retrieve smoke-test prereqs artifact for each architecture (e.g. x64 and arm64) from [tarball build](https://dev.azure.com/dnceng/internal/_build?definitionId=1011) (internal link)
        - [ ] x64 - `Build Tarball CentOS7-Offline_Artifacts/dotnet-smoke-test-prereqs.6.0.xxx.tar.gz`
        - [ ] arm64 - `Build Tarball Debian9-Offline_Artifacts/dotnet-smoke-test-prereqs.6.0.xxx.tar.gz`
-     - [ ] Retrieve additional packages from internal MSFT feed using [this project](https://gist.github.com/lbussell/47a3953686c218ede865e305478df74a).
+     - [ ] Retrieve additional packages from internal MSFT feed using [this project](../../test/GatherPackages.csproj).
      - [ ] Create a new tarball of unique packages using [this script](https://gist.github.com/lbussell/5789974491e3d3ed737aac0e8b97b594).
      - [ ] Upload smoke-test-prereqs tarball to dotnetclimsrc storage account, following the pattern of previous releases for directory and filename.
          - Never overwrite a tarball. At least change the blob storage virtual dir to represent a new build. This can help avoid timing issues and make it more obvious if stale links were accidentally re-sent rather than new ones.

--- a/test/GatherPackages.csproj
+++ b/test/GatherPackages.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RestorePackagesPath>$(MSBuildThisFileDirectory)/restored/</RestorePackagesPath>
+    <PackageVersionToDownload>6.0.0</PackageVersionToDownload>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageDownload Include="Microsoft.NET.Runtime.Emscripten.2.0.23.Node.linux-x64" Version="[$(PackageVersionToDownload)]" Condition="$(PackageVersionToDownload.StartsWith('6.0'))" />
+    <PackageDownload Include="Microsoft.NET.Runtime.Emscripten.2.0.23.Sdk.linux-x64" Version="[$(PackageVersionToDownload)]" Condition="$(PackageVersionToDownload.StartsWith('6.0'))" />
+    <PackageDownload Include="Microsoft.NET.Runtime.Emscripten.3.1.12.Node.linux-x64" Version="[$(PackageVersionToDownload)]" Condition="$(PackageVersionToDownload.StartsWith('7.0'))" />
+    <PackageDownload Include="Microsoft.NET.Runtime.Emscripten.3.1.12.Sdk.linux-x64" Version="[$(PackageVersionToDownload)]" Condition="$(PackageVersionToDownload.StartsWith('7.0'))" />
+    <PackageDownload Include="Microsoft.NET.Runtime.MonoAOTCompiler.Task" Version="[$(PackageVersionToDownload)]" />
+    <PackageDownload Include="Microsoft.NET.Runtime.MonoTargets.Sdk" Version="[$(PackageVersionToDownload)]" />
+    <PackageDownload Include="Microsoft.NET.Runtime.WebAssembly.Sdk" Version="[$(PackageVersionToDownload)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Runtime.AOT.linux-x64.Cross.browser-wasm" Version="[$(PackageVersionToDownload)]" />
+    <PackageDownload Include="microsoft.netcore.app.runtime.mono.browser-wasm" Version="[$(PackageVersionToDownload)]" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This adds the GatherPackages.csproj used to get the smoke-test prereqs - I thought having this centralized and working for all versions was worthwhile.  I will add instructions for use to the checklist when I make that PR.