### PR TITLE
Automate creation of GitHub tag & release 

### DIFF
--- a/.github/ISSUE_TEMPLATE/releases/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/releases/release_checklist.md
@@ -58,10 +58,7 @@
            - [ ] Approve the `Approval - Partner notification` approval stage.
       1. - [ ] `Approval - Release` stage
            - [ ] **SYNC POINT**: Wait for Microsoft build release.
-           - [ ] ⚠️ 8.0: In case you decided to not create the GitHub release (you set the pipeline parameter to `skip`), push the release tag to `dotnet/dotnet`
-                - The tag name should match the custom tag used when staging the release pipeline.
-                - The tag should be available in the `dnceng/dotnet-security-partners` repository.
-                - The commit to which this tag belongs is shown in the `Pre-Release` stage (in the `Get Associated Pipeline Run IDs` step).
+           - [ ] ⚠️ 8.0: Verify the release tag in the `dnceng/dotnet-security-partners` repository matches theVMR commit to which is shown in the `Pre-Release` stage (in the `Get Associated Pipeline Run IDs` step).
            - [ ] Approve the `Approval - Release` approval stage.
       1. - [ ] `Release` stage
            - [ ] Verify that the announcement was posted to [dotnet/source-build discussions](https://github.com/dotnet/source-build/discussions) and that the content is correct and all links work.

--- a/.github/ISSUE_TEMPLATE/releases/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/releases/release_checklist.md
@@ -9,7 +9,7 @@
 1. - [ ] Retrieve the final run of the [Stage-DotNet](https://dev.azure.com/dnceng/internal/_build?definitionId=792&_a=summary) pipeline from internal release communications.
 1. - [ ] Run the [`source-build-release-official`](https://dev.azure.com/dnceng/internal/_build?definitionId=1229) pipeline.
      - When staging the pipeline run, click "Resources" and select the final run of `Stage-DotNet` mentioned above.
-     - If a special source-build tag was created for the release, check `Use custom tag?` and set the `Installer custom tag` parameter.
+     - If a special source-build tag was created for the release, check `Use custom tag` and set the `Custom tag` parameter. Otherwise, a release name from the release manifest is used.
      - If necessary, run the pipeline as a dry-run first to make sure the stages have the correct output.
      - In case a different installer commit is being released than the one in the associated staging pipeline, input the official build numbers of the builds belonging to the released commit.
      - The pipeline has several stages with approval gates in between them where each approval should follow some verification described in this checklist.
@@ -22,7 +22,7 @@
            - **It is advised to run this stage a day prior to the release to verify that all required builds exist.**
            - ⚠️ 8.0: It can happen that the commit of installer that the staging pipeline is associated with doesn't have a corresponding VMR build (as this one is batched). In this case, the stage will fail to find it and let you know it didn't find the build. When this happens, queue the [`dotnet-dotnet`](https://dev.azure.com/dnceng/internal/_build?definitionId=1219) pipeline from the VMR commit that has synchronized the installer commit that is being released (you can search commits in VMR for the commit SHA as it's part of the commit message). The resulting build run should be tagged with the installer SHA. You can then re-run the `Pre-Release` stage and it should find this build.
            - ⚠️ 6.0 / 7.0: This pipeline also uploads the dotnet source tarball to `dotnetclimsrc` with the tarball contents.
-           - The `dotnet/installer` commit that represents the release will be in the logs for "Read Release Info"
+           - [ ] Verify the release metadata logged as part of the `Read Release Info` build step.
            - The `Get Associated Pipeline Run IDs` build step will contain links to pipelines associated with this release:
                 - ⚠️ 6.0 / 7.0: [dotnet-installer-official-ci](https://dev.azure.com/dnceng/internal/_build?definitionId=286) and [dotnet-installer-source-build-tarball-build](https://dev.azure.com/dnceng/internal/_build?definitionId=1011)
                 - ⚠️ 8.0: [dotnet-dotnet](https://dev.azure.com/dnceng/internal/_build?definitionId=1219) and the `dotnet/dotnet` commit that represents the release
@@ -58,7 +58,7 @@
            - [ ] Approve the `Approval - Partner notification` approval stage.
       1. - [ ] `Approval - Release` stage
            - [ ] **SYNC POINT**: Wait for Microsoft build release.
-           - [ ] ⚠️ 8.0: Push the release tag to `dotnet/dotnet`
+           - [ ] ⚠️ 8.0: In case you decided to not create the GitHub release (you set the pipeline parameter to `skip`), push the release tag to `dotnet/dotnet`
                 - The tag name should match the custom tag used when staging the release pipeline.
                 - The tag should be available in the `dnceng/dotnet-security-partners` repository.
                 - The commit to which this tag belongs is shown in the `Pre-Release` stage (in the `Get Associated Pipeline Run IDs` step).
@@ -67,6 +67,7 @@
            - [ ] Verify that the announcement was posted to [dotnet/source-build discussions](https://github.com/dotnet/source-build/discussions) and that the content is correct and all links work.
                 - If special edits to the announcement are needed, or the content of the announcement discussion is incorrect, source-build repo maintainers can edit the discussion directly once it is posted.
                 - [ ] ⚠️ 7.0 / 8.0: Fix the release notes link ([known issue](https://github.com/dotnet/source-build/issues/3178))
+           - [ ] ⚠️ 8.0: In case a release has been published into `dotnet/dotnet` as draft, check its contents and publish it. The URL to the draft can be find in the `Create GitHub release` step.
            - [ ] Verify that the release-day PR was submitted to [dotnet/installer](https://github.com/dotnet/installer/pulls) and the content is correct.
                 - If there is an error in the PR, commit directly to the PR branch directly to fix the problem by hand, then submit an issue to [dotnet/source-build](https://github.com/dotnet/source-build).
 1. - [ ] Once the internal changes have been merged to the public GitHub repos, update the `PoisonTests` and `SdkContentTests` with any diffs from the official associated build.

--- a/eng/get-build-info.sh
+++ b/eng/get-build-info.sh
@@ -75,10 +75,10 @@ function get_build_info() {
     local source_version_variable_name="$6"
     local check_build_status="$7"
     local search_by="$8"
-    local commit="$9"
+    local query="$9"
 
     IFS=' '
-    run_info=$(get_build_run "$pipeline_id" "$pipeline_name" "$azdo_org" "$azdo_project" "$check_build_status" "$search_by" "$commit")
+    run_info=$(get_build_run "$pipeline_id" "$pipeline_name" "$azdo_org" "$azdo_project" "$check_build_status" "$search_by" "$query")
     if [[ $? != "0" ]]; then
         echo "$run_info"
         exit 1

--- a/eng/get-build-info.sh
+++ b/eng/get-build-info.sh
@@ -9,14 +9,16 @@ function get_build_run () {
     local azdo_project="$4"
     local check_build_status="$5"
     local search_by="$6"
-    local commit="$7"
+    local query="$7"
 
     # We search by a tag or by a commit for which the build was running
     # We use the tag for the VMR builds (8.0+) and the commit for older installer builds
     if [[ "$search_by" == 'tag' ]]; then
-        build_runs=$(az pipelines runs list --organization "$azdo_org" --project "$azdo_project" --pipeline-ids "$pipeline_id" --tags "$commit")
+        build_runs=$(az pipelines runs list --organization "$azdo_org" --project "$azdo_project" --pipeline-ids "$pipeline_id" --tags "$query")
+    elif [[ "$search_by" == 'name' ]]; then
+        build_runs=$(az pipelines runs list --organization "$azdo_org" --project "$azdo_project" --pipeline-ids "$pipeline_id" --query "[?buildNumber == '$query']")
     else
-        build_runs=$(az pipelines runs list --organization "$azdo_org" --project "$azdo_project" --pipeline-ids "$pipeline_id" --query "[?sourceVersion == '$commit']")
+        build_runs=$(az pipelines runs list --organization "$azdo_org" --project "$azdo_project" --pipeline-ids "$pipeline_id" --query "[?sourceVersion == '$query']")
     fi
 
     runs=$(echo "$build_runs" | jq -r '[.[] | { "result": .result, "id": .id, "buildNumber": .buildNumber, "sourceVersion": .sourceVersion }]')
@@ -64,7 +66,7 @@ function print_build_info() {
     echo "##vso[task.setvariable variable=${source_version_variable_name};isOutput=true]${source_version}"
 }
 
-function get_build_info () {
+function get_build_info() {
     local azdo_org="$1"
     local azdo_project="$2"
     local pipeline_id="$3"

--- a/eng/source-build-release-announcement.md
+++ b/eng/source-build-release-announcement.md
@@ -1,6 +1,6 @@
-<!-- This file is a template for a GitHub Discussion post.  -->
+<!-- This file is a template for a GitHub Discussion post. -->
 <!-- The line prefixed by 'Title:' will be submitted as the title of the discussion, and the rest of the file will be submitted as the body. -->
-Title: .NET $RELEASE_CHANNEL $RELEASE_DATE Update - .NET $RUNTIME_VERSION and SDK $SDK_VERSION
+Title: .NET $RELEASE_NAME $RELEASE_DATE Update - .NET $RUNTIME_VERSION and SDK $SDK_VERSION
 
 Please use the [$TAG tag]($TAG_URL) to source-build .NET version $RUNTIME_VERSION / $SDK_VERSION.
 

--- a/eng/source-build-release-official.yml
+++ b/eng/source-build-release-official.yml
@@ -69,6 +69,7 @@ parameters:
   displayName: Submit Release PR
   type: boolean
   default: true
+# Auto means that for dry run, we only create a draft release; full otherwise.
 - name: createGitHubRelease
   displayName: '[⚠️ 8.0] Create tag & release in dotnet/dotnet'
   type: string

--- a/eng/source-build-release-official.yml
+++ b/eng/source-build-release-official.yml
@@ -8,6 +8,12 @@ resources:
   pipelines:
   - pipeline: dotnet-staging-pipeline-resource
     source: Stage-DotNet
+    version: 20230215.2-8.0.100-preview.1.23115.2-167122 # TODO: Remove this
+  repositories:
+  - repository: dotnet-dotnet
+    type: git
+    name: dotnet-dotnet
+    ref: ${{ parameters.releaseBranchName }}
 
 pool:
   name: NetCore1ESPool-Svc-Internal
@@ -24,6 +30,18 @@ parameters:
 - name: releaseBranchName
   displayName: Release branch name (e.g. release/8.0.1xx-preview1)
   type: string
+- name: isPreviewRelease
+  displayName: Preview release
+  type: boolean
+  default: false
+- name: useCustomTag
+  displayName: Use custom tag
+  type: boolean
+  default: false
+- name: customTag
+  displayName: Custom release tag (e.g. v6.0.XYY-source-build)
+  type: string
+  default: ' '
 - name: useSpecificPipelineRunIDs
   displayName: Use specific pipeline run IDs
   type: boolean
@@ -45,25 +63,18 @@ parameters:
   type: boolean
   default: true
 - name: createReleaseAnnouncement
-  displayName:  Create Release Announcement
+  displayName: Create Release Announcement
   type: boolean
   default: true
 - name: submitReleasePR
   displayName: Submit Release PR
   type: boolean
   default: true
-- name: useCustomTag
-  displayName: Use custom tag?
-  type: boolean
-  default: false
-- name: customTag
-  displayName: Custom release tag (e.g. v6.0.XYY-source-build)
+- name: createGitHubRelease
+  displayName: '[⚠️ 8.0] Create tag & release in dotnet/dotnet'
   type: string
-  default: ' '
-- name: pushGitHubTag
-  displayName: Push release tag to GitHub
-  type: boolean
-  default: true
+  values: [ 'skip', 'draft', 'full' ]
+  default: draft
 - name: isDryRun
   displayName: Dry Run
   type: boolean
@@ -128,7 +139,8 @@ stages:
     dotnetMajorVersion: ${{ parameters.dotnetMajorVersion }}
     releaseName: ${{ parameters.releaseName }}
     releaseBranchName: ${{ parameters.releaseBranchName }}
+    isPreviewRelease: ${{ parameters.isPreviewRelease }}
     createReleaseAnnouncement: ${{ parameters.createReleaseAnnouncement }}
-    pushGitHubTag: ${{ parameters.pushGitHubTag }}
+    createGitHubRelease: ${{ parameters.createGitHubRelease }}
     submitReleasePR: ${{ parameters.submitReleasePR }}
     isDryRun: ${{ parameters.isDryRun }}

--- a/eng/source-build-release-official.yml
+++ b/eng/source-build-release-official.yml
@@ -72,8 +72,8 @@ parameters:
 - name: createGitHubRelease
   displayName: '[⚠️ 8.0] Create tag & release in dotnet/dotnet'
   type: string
-  values: [ 'skip', 'draft', 'full' ]
-  default: draft
+  values: [ 'auto', 'skip', 'draft', 'full' ]
+  default: auto
 - name: isDryRun
   displayName: Dry Run
   type: boolean

--- a/eng/source-build-release-official.yml
+++ b/eng/source-build-release-official.yml
@@ -8,7 +8,6 @@ resources:
   pipelines:
   - pipeline: dotnet-staging-pipeline-resource
     source: Stage-DotNet
-    version: 20230215.2-8.0.100-preview.1.23115.2-167122 # TODO: Remove this
   repositories:
   - repository: dotnet-dotnet
     type: git
@@ -16,10 +15,8 @@ resources:
     ref: ${{ parameters.releaseBranchName }}
 
 pool:
-  # TODO
-  # name: NetCore1ESPool-Svc-Internal
-  # demands: ImageOverride -equals 1es-ubuntu-2004
-  vmImage: ubuntu-latest
+  name: NetCore1ESPool-Svc-Internal
+  demands: ImageOverride -equals 1es-ubuntu-2004
 
 parameters:
 - name: dotnetMajorVersion

--- a/eng/source-build-release-official.yml
+++ b/eng/source-build-release-official.yml
@@ -18,6 +18,9 @@ parameters:
   displayName: Major .NET version being released
   type: string
   values: [ '6.0', '7.0', '8.0' ]
+- name: releaseName
+  displayName: Release name (e.g. ".NET 8.0 Preview 1")
+  type: string
 - name: releaseBranchName
   displayName: Release branch name (e.g. release/8.0.1xx-preview1)
   type: string
@@ -57,6 +60,10 @@ parameters:
   displayName: Custom release tag (e.g. v6.0.XYY-source-build)
   type: string
   default: ' '
+- name: pushGitHubTag
+  displayName: Push release tag to GitHub
+  type: boolean
+  default: true
 - name: isDryRun
   displayName: Dry Run
   type: boolean
@@ -73,6 +80,8 @@ stages:
     dotnetInstallerOfficialRunID: ${{ parameters.dotnetInstallerOfficialRunID }}
     dotnetInstallerTarballBuildRunID: ${{ parameters.dotnetInstallerTarballBuildRunID }}
     verifyBuildSuccess: ${{ parameters.verifyBuildSuccess }}
+    useCustomTag: ${{ parameters.useCustomTag }}
+    customTag: ${{ replace(parameters.customTag, ' ', '') }}
     isDryRun: ${{ parameters.isDryRun }}
 
 - stage: MirrorApproval
@@ -117,9 +126,9 @@ stages:
   parameters:
     dotnetStagingPipelineResource: dotnet-staging-pipeline-resource
     dotnetMajorVersion: ${{ parameters.dotnetMajorVersion }}
+    releaseName: ${{ parameters.releaseName }}
     releaseBranchName: ${{ parameters.releaseBranchName }}
     createReleaseAnnouncement: ${{ parameters.createReleaseAnnouncement }}
-    useCustomTag: ${{ parameters.useCustomTag }}
-    customTag: ${{ replace(parameters.customTag, ' ', '') }}
+    pushGitHubTag: ${{ parameters.pushGitHubTag }}
     submitReleasePR: ${{ parameters.submitReleasePR }}
     isDryRun: ${{ parameters.isDryRun }}

--- a/eng/source-build-release-official.yml
+++ b/eng/source-build-release-official.yml
@@ -16,8 +16,10 @@ resources:
     ref: ${{ parameters.releaseBranchName }}
 
 pool:
-  name: NetCore1ESPool-Svc-Internal
-  demands: ImageOverride -equals 1es-ubuntu-2004
+  # TODO
+  # name: NetCore1ESPool-Svc-Internal
+  # demands: ImageOverride -equals 1es-ubuntu-2004
+  vmImage: ubuntu-latest
 
 parameters:
 - name: dotnetMajorVersion

--- a/eng/templates/stages/pre-release.yml
+++ b/eng/templates/stages/pre-release.yml
@@ -28,6 +28,10 @@ parameters:
   displayName: Verify that associated pipeline runs succeeded
   type: boolean
   default: true
+- name: useCustomTag
+  type: boolean
+- name: customTag
+  type: string
 - name: isDryRun
   displayName: Dry Run
   type: boolean
@@ -60,7 +64,7 @@ stages:
           value: release
 
     steps:
-    - template: ../steps/get-build-info.yml
+    - template: ../steps/initialize-release-info.yml
       parameters:
         dotnetStagingPipelineResource: dotnet-staging-pipeline-resource
         releaseBranchName: ${{ parameters.releaseBranchName }}
@@ -70,6 +74,8 @@ stages:
         dotnetInstallerOfficialRunID: ${{ parameters.dotnetInstallerOfficialRunID }}
         dotnetInstallerTarballBuildRunID: ${{ parameters.dotnetInstallerTarballBuildRunID }}
         verifyBuildSuccess: ${{ parameters.verifyBuildSuccess }}
+        useCustomTag: ${{ parameters.useCustomTag }}
+        customTag: ${{ replace(parameters.customTag, ' ', '') }}
         isDryRun: ${{ parameters.isDryRun }}
 
     - ${{ if or(eq(parameters.dotnetMajorVersion, '6.0'), eq(parameters.dotnetMajorVersion, '7.0')) }}:

--- a/eng/templates/stages/pre-release.yml
+++ b/eng/templates/stages/pre-release.yml
@@ -68,7 +68,6 @@ stages:
       parameters:
         dotnetStagingPipelineResource: dotnet-staging-pipeline-resource
         releaseBranchName: ${{ parameters.releaseBranchName }}
-        getAssociatedPipelineRuns: true
         useSpecificPipelineRunIDs: ${{ parameters.useSpecificPipelineRunIDs }}
         dotnetDotnetRunID: ${{ parameters.dotnetDotnetRunID }}
         dotnetInstallerOfficialRunID: ${{ parameters.dotnetInstallerOfficialRunID }}

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -115,7 +115,6 @@ stages:
     steps:
     - checkout: self
 
-    # TODO: Add not(parameters.isDryRun)
     - ${{ if and(ne(parameters.createGitHubRelease, 'skip'), ne(parameters.dotnetMajorVersion, '6.0'), ne(parameters.dotnetMajorVersion, '7.0')) }}:
       - checkout: dotnet-dotnet
         displayName: Checkout dotnet-dotnet
@@ -159,29 +158,31 @@ stages:
         env:
           GH_TOKEN: $(BotAccount-dotnet-bot-repo-PAT)
 
-    - script: |
-        set -euo pipefail
+    # Skip release tag validation for draft releases as the tag won't be immediately visible until the draft is published
+    - ${{ if or(eq(parameters.createGitHubRelease, 'skip'), eq(parameters.createGitHubRelease, 'full'), eq(parameters.dotnetMajorVersion, '6.0'), eq(parameters.dotnetMajorVersion, '7.0')) }}:
+      - script: |
+          set -euo pipefail
 
-        if [[ "$(releaseChannel)" == '6.0' || "$(releaseChannel)" == '7.0' ]]; then
-          repo='installer'
-        else
-          repo='dotnet'
-        fi
+          if [[ "$(releaseChannel)" == '6.0' || "$(releaseChannel)" == '7.0' ]]; then
+            repo='installer'
+          else
+            repo='dotnet'
+          fi
 
-        # Checks for all matching tags (there can be more, e.g. 7.0.100 will match 7.0.100-preview.1.21102.12)
-        query="{ repository(owner: \"dotnet\", name: \"$repo\") { refs(refPrefix: \"refs/tags/\", last: 100, query: \"$(releaseTag)\") { nodes { name }}}}"
-        tags=$(gh api graphql -f query="$query" --template '{{.data.repository.refs.nodes}}')
+          # Checks for all matching tags (there can be more, e.g. 7.0.100 will match 7.0.100-preview.1.21102.12)
+          query="{ repository(owner: \"dotnet\", name: \"$repo\") { refs(refPrefix: \"refs/tags/\", last: 100, query: \"$(releaseTag)\") { nodes { name }}}}"
+          tags=$(gh api graphql -f query="$query" --template '{{.data.repository.refs.nodes}}')
 
-        # Find the exact match
-        if echo "$tags" | grep -q "map\[name:$(releaseTag)\]"; then
-          echo "Tag $(releaseTag) exists"
-        else
-          echo "##vso[task.logissue type=error]Tag $(releaseTag) does not exist in dotnet/$repo"
-          exit 1
-        fi
-      displayName: Validate release tag
-      env:
-        GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
+          # Find the exact match
+          if echo "$tags" | grep -q "map\[name:$(releaseTag)\]"; then
+            echo "Tag $(releaseTag) exists"
+          else
+            echo "##vso[task.logissue type=error]Tag $(releaseTag) does not exist in dotnet/$repo"
+            exit 1
+          fi
+        displayName: Validate release tag
+        env:
+          GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
 
     - ${{ if parameters.createReleaseAnnouncement }}:
       - script: |

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -84,6 +84,20 @@ stages:
     - name: sdkArtifactFileName
       value: dotnet-sdk-*.tar.gz
 
+  # GitHub release is skipped for 6.0/7.0
+  # For dry run, we only create a draft release
+  - name: createGitHubRelease
+    ${{ if eq(parameters.createGitHubRelease, 'auto') }}:
+      ${{ if or(eq(parameters.dotnetMajorVersion, '6.0'), eq(parameters.dotnetMajorVersion, '7.0')) }}:
+        value: skip
+      ${{ else }}:
+        ${{ if parameters.isDryRun }}:
+          value: draft
+        ${{ else }}:
+          value: full
+    ${{ else }}:
+      value: ${{ parameters.createGitHubRelease }}
+
   # Variables from the Pre-Release stage
   - name: release
     value: $[ stageDependencies.PreRelease.PreRelease.outputs['ReadReleaseInfo.Release'] ]
@@ -115,7 +129,7 @@ stages:
     steps:
     - checkout: self
 
-    - ${{ if and(ne(parameters.createGitHubRelease, 'skip'), ne(parameters.dotnetMajorVersion, '6.0'), ne(parameters.dotnetMajorVersion, '7.0')) }}:
+    - ${{ if and(ne(variables.createGitHubRelease, 'skip'), ne(parameters.dotnetMajorVersion, '6.0'), ne(parameters.dotnetMajorVersion, '7.0')) }}:
       - checkout: dotnet-dotnet
         displayName: Checkout dotnet-dotnet
         fetchDepth: 0
@@ -143,7 +157,7 @@ stages:
           fi
 
           draft=''
-          if [ ${{ parameters.createGitHubRelease }} = draft ]; then
+          if [ ${{ variables.createGitHubRelease }} = draft ]; then
             draft='--draft'
           fi
 
@@ -159,7 +173,7 @@ stages:
           GH_TOKEN: $(BotAccount-dotnet-bot-repo-PAT)
 
     # Skip release tag validation for draft releases as the tag won't be immediately visible until the draft is published
-    - ${{ if or(eq(parameters.createGitHubRelease, 'skip'), eq(parameters.createGitHubRelease, 'full'), eq(parameters.dotnetMajorVersion, '6.0'), eq(parameters.dotnetMajorVersion, '7.0')) }}:
+    - ${{ if or(eq(variables.createGitHubRelease, 'skip'), eq(variables.createGitHubRelease, 'full'), eq(parameters.dotnetMajorVersion, '6.0'), eq(parameters.dotnetMajorVersion, '7.0')) }}:
       - script: |
           set -euo pipefail
 

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -147,7 +147,7 @@ stages:
             draft='--draft'
           fi
 
-          gh release create "$(releaseTag)" "$(SourceTarballPath)#Packed sources" \
+          gh release create "$(releaseTag)" "$(SourceTarballPath)#Source code (tar.gz)" \
             --repo dotnet/dotnet \
             --title "${{ parameters.releaseName }}" \
             --target "$(dotnetDotnetCommit)" \

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -33,7 +33,7 @@ stages:
 
   - group: DotNet-Source-Build-Bot-Secrets
   - group: DotNet-DotNetCli-Storage
-  - group: DotNetBot-GitHub
+  - group: DotNetBot-GitHub-AllBranches
 
   - name: releasePrRepo
     value: dotnet/installer

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -111,7 +111,7 @@ stages:
 
   jobs:
   - job: Release
-    displayName: Announce & Release
+    displayName: Announcements, PRs & Release
     steps:
     - checkout: self
 
@@ -123,7 +123,7 @@ stages:
         fetchTags: true
 
       - script: |
-          set -euxo pipefail
+          set -euo pipefail
           tarball_path="$(Build.ArtifactStagingDirectory)/dotnet-sdk-source-$(release).tar.gz"
           echo "Creating source tarball from dotnet-dotnet / $(dotnetDotnetCommit)"
 
@@ -136,7 +136,7 @@ stages:
         workingDirectory: $(Build.SourcesDirectory)/dotnet-dotnet
 
       - script: |
-          set -euxo pipefail
+          set -euo pipefail
 
           prerelease=''
           if [ ${{ parameters.isPreviewRelease }} = True ]; then

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -132,7 +132,7 @@ stages:
           echo "##vso[task.setvariable variable=SourceTarballPath]$tarball_path"
 
         displayName: Prepare source tarball
-        workingDirectory: $(Agent.BuildDirectory)/dotnet-dotnet
+        workingDirectory: $(Build.SourcesDirectory)/dotnet-dotnet
 
       - script: |
           set -euxo pipefail
@@ -246,7 +246,7 @@ stages:
             echo "Release Notes URL: $RELEASE_NOTES_URL"
           fi
         displayName: Submit announcement discussion
-        workingDirectory: $(Agent.BuildDirectory)/source-build/eng
+        workingDirectory: $(Build.SourcesDirectory)/dotnet-source-build/eng
         env:
           GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
 
@@ -340,6 +340,6 @@ stages:
               "${extraArgs[@]}"
           fi
         displayName: Submit Release PR
-        workingDirectory: $(Agent.BuildDirectory)/source-build/eng
+        workingDirectory: $(Build.SourcesDirectory)/dotnet-source-build/eng
         env:
           GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -33,6 +33,7 @@ stages:
 
   - group: DotNet-Source-Build-Bot-Secrets
   - group: DotNet-DotNetCli-Storage
+  - group: DotNetBot-GitHub
 
   - name: releasePrRepo
     value: dotnet/installer
@@ -156,7 +157,7 @@ stages:
 
         displayName: Create GitHub release
         env:
-          GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
+          GH_TOKEN: $(BotAccount-dotnet-bot-repo-PAT)
 
     - script: |
         set -euo pipefail

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -3,6 +3,8 @@ parameters:
   type: string
 - name: dotnetMajorVersion
   type: string
+- name: releaseName
+  type: string
 - name: releaseBranchName
   type: string
 - name: createReleaseAnnouncement
@@ -11,11 +13,8 @@ parameters:
 - name: submitReleasePR
   type: boolean
   default: true
-- name: useCustomTag
+- name: pushGitHubTag
   type: boolean
-  default: false
-- name: customTag
-  type: string
 - name: isDryRun
   type: boolean
   default: false
@@ -28,10 +27,15 @@ stages:
   - ReleaseApproval
 
   variables:
+  - template: ../variables/pipelines.yml
+
   - group: DotNet-Source-Build-Bot-Secrets
   - group: DotNet-DotNetCli-Storage
 
-  - template: ../variables/pipelines.yml
+  - name: releasePrRepo
+    value: dotnet/installer
+  - name: releasePrForkRepo
+    value: dotnet-sb-bot/installer
   - name: announcementOrg
     value: dotnet
   - name: announcementRepo
@@ -53,13 +57,41 @@ stages:
   - name: Codeql.Enabled
     value: true
 
-  # Variables from the Pre-Release stage (from get-build-info)
+  - ${{ if eq(parameters.dotnetMajorVersion, '6.0') }}:
+    - name: sourceBuildArtifactLeg
+      value: Build_Tarball_x64 CentOS7-Offline_Artifacts
+    - name: sourceBuiltArtifactsFileName
+      value: Private.SourceBuilt.Artifacts.$(sdkVersion).tar.gz
+    - name: sdkArtifactFileName
+      value: dotnet-sdk-$(sdkVersion)-*.tar.gz
+
+  - ${{ if eq(parameters.dotnetMajorVersion, '7.0') }}:
+    - name: sourceBuildArtifactLeg
+      value: Build_Tarball_x64 CentOSStream8-Offline_Artifacts
+    - name: sourceBuiltArtifactsFileName
+      value: Private.SourceBuilt.Artifacts.$(sdkVersion).tar.gz
+    - name: sdkArtifactFileName
+      value: dotnet-sdk-$(sdkVersion)-*.tar.gz
+
+  - ${{ if eq(parameters.dotnetMajorVersion, '8.0') }}:
+    - name: sourceBuildArtifactLeg
+      value: CentOSStream8_Offline_x64_Artifacts
+    - name: sourceBuiltArtifactsFileName
+      value: Private.SourceBuilt.Artifacts.8.0.100.centos.8-x64.tar.gz
+    - name: sdkArtifactFileName
+      value: dotnet-sdk-*.tar.gz
+
+  # Variables from the Pre-Release stage
+  - name: release
+    value: $[ stageDependencies.PreRelease.PreRelease.outputs['ReadReleaseInfo.Release'] ]
   - name: sdkVersion
     value: $[ stageDependencies.PreRelease.PreRelease.outputs['ReadReleaseInfo.SdkVersion'] ]
   - name: runtimeVersion
     value: $[ stageDependencies.PreRelease.PreRelease.outputs['ReadReleaseInfo.RuntimeVersion'] ]
   - name: releaseChannel
     value: $[ stageDependencies.PreRelease.PreRelease.outputs['ReadReleaseInfo.ReleaseChannel'] ]
+  - name: releaseTag
+    value: $[ stageDependencies.PreRelease.PreRelease.outputs['ReadReleaseInfo.ReleaseTag'] ]
 
   - ${{ if or(eq(parameters.dotnetMajorVersion, '6.0'), eq(parameters.dotnetMajorVersion, '7.0')) }}:
     - name: officialBuildPipelineId
@@ -73,20 +105,13 @@ stages:
       value: $[ stageDependencies.PreRelease.PreRelease.outputs['AssociatedPipelineRuns.DotnetDotnetRunId'] ]
 
   jobs:
-  - job: ValidateReleaseTag
-    displayName: Validate release tag
+  - job: Release
+    displayName: Announce & Release
     steps:
-    - checkout: none
+    - checkout: self
 
     - script: |
         set -euo pipefail
-        if [ "${{ parameters.useCustomTag }}" = "True" ] ; then
-          tag="${{ parameters.customTag }}"
-          echo "Using custom tag ${tag}"
-        else
-          tag="v$(SdkVersion)"
-          echo "Using tag ${tag}"
-        fi
 
         if [[ "$(releaseChannel)" == '6.0' || "$(releaseChannel)" == '7.0' ]]; then
           repo='installer'
@@ -94,220 +119,179 @@ stages:
           repo='dotnet'
         fi
 
-        # Checks for all graphs that match the tag name (there can be more, e.g. 7.0.100 will match 7.0.100-preview.1.21102.12)
-        query="{ repository(owner: \"dotnet\", name: \"$repo\") { refs(refPrefix: \"refs/tags/\", last: 100, query: \"$tag\") { nodes { name }}}}"
+        # Checks for all matching tags (there can be more, e.g. 7.0.100 will match 7.0.100-preview.1.21102.12)
+        query="{ repository(owner: \"dotnet\", name: \"$repo\") { refs(refPrefix: \"refs/tags/\", last: 100, query: \"$(releaseTag)\") { nodes { name }}}}"
         tags=$(gh api graphql -f query="$query" --template '{{.data.repository.refs.nodes}}')
 
-        if echo "$tags" | grep -q "map\[name:$tag\]"; then
-          echo "##vso[task.setvariable variable=Tag;isOutput=true]$tag"
-          echo "Tag $tag exists"
+        # Find the exact match
+        if echo "$tags" | grep -q "map\[name:$(releaseTag)\]"; then
+          echo "Tag $(releaseTag) exists"
         else
-          echo "##vso[task.logissue type=error]Tag $tag does not exist in dotnet/$repo"
+          echo "##vso[task.logissue type=error]Tag $(releaseTag) does not exist in dotnet/$repo"
           exit 1
         fi
       displayName: Validate release tag
-      name: TagValidation
       env:
         GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
 
-  - job: CreateReleaseAnnouncementJob
-    displayName: Create Release Announcement
-    condition: and(succeeded(), eq('${{ parameters.createReleaseAnnouncement }}', true))
-    dependsOn: ValidateReleaseTag
-    variables:
-    - name: Tag
-      value: $[ dependencies.ValidateReleaseTag.outputs['TagValidation.Tag'] ]
-    steps:
-    - script: |
-        set -euxo pipefail
+    - ${{ if parameters.createReleaseAnnouncement }}:
+      - script: |
+          set -euxo pipefail
 
-        query='query { repository(owner: "${{ variables.announcementOrg }}", name: "${{ variables.announcementRepo }}") { id } }'
-        echo "${query}"
-        repo_id=$( gh api graphql -f query="$query" --template '{{.data.repository.id}}' )
-        echo ${{ variables.announcementOrg }}/${{ variables.announcementRepo }} repo ID is ${repo_id}
+          query='query { repository(owner: "${{ variables.announcementOrg }}", name: "${{ variables.announcementRepo }}") { id } }'
+          echo "${query}"
+          repo_id=$( gh api graphql -f query="$query" --template '{{.data.repository.id}}' )
+          echo ${{ variables.announcementOrg }}/${{ variables.announcementRepo }} repo ID is ${repo_id}
 
-        query='query { repository(name: "${{ variables.announcementRepo }}", owner: "${{ variables.announcementOrg }}") { discussionCategories(first: 10) { edges { node { id, name } } } } }'
-        echo "${query}"
-        category_id=$( gh api graphql -f query="$query" --template '{{range .data.repository.discussionCategories.edges}}{{if eq .node.name "Announcements"}}{{.node.id}}{{end}}{{end}}' )
-        echo Discussion Category ID is ${category_id}
+          query='query { repository(name: "${{ variables.announcementRepo }}", owner: "${{ variables.announcementOrg }}") { discussionCategories(first: 10) { edges { node { id, name } } } } }'
+          echo "${query}"
+          category_id=$( gh api graphql -f query="$query" --template '{{range .data.repository.discussionCategories.edges}}{{if eq .node.name "Announcements"}}{{.node.id}}{{end}}{{end}}' )
+          echo Discussion Category ID is ${category_id}
 
-        echo "##vso[task.setvariable variable=RepoId;]${repo_id}"
-        echo "##vso[task.setvariable variable=DiscussionCategoryId;]${category_id}"
-      displayName: Get category IDs
-      env:
-        GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
+          echo "##vso[task.setvariable variable=RepoId;]${repo_id}"
+          echo "##vso[task.setvariable variable=DiscussionCategoryId;]${category_id}"
+        displayName: Get announcement category
+        env:
+          GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
 
-    - script: |
-        set -euxo pipefail
-        echo "Repo ID is $(RepoId)"
-        echo "Discussion Category ID is $(DiscussionCategoryId)"
+      - script: |
+          set -euxo pipefail
+          echo "Repo ID is $(RepoId)"
+          echo "Discussion Category ID is $(DiscussionCategoryId)"
 
-        # Set environment variables that go in the announcement template
-        export TAG=$(Tag)
-        export RUNTIME_VERSION="$(runtimeVersion)"
-        export RELEASE_CHANNEL="$(releaseChannel)"
-        export SDK_VERSION="$(sdkVersion)"
-        export RELEASE_NOTES_URL="https://github.com/dotnet/core/blob/main/release-notes/$RELEASE_CHANNEL/$RUNTIME_VERSION/$SDK_VERSION.md"
-        export RELEASE_DATE=$(date +"%B %Y") # e.g. "March 2022"
+          # Set environment variables that go in the announcement template
+          export TAG=$(releaseTag)
+          export RELEASE_NAME="$(releaseName)"
+          export RUNTIME_VERSION="$(runtimeVersion)"
+          export RELEASE_CHANNEL="$(releaseChannel)"
+          export SDK_VERSION="$(sdkVersion)"
+          export RELEASE_NOTES_URL="https://github.com/dotnet/core/blob/main/release-notes/$RELEASE_CHANNEL/$RUNTIME_VERSION/$SDK_VERSION.md"
+          export RELEASE_DATE=$(date +"%B %Y") # e.g. "March 2022"
 
-        if [[ "$(releaseChannel)" == '6.0' || "$(releaseChannel)" == '7.0' ]]; then
-          export TAG_URL="https://github.com/dotnet/installer/releases/tag/$TAG"
-        else
-          export TAG_URL="https://github.com/dotnet/dotnet/releases/tag/$TAG"
-        fi
+          if [[ "$(releaseChannel)" == '6.0' || "$(releaseChannel)" == '7.0' ]]; then
+            export TAG_URL="https://github.com/dotnet/installer/releases/tag/$TAG"
+          else
+            export TAG_URL="https://github.com/dotnet/dotnet/releases/tag/$TAG"
+          fi
 
-        template="$(envsubst < source-build-release-announcement.md)"
-        # Get the line in the template that is prefixed with "Title:" and remove the prefix
-        title=$(echo "$template" | grep "^Title:" | cut -d " " -f2-)
-        # Get the inverse of the above selection
-        body=$(echo "$template" | grep -v "^Title:")
+          template="$(envsubst < source-build-release-announcement.md)"
+          # Get the line in the template that is prefixed with "Title:" and remove the prefix
+          title=$(echo "$template" | grep "^Title:" | cut -d " " -f2-)
+          # Get the inverse of the above selection
+          body=$(echo "$template" | grep -v "^Title:")
 
-        query='mutation($RepoId: ID!, $categoryId: ID!, $body: String!, $title: String!) { createDiscussion(input: {repositoryId: $RepoId, categoryId: $categoryId, body: $body, title: $title}) { discussion { url } } }'
+          query='mutation($RepoId: ID!, $categoryId: ID!, $body: String!, $title: String!) { createDiscussion(input: {repositoryId: $RepoId, categoryId: $categoryId, body: $body, title: $title}) { discussion { url } } }'
 
-        if [ ${{ parameters.isDryRun }} = True ]; then
-          set +x
-          echo -e "\n\n\n#########################\n\n"
-          echo "Doing a dry run, not submitting announcement."
-          echo -e "\n\n#########################\n\n\n"
-          echo "Announcement title: ${title}"
-          echo "Announcement body: ${body}"
-        else
-          echo "Submitting announcement."
-          announcement_url=$( gh api graphql -F RepoId=$(RepoId) -F categoryId=$(DiscussionCategoryId) -F body="${body}" -F title="${title}" -f query="$query" --template '{{.data.createDiscussion.discussion.url}}' )
+          if [ ${{ parameters.isDryRun }} = True ]; then
+            set +x
+            echo -e "\n\n\n#########################\n\n"
+            echo "Doing a dry run, not submitting announcement."
+            echo -e "\n\n#########################\n\n\n"
+            echo "Announcement title: ${title}"
+            echo "Announcement body: ${body}"
+          else
+            echo "Submitting announcement."
+            announcement_url=$( gh api graphql -F RepoId=$(RepoId) -F categoryId=$(DiscussionCategoryId) -F body="${body}" -F title="${title}" -f query="$query" --template '{{.data.createDiscussion.discussion.url}}' )
 
-          echo "Announcement URL: $announcement_url"
-          echo "Tag URL: $TAG_URL"
-          echo "Release Notes URL: $RELEASE_NOTES_URL"
-        fi
-      displayName: Submit announcement discussion
-      workingDirectory: $(Build.SourcesDirectory)/eng
-      env:
-        GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
+            echo "Announcement URL: $announcement_url"
+            echo "Tag URL: $TAG_URL"
+            echo "Release Notes URL: $RELEASE_NOTES_URL"
+          fi
+        displayName: Submit announcement discussion
+        workingDirectory: $(Build.SourcesDirectory)/eng
+        env:
+          GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
 
-  - job: SubmitReleasePrJob
-    displayName: Submit Release PR
-    dependsOn: ValidateReleaseTag
-    condition: and(succeeded(), eq('${{ parameters.submitReleasePR }}', true))
-    variables:
-    - name: TargetRepo
-      value: dotnet/installer
-    - name: ForkRepo
-      value: dotnet-sb-bot/installer
+    - ${{ if parameters.submitReleasePR }}:
+      - task: DownloadPipelineArtifact@2
+        name: DownloadSourceBuiltArtifactsStep
+        displayName: Download Source-Built Artifacts
+        inputs:
+          source: specific
+          project: $(AZDO_PROJECT)
+          pipeline: $(officialBuildPipelineId)
+          runVersion: specific
+          runId: $(officialBuildRunId)
+          artifact: $(sourceBuildArtifactLeg)
+          patterns: $(sourceBuiltArtifactsFileName)
 
-    - ${{ if eq(parameters.dotnetMajorVersion, '6.0') }}:
-      - name: SourceBuildArtifactLeg
-        value: Build_Tarball_x64 CentOS7-Offline_Artifacts
-      - name: SourceBuiltArtifactsFileName
-        value: Private.SourceBuilt.Artifacts.$(sdkVersion).tar.gz
-      - name: SdkArtifactFileName
-        value: dotnet-sdk-$(sdkVersion)-*.tar.gz
+      - task: DownloadPipelineArtifact@2
+        name: DownloadSourceBuiltSDKStep
+        displayName: Download Source-Built SDK
+        inputs:
+          source: specific
+          project: $(AZDO_PROJECT)
+          pipeline: $(officialBuildPipelineId)
+          runVersion: specific
+          runId: $(officialBuildRunId)
+          artifact: $(sourceBuildArtifactLeg)
+          patterns: $(sdkArtifactFileName)
 
-    - ${{ if eq(parameters.dotnetMajorVersion, '7.0') }}:
-      - name: SourceBuildArtifactLeg
-        value: Build_Tarball_x64 CentOSStream8-Offline_Artifacts
-      - name: SourceBuiltArtifactsFileName
-        value: Private.SourceBuilt.Artifacts.$(sdkVersion).tar.gz
-      - name: SdkArtifactFileName
-        value: dotnet-sdk-$(sdkVersion)-*.tar.gz
+      - template: ../steps/upload-to-blob-storage.yml
+        parameters:
+          file: $(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName)
+          accountName: $(storageAccountName)
+          containerName: $(blobContainerName)
+          uploadPath: $(artifactsUploadBaseFilePath)
+          azureStorageKey: $(dotnetcli-storage-key)
 
-    - ${{ if eq(parameters.dotnetMajorVersion, '8.0') }}:
-      - name: SourceBuildArtifactLeg
-        value: CentOSStream8_Offline_x64_Artifacts
-      - name: SourceBuiltArtifactsFileName
-        value: Private.SourceBuilt.Artifacts.8.0.100.centos.8-x64.tar.gz
-      - name: SdkArtifactFileName
-        value: dotnet-sdk-*.tar.gz
+      - template: ../steps/upload-to-blob-storage.yml
+        parameters:
+          file: $(PIPELINE.WORKSPACE)/$(sdkArtifactFileName)
+          accountName: $(storageAccountName)
+          containerName: $(blobContainerName)
+          uploadPath: $(sdkUploadBaseFilePath)
+          azureStorageKey: $(dotnetcli-storage-key)
 
-    steps:
-    - task: DownloadPipelineArtifact@2
-      name: DownloadSourceBuiltArtifactsStep
-      displayName: Download Source-Built Artifacts
-      inputs:
-        source: specific
-        project: $(AZDO_PROJECT)
-        pipeline: $(officialBuildPipelineId)
-        runVersion: specific
-        runId: $(officialBuildRunId)
-        artifact: $(SourceBuildArtifactLeg)
-        patterns: $(SourceBuiltArtifactsFileName)
+      - script: |
+          set -euo pipefail
 
-    - task: DownloadPipelineArtifact@2
-      name: DownloadSourceBuiltSDKStep
-      displayName: Download Source-Built SDK
-      inputs:
-        source: specific
-        project: $(AZDO_PROJECT)
-        pipeline: $(officialBuildPipelineId)
-        runVersion: specific
-        runId: $(officialBuildRunId)
-        artifact: $(SourceBuildArtifactLeg)
-        patterns: $(SdkArtifactFileName)
+          export RELEASE_DATE=$(date +"%B %Y") # e.g. "March 2022"
+          export RUNTIME_VERSION="$(runtimeVersion)"
+          export SDK_VERSION="$(sdkVersion)"
 
-    - template: ../steps/upload-to-blob-storage.yml
-      parameters:
-        file: $(PIPELINE.WORKSPACE)/$(SourceBuiltArtifactsFileName)
-        accountName: $(storageAccountName)
-        containerName: $(blobContainerName)
-        uploadPath: $(artifactsUploadBaseFilePath)
-        azureStorageKey: $(dotnetcli-storage-key)
+          template="$(envsubst < source-build-release-pr.md)"
+          # Get the line in the template that is prefixed with "Title:" and remove the prefix
+          title=$(echo "$template" | grep "^Title:" | cut -d " " -f2-)
+          # Get the inverse of the above selection
+          body=$(echo "$template" | grep -v "^Title:")
 
-    - template: ../steps/upload-to-blob-storage.yml
-      parameters:
-        file: $(PIPELINE.WORKSPACE)/$(SdkArtifactFileName)
-        accountName: $(storageAccountName)
-        containerName: $(blobContainerName)
-        uploadPath: $(sdkUploadBaseFilePath)
-        azureStorageKey: $(dotnetcli-storage-key)
+          echo "TargetRepo: $(releasePrRepo)"
+          echo "ForkRepo: $(releasePrForkRepo)"
+          echo "SdkVersion: $(sdkVersion)"
+          echo "Title: ${title}"
+          echo "Body: ${body}"
 
-    - script: |
-        set -euo pipefail
+          extraArgs=()
+          if [[ "$(releaseChannel)" == '6.0' || "$(releaseChannel)" == '7.0' ]]; then
+            extraArgs+=("--globalJson" "src/SourceBuild/tarball/content/global.json")
+            extraArgs+=("--versionProps" "eng/Versions.props")
+          fi
 
-        export RELEASE_DATE=$(date +"%B %Y") # e.g. "March 2022"
-        export RUNTIME_VERSION="$(runtimeVersion)"
-        export SDK_VERSION="$(sdkVersion)"
-
-        template="$(envsubst < source-build-release-pr.md)"
-        # Get the line in the template that is prefixed with "Title:" and remove the prefix
-        title=$(echo "$template" | grep "^Title:" | cut -d " " -f2-)
-        # Get the inverse of the above selection
-        body=$(echo "$template" | grep -v "^Title:")
-
-        echo "TargetRepo: $(TargetRepo)"
-        echo "ForkRepo: $(ForkRepo)"
-        echo "SdkVersion: $(sdkVersion)"
-        echo "title: ${title}"
-        echo "body: ${body}"
-
-        extraArgs=()
-        if [[ "$(releaseChannel)" == '6.0' || "$(releaseChannel)" == '7.0' ]]; then
-          extraArgs+=("--globalJson" "src/SourceBuild/tarball/content/global.json")
-          extraArgs+=("--versionProps" "eng/Versions.props")
-        fi
-
-        if [ ${{ parameters.isDryRun }} = True ]; then
-          echo "Doing a dry run, not submitting PR. Would have called:"
-          echo "./submit-source-build-release-pr.sh"
-          echo "  --setupGitAuth"
-          echo "  --targetRepo $(TargetRepo)"
-          echo "  --forkRepo $(ForkRepo)"
-          echo "  --sdkVersion $(sdkVersion)"
-          echo "  --title ${title}"
-          echo "  --body ${body}"
-          echo "  --targetBranch ${{ parameters.releaseBranchName }}"
-          echo "  ${extraArgs[@]}"
-        else
-          echo "Submitting PR"
-          ./submit-source-build-release-pr.sh \
-            --setupGitAuth \
-            --targetRepo $(TargetRepo) \
-            --forkRepo $(ForkRepo) \
-            --sdkVersion $(sdkVersion) \
-            --title "${title}" \
-            --body "${body}" \
-            --targetBranch "${{ parameters.releaseBranchName }}" \
-            "${extraArgs[@]}"
-        fi
-      displayName: Submit Release PR
-      workingDirectory: $(Build.SourcesDirectory)/eng
-      env:
-        GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
+          if [ ${{ parameters.isDryRun }} = True ]; then
+            echo "Doing a dry run, not submitting PR. Would have called:"
+            echo "./submit-source-build-release-pr.sh"
+            echo "  --setupGitAuth"
+            echo "  --targetRepo $(releasePrRepo)"
+            echo "  --forkRepo $(releasePrForkRepo)"
+            echo "  --sdkVersion $(sdkVersion)"
+            echo "  --title ${title}"
+            echo "  --body ${body}"
+            echo "  --targetBranch ${{ parameters.releaseBranchName }}"
+            echo "  ${extraArgs[@]}"
+          else
+            echo "Submitting PR"
+            ./submit-source-build-release-pr.sh \
+              --setupGitAuth \
+              --targetRepo $(releasePrRepo) \
+              --forkRepo $(releasePrForkRepo) \
+              --sdkVersion $(sdkVersion) \
+              --title "${title}" \
+              --body "${body}" \
+              --targetBranch "${{ parameters.releaseBranchName }}" \
+              "${extraArgs[@]}"
+          fi
+        displayName: Submit Release PR
+        workingDirectory: $(Build.SourcesDirectory)/eng
+        env:
+          GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -3,6 +3,8 @@ parameters:
   type: string
 - name: dotnetMajorVersion
   type: string
+- name: isPreviewRelease
+  type: boolean
 - name: releaseName
   type: string
 - name: releaseBranchName
@@ -13,8 +15,8 @@ parameters:
 - name: submitReleasePR
   type: boolean
   default: true
-- name: pushGitHubTag
-  type: boolean
+- name: createGitHubRelease
+  type: string
 - name: isDryRun
   type: boolean
   default: false
@@ -103,12 +105,58 @@ stages:
       value: $(DOTNET_DOTNET_CI_PIPELINE_ID)
     - name: officialBuildRunId
       value: $[ stageDependencies.PreRelease.PreRelease.outputs['AssociatedPipelineRuns.DotnetDotnetRunId'] ]
+    - name: dotnetDotnetCommit
+      value: $[ stageDependencies.PreRelease.PreRelease.outputs['AssociatedPipelineRuns.DotnetDotnetCommit'] ]
 
   jobs:
   - job: Release
     displayName: Announce & Release
     steps:
     - checkout: self
+
+    # TODO: Add not(parameters.isDryRun)
+    - ${{ if and(ne(parameters.createGitHubRelease, 'skip'), ne(parameters.dotnetMajorVersion, '6.0'), ne(parameters.dotnetMajorVersion, '7.0')) }}:
+      - checkout: dotnet-dotnet
+        displayName: Checkout dotnet-dotnet
+        fetchDepth: 0
+        fetchTags: true
+
+      - script: |
+          set -euxo pipefail
+          tarball_path="$(Build.ArtifactStagingDirectory)/dotnet-sdk-source-$(release).tar.gz"
+          echo "Creating source tarball from dotnet-dotnet / $(dotnetDotnetCommit)"
+
+          git checkout "$(dotnetDotnetCommit)"
+          ./eng/pack-sources.sh --output "$tarball_path"
+
+          echo "##vso[task.setvariable variable=SourceTarballPath]$tarball_path"
+
+        displayName: Prepare source tarball
+        workingDirectory: $(Agent.BuildDirectory)/dotnet-dotnet
+
+      - script: |
+          set -euxo pipefail
+
+          prerelease=''
+          if [ ${{ parameters.isPreviewRelease }} = True ]; then
+            prerelease='--prerelease'
+          fi
+
+          draft=''
+          if [ ${{ parameters.createGitHubRelease }} = draft ]; then
+            draft='--draft'
+          fi
+
+          gh release create "$(releaseTag)" "$(SourceTarballPath)#Packed sources" \
+            --repo dotnet/dotnet \
+            --title "${{ parameters.releaseName }}" \
+            --target "$(dotnetDotnetCommit)" \
+            $prerelease \
+            $draft
+
+        displayName: Create GitHub release
+        env:
+          GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
 
     - script: |
         set -euo pipefail
@@ -148,8 +196,8 @@ stages:
           category_id=$( gh api graphql -f query="$query" --template '{{range .data.repository.discussionCategories.edges}}{{if eq .node.name "Announcements"}}{{.node.id}}{{end}}{{end}}' )
           echo Discussion Category ID is ${category_id}
 
-          echo "##vso[task.setvariable variable=RepoId;]${repo_id}"
-          echo "##vso[task.setvariable variable=DiscussionCategoryId;]${category_id}"
+          echo "##vso[task.setvariable variable=RepoId]$repo_id"
+          echo "##vso[task.setvariable variable=DiscussionCategoryId]$category_id"
         displayName: Get announcement category
         env:
           GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
@@ -187,18 +235,18 @@ stages:
             echo -e "\n\n\n#########################\n\n"
             echo "Doing a dry run, not submitting announcement."
             echo -e "\n\n#########################\n\n\n"
-            echo "Announcement title: ${title}"
-            echo "Announcement body: ${body}"
+            echo "Announcement title: $title"
+            echo "Announcement body: $body"
           else
             echo "Submitting announcement."
-            announcement_url=$( gh api graphql -F RepoId=$(RepoId) -F categoryId=$(DiscussionCategoryId) -F body="${body}" -F title="${title}" -f query="$query" --template '{{.data.createDiscussion.discussion.url}}' )
+            announcement_url=$( gh api graphql -F RepoId=$(RepoId) -F categoryId=$(DiscussionCategoryId) -F body="$body" -F title="$title" -f query="$query" --template '{{.data.createDiscussion.discussion.url}}' )
 
             echo "Announcement URL: $announcement_url"
             echo "Tag URL: $TAG_URL"
             echo "Release Notes URL: $RELEASE_NOTES_URL"
           fi
         displayName: Submit announcement discussion
-        workingDirectory: $(Build.SourcesDirectory)/eng
+        workingDirectory: $(Agent.BuildDirectory)/source-build/eng
         env:
           GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
 
@@ -259,8 +307,8 @@ stages:
           echo "TargetRepo: $(releasePrRepo)"
           echo "ForkRepo: $(releasePrForkRepo)"
           echo "SdkVersion: $(sdkVersion)"
-          echo "Title: ${title}"
-          echo "Body: ${body}"
+          echo "Title: $title"
+          echo "Body: $body"
 
           extraArgs=()
           if [[ "$(releaseChannel)" == '6.0' || "$(releaseChannel)" == '7.0' ]]; then
@@ -275,8 +323,8 @@ stages:
             echo "  --targetRepo $(releasePrRepo)"
             echo "  --forkRepo $(releasePrForkRepo)"
             echo "  --sdkVersion $(sdkVersion)"
-            echo "  --title ${title}"
-            echo "  --body ${body}"
+            echo "  --title $title"
+            echo "  --body $body"
             echo "  --targetBranch ${{ parameters.releaseBranchName }}"
             echo "  ${extraArgs[@]}"
           else
@@ -286,12 +334,12 @@ stages:
               --targetRepo $(releasePrRepo) \
               --forkRepo $(releasePrForkRepo) \
               --sdkVersion $(sdkVersion) \
-              --title "${title}" \
-              --body "${body}" \
+              --title "$title" \
+              --body "$body" \
               --targetBranch "${{ parameters.releaseBranchName }}" \
               "${extraArgs[@]}"
           fi
         displayName: Submit Release PR
-        workingDirectory: $(Build.SourcesDirectory)/eng
+        workingDirectory: $(Agent.BuildDirectory)/source-build/eng
         env:
           GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)

--- a/eng/templates/steps/initialize-release-info.yml
+++ b/eng/templates/steps/initialize-release-info.yml
@@ -107,7 +107,7 @@ steps:
 - script: |
     set -euo pipefail
     source eng/get-build-info.sh
-
+    set -x
     if [[ "$(ReadReleaseInfo.ReleaseChannel)" == "6.0" || "$(ReadReleaseInfo.ReleaseChannel)" == "7.0" ]]; then
       if [[ "${{ parameters.useSpecificPipelineRunIDs }}" == "True" ]]; then
         search_by=name

--- a/eng/templates/steps/initialize-release-info.yml
+++ b/eng/templates/steps/initialize-release-info.yml
@@ -20,6 +20,11 @@ parameters:
   default: ''
 - name: verifyBuildSuccess
   type: boolean
+- name: useCustomTag
+  type: boolean
+  default: false
+- name: customTag
+  type: string
 - name: isDryRun
   type: boolean
   default: false
@@ -43,6 +48,7 @@ steps:
 
     runtime_version="$(jq -r '.Runtime' "$config_path")"
     release_channel="$(jq -r '.Channel' "$config_path")"
+    release="$(jq -r '.Release' "$config_path")"
 
     # Source-build only supports the lowest available feature band.
     # Sort the SDK releases by number and pick the lowest value.
@@ -68,15 +74,26 @@ steps:
       exit 1
     fi
 
-    echo "Release channel: ${release_channel}"
-    echo "Runtime version: ${runtime_version}"
-    echo "SDK version: ${sdk_version}"
-    echo "Installer commit: ${commit}"
+    if [ "${{ parameters.useCustomTag }}" = "True" ] ; then
+      tag="${{ parameters.customTag }}"
+      echo "Using custom tag $tag"
+    else
+      tag="v$release"
+    fi
 
-    echo "##vso[task.setvariable variable=SdkVersion;isOutput=true]${sdk_version}"
-    echo "##vso[task.setvariable variable=RuntimeVersion;isOutput=true]${runtime_version}"
-    echo "##vso[task.setvariable variable=ReleaseChannel;isOutput=true]${release_channel}"
-    echo "##vso[task.setvariable variable=InstallerCommit;isOutput=true]${commit}"
+    echo "Release: $release"
+    echo "Release channel: $release_channel"
+    echo "Runtime version: $runtime_version"
+    echo "Release tag: $tag"
+    echo "SDK version: $sdk_version"
+    echo "Installer commit: $commit"
+
+    echo "##vso[task.setvariable variable=Release;isOutput=true]$release"
+    echo "##vso[task.setvariable variable=SdkVersion;isOutput=true]$sdk_version"
+    echo "##vso[task.setvariable variable=RuntimeVersion;isOutput=true]$runtime_version"
+    echo "##vso[task.setvariable variable=ReleaseChannel;isOutput=true]$release_channel"
+    echo "##vso[task.setvariable variable=ReleaseTag;isOutput=true]$tag"
+    echo "##vso[task.setvariable variable=InstallerCommit;isOutput=true]$commit"
 
     build_name="$(resources.pipeline.dotnet-staging-pipeline-resource.runName)"
     if [ ${{ parameters.isDryRun }} = True ]; then
@@ -86,7 +103,7 @@ steps:
     original_build_name='$(Build.BuildNumber)'
     revision="${original_build_name:9}"
 
-    echo "##vso[build.updatebuildnumber]${build_name}-${revision}"
+    echo "##vso[build.updatebuildnumber]$build_name-$revision"
   name: ReadReleaseInfo
   displayName: Read Release Info
 

--- a/eng/templates/steps/initialize-release-info.yml
+++ b/eng/templates/steps/initialize-release-info.yml
@@ -3,9 +3,6 @@ parameters:
   type: string
 - name: releaseBranchName
   type: string
-- name: getAssociatedPipelineRuns
-  type: boolean
-  default: false
 - name: useSpecificPipelineRunIDs
   type: boolean
   default: false
@@ -107,61 +104,63 @@ steps:
   name: ReadReleaseInfo
   displayName: Read Release Info
 
-- ${{ if eq(parameters.getAssociatedPipelineRuns, true) }}:
-  - ${{ if eq(parameters.useSpecificPipelineRunIDs, false) }}:
-    - script: |
-        set -euo pipefail
-        source eng/get-build-info.sh
+- script: |
+    set -euo pipefail
+    source eng/get-build-info.sh
 
-        if [[ "$(ReadReleaseInfo.ReleaseChannel)" == "8.0" ]]; then
-            get_build_info \
-              "$(AZDO_ORG)" \
-              "$(AZDO_PROJECT)" \
-              "$(DOTNET_DOTNET_CI_PIPELINE_ID)" \
-              dotnet-dotnet \
-              DotnetDotnetRunId \
-              DotnetDotnetCommit \
-              "${{ parameters.verifyBuildSuccess }}" \
-              tag \
-              "installer-$(ReadReleaseInfo.InstallerCommit)"
-        else
-            get_build_info \
-              "$(AZDO_ORG)" \
-              "$(AZDO_PROJECT)" \
-              "$(INSTALLER_OFFICIAL_CI_PIPELINE_ID)" \
-              dotnet-installer-official-ci \
-              InstallerOfficialRunId \
-              InstallerCommit \
-              "${{ parameters.verifyBuildSuccess }}" \
-              sourceVersion \
-              "$(ReadReleaseInfo.InstallerCommit)"
+    if [[ "$(ReadReleaseInfo.ReleaseChannel)" == "6.0" || "$(ReadReleaseInfo.ReleaseChannel)" == "7.0" ]]; then
+      if [[ "${{ parameters.useSpecificPipelineRunIDs }}" == "True" ]]; then
+        search_by=name
+        query1="$(dotnetInstallerOfficialRunID)"
+        query2="$(dotnetInstallerTarballBuildRunID)"
+      else
+        search_by=sourceVersion
+        query1="$(ReadReleaseInfo.InstallerCommit)"
+        query2="$(ReadReleaseInfo.InstallerCommit)"
+      fi
 
-            get_build_info \
-              "$(AZDO_ORG)" \
-              "$(AZDO_PROJECT)" \
-              "$(INSTALLER_TARBALL_BUILD_CI_PIPELINE_ID)" \
-              dotnet-installer-source-build-tarball-build \
-              InstallerTarballBuildRunId \
-              InstallerCommit \
-              "${{ parameters.verifyBuildSuccess }}" \
-              sourceVersion \
-              "$(ReadReleaseInfo.InstallerCommit)"
-        fi
-      name: AssociatedPipelineRuns
-      displayName: Get Associated Pipeline Run IDs
-      env:
-        AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
+      get_build_info \
+        "$(AZDO_ORG)" \
+        "$(AZDO_PROJECT)" \
+        "$(INSTALLER_OFFICIAL_CI_PIPELINE_ID)" \
+        dotnet-installer-official-ci \
+        InstallerOfficialRunId \
+        InstallerCommit \
+        "${{ parameters.verifyBuildSuccess }}" \
+        $search_by \
+        $query1
 
-  - ${{ else }}:
-    - script: |
-        set -euo pipefail
-        source eng/get-build-info.sh
+      get_build_info \
+        "$(AZDO_ORG)" \
+        "$(AZDO_PROJECT)" \
+        "$(INSTALLER_TARBALL_BUILD_CI_PIPELINE_ID)" \
+        dotnet-installer-source-build-tarball-build \
+        InstallerTarballBuildRunId \
+        InstallerCommit \
+        "${{ parameters.verifyBuildSuccess }}" \
+        $search_by \
+        $query2
+    else
+      if [[ "${{ parameters.useSpecificPipelineRunIDs }}" == "True" ]]; then
+        search_by=name
+        query="$(dotnetInstallerOfficialRunID)"
+      else
+        search_by=tag
+        query="installer-$(ReadReleaseInfo.InstallerCommit)"
+      fi
 
-        if [[ "$(ReadReleaseInfo.ReleaseChannel)" == "8.0" ]]; then
-          print_build_info dotnet-dotnet DotnetDotnetRunId DotnetDotnetCommit "$(dotnetDotnetRunID)" "See the build info"
-        else
-          print_build_info dotnet-installer-official-ci InstallerOfficialRunId InstallerCommit "$(dotnetInstallerOfficialRunID)" "$(ReadReleaseInfo.InstallerCommit)"
-          print_build_info dotnet-installer-source-build-tarball-build InstallerTarballBuildRunId InstallerCommit "$(dotnetInstallerTarballBuildRunID)" "N/A"
-        fi
-      name: AssociatedPipelineRuns
-      displayName: Set Associated Pipeline Run IDs
+      get_build_info \
+        "$(AZDO_ORG)" \
+        "$(AZDO_PROJECT)" \
+        "$(DOTNET_DOTNET_CI_PIPELINE_ID)" \
+        dotnet-dotnet \
+        DotnetDotnetRunId \
+        DotnetDotnetCommit \
+        "${{ parameters.verifyBuildSuccess }}" \
+        $search_by \
+        $query
+    fi
+  name: AssociatedPipelineRuns
+  displayName: Get associated pipeline runs
+  env:
+    AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)

--- a/eng/templates/steps/initialize-release-info.yml
+++ b/eng/templates/steps/initialize-release-info.yml
@@ -107,12 +107,13 @@ steps:
 - script: |
     set -euo pipefail
     source eng/get-build-info.sh
-    set -x
+
     if [[ "$(ReadReleaseInfo.ReleaseChannel)" == "6.0" || "$(ReadReleaseInfo.ReleaseChannel)" == "7.0" ]]; then
       if [[ "${{ parameters.useSpecificPipelineRunIDs }}" == "True" ]]; then
         search_by=name
-        query1="$(dotnetInstallerOfficialRunID)"
-        query2="$(dotnetInstallerTarballBuildRunID)"
+        query1="${{ parameters.dotnetInstallerOfficialRunID }}"
+        query2="${{ parameters.dotnetInstallerTarballBuildRunID }}"
+        echo "Searching for associated builds $query1 and $query2"
       else
         search_by=sourceVersion
         query1="$(ReadReleaseInfo.InstallerCommit)"
@@ -128,7 +129,7 @@ steps:
         InstallerCommit \
         "${{ parameters.verifyBuildSuccess }}" \
         $search_by \
-        $query1
+        "$query1"
 
       get_build_info \
         "$(AZDO_ORG)" \
@@ -139,11 +140,12 @@ steps:
         InstallerCommit \
         "${{ parameters.verifyBuildSuccess }}" \
         $search_by \
-        $query2
+        "$query2"
     else
       if [[ "${{ parameters.useSpecificPipelineRunIDs }}" == "True" ]]; then
         search_by=name
-        query="$(dotnetInstallerOfficialRunID)"
+        query="${{ parameters.dotnetDotnetRunID }}"
+        echo "Searching for associated build $query"
       else
         search_by=tag
         query="installer-$(ReadReleaseInfo.InstallerCommit)"
@@ -158,7 +160,7 @@ steps:
         DotnetDotnetCommit \
         "${{ parameters.verifyBuildSuccess }}" \
         $search_by \
-        $query
+        "$query"
     fi
   name: AssociatedPipelineRuns
   displayName: Get associated pipeline runs


### PR DESCRIPTION
There are many improvements in this PR to the SB release pipeline:
- Release tag now comes from staging pipeline information so preview releases work without a custom tag (https://github.com/dotnet/source-build/issues/3269)
- It is possible to specify a human readable name (e.g. ".NET 8 Preview 1") that is used during the release
    - Used in announcement title
    - Used in release title
- Added automation for creation of tag+release in the dotnet/dotnet repo (https://github.com/dotnet/source-build/issues/3271)
    - We use `pack-sources.sh` to append sources to the release (temporary fix for https://github.com/dotnet/source-build/issues/3265)
    - Release can be created as a draft - the tag is then only published once we publish the draft
    - Example release: https://github.com/dotnet/dotnet/releases/tag/untagged-fb19defbe3cfd793befd
- Fix handling of specific associated installer/VMR builds to now correctly find the SHA it belongs to - the SHA is then used for the GitHub release
- Release stage jobs are consolidated into one to save time (https://github.com/dotnet/source-build/issues/3272)

Example dry-run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2123565
Example release: https://github.com/dotnet/dotnet/releases/tag/untagged-fb19defbe3cfd793befd (unpublished)
