### PR TITLE
Make the SB mirroring pipeline work for 8.0 preview 1

### DIFF
--- a/eng/source-build-pre-release-8.0.yml
+++ b/eng/source-build-pre-release-8.0.yml
@@ -8,7 +8,7 @@ pool:
 resources:
   pipelines:
   - pipeline: dotnet-staging-pipeline-resource
-    source: Stage-DotNet-Test
+    source: Stage-DotNet
 
 parameters:
 - name: useSpecificPipelineRunIDs

--- a/eng/source-build-release-mirror.yml
+++ b/eng/source-build-release-mirror.yml
@@ -20,11 +20,11 @@ parameters:
 variables:
 - group: DotNet-Source-Build-All-Orgs-Source-Access
 - name: RepoDir
-  value: 'vmr'
+  value: vmr
 - name: GitUser
-  value: 'dn-bot'
+  value: dn-bot
 - name: GitEmail
-  value: 'dn-bot@microsoft.com'
+  value: dn-bot@microsoft.com
 
 jobs:
 - ${{ each mirror in parameters.mirrors }}:
@@ -35,7 +35,6 @@ jobs:
 
     - script: |
         set -euo pipefail
-        set -x
 
         repo_dir=$(Pipeline.Workspace)/$(RepoDir)
         git init "${repo_dir}"
@@ -58,7 +57,6 @@ jobs:
     - ${{ each branch in mirror.branches }}:
       - script: |
           set -euxo pipefail
-          set -x
 
           git fetch source "${{ branch.name }}"
           git checkout "${{ branch.name }}"

--- a/eng/source-build-release-mirror.yml
+++ b/eng/source-build-release-mirror.yml
@@ -34,6 +34,7 @@ jobs:
 
     - script: |
         set -euo pipefail
+        set -x
 
         repo_dir=$(Pipeline.Workspace)/$(RepoDir)
         git init "${repo_dir}"
@@ -56,6 +57,7 @@ jobs:
     - ${{ each branch in mirror.branches }}:
       - script: |
           set -euxo pipefail
+          set -x
 
           git fetch source "${{ branch.name }}"
           git checkout "${{ branch.name }}"

--- a/eng/source-build-release-mirror.yml
+++ b/eng/source-build-release-mirror.yml
@@ -29,6 +29,7 @@ variables:
 jobs:
 - ${{ each mirror in parameters.mirrors }}:
   - job:
+    displayName: Mirror ${{ mirror.sourceUrl }}
     steps:
     - checkout: none
 
@@ -45,8 +46,8 @@ jobs:
         git config --global user.name "${{ variables.GitUser }}"
         git config --global user.email "${{ variables.GitEmail }}"
 
-        source_url=$(echo "${{ mirror.sourceUrl }}" | sed "s,https://.*@,https://${{ variables.GitUser }}:${AZDO_PAT}@,g")
-        destination_url=$(echo "${{ mirror.destinationUrl }}" | sed "s,https://.*@,https://${{ variables.GitUser }}:${AZDO_PAT}@,g")
+        source_url=$(echo '${{ mirror.sourceUrl }}' | sed "s,https://.*@,https://${{ variables.GitUser }}:${AZDO_PAT}@,g")
+        destination_url=$(echo '${{ mirror.destinationUrl }}' | sed "s,https://.*@,https://${{ variables.GitUser }}:${AZDO_PAT}@,g")
 
         git remote add source "${source_url}"
         git remote add destination "${destination_url}"
@@ -66,7 +67,7 @@ jobs:
           message=".NET Source-build ${{ branch.sdkVersion }}-SDK"
           git tag "${tag_name}" HEAD -m "${message}"
 
-          git fetch destination "${{ branch.name }}"
+          git fetch destination '${{ branch.name }}' || echo 'Branch ${{ branch.name }} does not exist in destination yet'
 
           git push --follow-tags destination "${{ branch.name }}"
         workingDirectory: $(Pipeline.Workspace)/$(RepoDir)

--- a/eng/source-build-release-mirror.yml
+++ b/eng/source-build-release-mirror.yml
@@ -39,6 +39,8 @@ jobs:
         git init "${repo_dir}"
         cd "${repo_dir}"
 
+        echo "Setting up git in ${repo_dir} repo for ${{ mirror.sourceUrl }} -> ${{ mirror.destinationUrl }}"
+
         git config --global user.name "${{ variables.GitUser }}"
         git config --global user.email "${{ variables.GitEmail }}"
 


### PR DESCRIPTION
There were a couple of minor things such as it could only push to an already existing branch.

I was able to mirror a dev branch: https://dev.azure.com/dnceng/internal/_build/results?buildId=2112291&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e&t=bf6cf4cf-6432-59cf-d384-6b3bcf32ede2

https://github.com/dotnet/source-build/issues/3194