### PR TITLE
Improve / fix the SB release pipeline for 6.0/7.0 flows

### DIFF
--- a/eng/get-build-info.sh
+++ b/eng/get-build-info.sh
@@ -25,13 +25,9 @@ function get_build_run () {
     run_count=$(echo "$runs"  | jq 'length')
 
     if [ "$run_count" != "1" ]; then
-        local tagged=''
-        if [[ -n "$tag" ]]; then
-            tagged=" tagged ${tag}"
-        fi
         set -x
-        echo "##vso[task.logissue type=error]There are ${run_count} runs of ${pipeline_name}${tagged}. Please manually specify run ID to use."
-        echo "##vso[task.logissue type=error]Run IDs are: ${runs}"
+        echo "##vso[task.logissue type=error]There are $run_count runs of $pipeline_name with $search_by='$query'. Please manually specify run ID to use."
+        echo "##vso[task.logissue type=error]Run IDs are: $runs"
         set +x
         exit 1
     fi

--- a/eng/push-tarball.sh
+++ b/eng/push-tarball.sh
@@ -68,8 +68,8 @@ done
 : ${upstream_url:?Missing --upstream}
 : ${source_tarball:?Missing --tarball}
 
-if [ ! -f "${source_tarball}" ]; then
-  echo "##vso[task.logissue type=error]File ${source_tarball} not found on disk. Exiting..."
+if [ ! -f "$source_tarball" ]; then
+  echo "##vso[task.logissue type=error]File $source_tarball not found on disk. Exiting..."
 fi
 
 month_year=$(date +"%b%Y" -d "+14 days" | sed 's/.*/\L&/') # e.g. aug2022
@@ -77,38 +77,43 @@ month_year=$(date +"%b%Y" -d "+14 days" | sed 's/.*/\L&/') # e.g. aug2022
 vmr_path="$(pwd)/dotnet-vmr"
 
 # replace the last two characters in sdk_version with xx
-branch_version=$(echo ${sdk_version} | sed 's/..$/xx/')
-target_branch="release/${branch_version}" # e.g. release/6.0.1xx
+branch_version=$(echo "$sdk_version" | sed 's/..$/xx/')
+target_branch="release/$branch_version" # e.g. release/6.0.1xx
 
-rm -rf "${vmr_path}"
-git init "${vmr_path}"
+rm -rf "$vmr_path"
+git init "$vmr_path"
 
-pushd "${vmr_path}"
-  git remote add upstream "${upstream_url}"
-  git fetch upstream "${target_branch}" --depth=1
+pushd "$vmr_path"
+  git remote add upstream "$upstream_url"
+  git fetch upstream "$target_branch" --depth=1
+  git checkout "$target_branch"
 
-  git checkout "${target_branch}"
-
-  new_branch_name="dev/${sdk_version}-${month_year}"
-  git checkout -b "${new_branch_name}"
+  new_branch_name="dev/$sdk_version-$month_year"
+  if git fetch upstream "$new_branch_name"; then
+    echo "Branch $new_branch_name already exists (possibly from a previous run)"
+    git checkout "$new_branch_name"
+  else
+    echo "Branch $new_branch_name not found in the remote"
+    git checkout -b "$new_branch_name"
+  fi
 
   # delete all contents except the .git folder
   # otherwise we won't catch deleted files in a commit
   ls | grep -v ".git" | xargs rm -rf
-  tar -xzf "${source_tarball}" -C "${vmr_path}"
+  tar -xzf "$source_tarball" -C "$vmr_path"
 
   git config user.email "dotnet-maestro[bot]@users.noreply.github.com"
   git config user.name "dotnet-maestro[bot]"
 
   # Re-runs should expect the branch being merged previously already
   git add -f .
-  git diff --staged --quiet || git commit -m "Update to .NET ${sdk_version}"
+  git diff --staged --quiet || git commit -m "Update to .NET $sdk_version"
 
   if [ "$is_dry_run" = true ]; then
     echo "Doing a dry run, not pushing to upstream. List of changes:"
     git log --name-status HEAD^..HEAD || echo "No changes to commit."
   else
     echo "Pushing branch to upstream."
-    git push -u upstream "${new_branch_name}"
+    git push -u upstream "$new_branch_name"
   fi
 popd

--- a/eng/push-tarball.sh
+++ b/eng/push-tarball.sh
@@ -97,22 +97,16 @@ pushd "${vmr_path}"
   ls | grep -v ".git" | xargs rm -rf
   tar -xzf "${source_tarball}" -C "${vmr_path}"
 
-  git add -f .
-  
   git config user.email "dotnet-maestro[bot]@users.noreply.github.com"
   git config user.name "dotnet-maestro[bot]"
 
-  # Dry-run re-runs should expect the branch being merged already
-  allow_empty=''
-  if [[ "$is_dry_run" = true ]]; then
-    allow_empty='--allow-empty'
-  fi
-
-  git commit $allow_empty -m "Update to .NET ${sdk_version}"
+  # Re-runs should expect the branch being merged previously already
+  git add -f .
+  git diff --staged --quiet || git commit -m "Update to .NET ${sdk_version}"
 
   if [ "$is_dry_run" = true ]; then
     echo "Doing a dry run, not pushing to upstream. List of changes:"
-    git log --name-status HEAD^..HEAD
+    git log --name-status HEAD^..HEAD || echo "No changes to commit."
   else
     echo "Pushing branch to upstream."
     git push -u upstream "${new_branch_name}"

--- a/eng/push-tarball.sh
+++ b/eng/push-tarball.sh
@@ -101,7 +101,14 @@ pushd "${vmr_path}"
   
   git config user.email "dotnet-maestro[bot]@users.noreply.github.com"
   git config user.name "dotnet-maestro[bot]"
-  git commit -m "Update to .NET ${sdk_version}"
+
+  # Dry-run re-runs should expect the branch being merged already
+  allow_empty=''
+  if [[ "$is_dry_run" = true ]]; then
+    allow_empty='--allow-empty'
+  fi
+
+  git commit $allow_empty -m "Update to .NET ${sdk_version}"
 
   if [ "$is_dry_run" = true ]; then
     echo "Doing a dry run, not pushing to upstream. List of changes:"

--- a/eng/push-tarball.sh
+++ b/eng/push-tarball.sh
@@ -72,7 +72,7 @@ if [ ! -f "${source_tarball}" ]; then
   echo "##vso[task.logissue type=error]File ${source_tarball} not found on disk. Exiting..."
 fi
 
-month_year=$(date +"%b%Y" -d "+1 month" | sed 's/.*/\L&/') # e.g. aug2022
+month_year=$(date +"%b%Y" -d "+14 days" | sed 's/.*/\L&/') # e.g. aug2022
 
 vmr_path="$(pwd)/dotnet-vmr"
 

--- a/eng/source-build-release-official.yml
+++ b/eng/source-build-release-official.yml
@@ -8,7 +8,6 @@ resources:
   pipelines:
   - pipeline: dotnet-staging-pipeline-resource
     source: Stage-DotNet
-    version: '20230226.1-6.0.407-servicing.23126.6,6.0.310-servicing.23126.5,6.0.115-servicing.23126.4-168350,168352,168351' # TODO
   repositories:
   - repository: dotnet-dotnet
     type: git
@@ -16,9 +15,8 @@ resources:
     ref: main
 
 pool:
-  # name: NetCore1ESPool-Svc-Internal
-  # demands: ImageOverride -equals 1es-ubuntu-2004
-  vmImage: ubuntu-latest # TODO
+  name: NetCore1ESPool-Svc-Internal
+  demands: ImageOverride -equals 1es-ubuntu-2004
 
 parameters:
 - name: dotnetMajorVersion

--- a/eng/source-build-release-official.yml
+++ b/eng/source-build-release-official.yml
@@ -8,6 +8,7 @@ resources:
   pipelines:
   - pipeline: dotnet-staging-pipeline-resource
     source: Stage-DotNet
+    version: '20230226.1-6.0.407-servicing.23126.6,6.0.310-servicing.23126.5,6.0.115-servicing.23126.4-168350,168352,168351' # TODO
   repositories:
   - repository: dotnet-dotnet
     type: git
@@ -15,8 +16,9 @@ resources:
     ref: main
 
 pool:
-  name: NetCore1ESPool-Svc-Internal
-  demands: ImageOverride -equals 1es-ubuntu-2004
+  # name: NetCore1ESPool-Svc-Internal
+  # demands: ImageOverride -equals 1es-ubuntu-2004
+  vmImage: ubuntu-latest # TODO
 
 parameters:
 - name: dotnetMajorVersion

--- a/eng/source-build-release-official.yml
+++ b/eng/source-build-release-official.yml
@@ -12,7 +12,7 @@ resources:
   - repository: dotnet-dotnet
     type: git
     name: dotnet-dotnet
-    ref: ${{ parameters.releaseBranchName }}
+    ref: main
 
 pool:
   name: NetCore1ESPool-Svc-Internal

--- a/eng/source-build-release-official.yml
+++ b/eng/source-build-release-official.yml
@@ -48,15 +48,15 @@ parameters:
   type: boolean
   default: false
 - name: dotnetDotnetRunID
-  displayName: '[⚠️ 8.0] Specific dotnet-dotnet run ID'
+  displayName: '[⚠️ 8.0] Specific dotnet-dotnet run name'
   type: string
   default: '200XXXX.Y'
 - name: dotnetInstallerOfficialRunID
-  displayName: '[⚠️ 6.0 / 7.0] Specific dotnet-installer-official-ci run ID'
+  displayName: '[⚠️ 6.0 / 7.0] Specific dotnet-installer-official-ci run name'
   type: string
   default: '200XXXX.Y'
 - name: dotnetInstallerTarballBuildRunID
-  displayName: '[⚠️ 6.0 / 7.0] Specific dotnet-installer-source-build-tarball-build run ID'
+  displayName: '[⚠️ 6.0 / 7.0] Specific dotnet-installer-source-build-tarball-build run name'
   type: string
   default: '200XXXX.Y'
 - name: verifyBuildSuccess

--- a/eng/templates/stages/mirror.yml
+++ b/eng/templates/stages/mirror.yml
@@ -103,7 +103,7 @@ stages:
 
         if [ "${{ parameters.isDryRun }}" = "True" ]; then
           set +x
-          echo "Doing a dry run, not pushing the tag $tag_name / $(ref_to_tag) to ${{ variables.destinationUrl }}"
+          echo "Doing a dry run, not pushing the tag $tag_name / $ref_to_tag to ${{ variables.destinationUrl }}"
         else
           echo "Pushing tag $tag_name to ${{ variables.destinationUrl }}"
           git push destination "$tag_name"

--- a/eng/templates/stages/mirror.yml
+++ b/eng/templates/stages/mirror.yml
@@ -81,34 +81,32 @@ stages:
 
         echo "Mirroring $branch_name from ${{ variables.sourceUrl }} to ${{ variables.destinationUrl }}"
 
-        git fetch source "$branch_name"
-
         if [[ "${{ parameters.dotnetMajorVersion }}" == '6.0' || "${{ parameters.dotnetMajorVersion }}" == '7.0' ]]; then
-          git checkout "$branch_name"
+          ref_to_tag="$branch_name"
         else
-          git checkout "$(sourceVersion)"
+          ref_to_tag="$(sourceVersion)"
         fi
+
+        git fetch source "$ref_to_tag"
+        git checkout "$ref_to_tag"
 
         if [ "${{ parameters.useCustomTag }}" = "True" ] ; then
           tag_name="${{ parameters.customTag }}"
           echo "Using custom tag ${tag_name}"
         else
-          tag_name="v$(SdkVersion)-SDK"
+          tag_name="v$(SdkVersion)"
           echo "Using tag ${tag_name}"
         fi
 
         message=".NET Source-build $(sdkVersion)-SDK"
-        git tag "$tag_name" "$(sourceVersion)" -m "$message"
-
-        git fetch destination '$branch_name' || echo 'Branch $branch_name does not exist in destination yet'
+        git tag "$tag_name" "$ref_to_tag" -m "$message"
 
         if [ "${{ parameters.isDryRun }}" = "True" ]; then
           set +x
-          echo "Doing a dry run, not pushing the tag $tag_name $branch_name / $(sourceVersion) to ${{ variables.destinationUrl }}"
-          exit 0
+          echo "Doing a dry run, not pushing the tag $tag_name / $(ref_to_tag) to ${{ variables.destinationUrl }}"
+        else
+          echo "Pushing tag $tag_name to ${{ variables.destinationUrl }}"
+          git push destination "$tag_name"
         fi
-
-        echo "Pushing ${{ parameters.releaseBranchName }} to ${{ variables.destinationUrl }}"
-        git push destination "$tag_name"
       workingDirectory: $(Pipeline.Workspace)/$(RepoDir)
       displayName: Mirror and tag

--- a/eng/templates/stages/mirror.yml
+++ b/eng/templates/stages/mirror.yml
@@ -74,7 +74,14 @@ stages:
     - script: |
         set -euxo pipefail
 
-        git fetch source "${{ parameters.releaseBranchName }}"
+        branch_name="${{ parameters.releaseBranchName }}"
+        if [[ "$branch_name" == internal/* ]]; then
+          branch_name="${branch_name#internal/}"
+        fi
+
+        echo "Mirroring $branch_name from ${{ variables.sourceUrl }} to ${{ variables.destinationUrl }}"
+
+        git fetch source "$branch_name"
         git checkout "$(sourceVersion)"
 
         if [ "${{ parameters.useCustomTag }}" = "True" ] ; then
@@ -88,11 +95,11 @@ stages:
         message=".NET Source-build $(sdkVersion)-SDK"
         git tag "$tag_name" "$(sourceVersion)" -m "$message"
 
-        git fetch destination '${{ parameters.releaseBranchName }}' || echo 'Branch ${{ parameters.releaseBranchName }} does not exist in destination yet'
+        git fetch destination '$branch_name' || echo 'Branch $branch_name does not exist in destination yet'
 
         if [ "${{ parameters.isDryRun }}" = "True" ]; then
           set +x
-          echo "Doing a dry run, not pushing the tag $tag_name ${{ parameters.releaseBranchName }} / $(sourceVersion) to ${{ variables.destinationUrl }}"
+          echo "Doing a dry run, not pushing the tag $tag_name $branch_name / $(sourceVersion) to ${{ variables.destinationUrl }}"
           exit 0
         fi
 

--- a/eng/templates/stages/mirror.yml
+++ b/eng/templates/stages/mirror.yml
@@ -82,8 +82,10 @@ stages:
         echo "Mirroring $branch_name from ${{ variables.sourceUrl }} to ${{ variables.destinationUrl }}"
 
         if [[ "${{ parameters.dotnetMajorVersion }}" == '6.0' || "${{ parameters.dotnetMajorVersion }}" == '7.0' ]]; then
+          # For 6.0 and 7.0 we tag the release branch into which we merged the release PR
           ref_to_tag="$branch_name"
         else
+          # For 8.0+ we tag a given VMR commit
           ref_to_tag="$(sourceVersion)"
         fi
 

--- a/eng/templates/stages/mirror.yml
+++ b/eng/templates/stages/mirror.yml
@@ -82,7 +82,12 @@ stages:
         echo "Mirroring $branch_name from ${{ variables.sourceUrl }} to ${{ variables.destinationUrl }}"
 
         git fetch source "$branch_name"
-        git checkout "$(sourceVersion)"
+
+        if [[ "${{ parameters.dotnetMajorVersion }}" == '6.0' || "${{ parameters.dotnetMajorVersion }}" == '7.0' ]]; then
+          git checkout "$branch_name"
+        else
+          git checkout "$(sourceVersion)"
+        fi
 
         if [ "${{ parameters.useCustomTag }}" = "True" ] ; then
           tag_name="${{ parameters.customTag }}"

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -333,6 +333,11 @@ stages:
             extraArgs+=("--versionProps" "eng/Versions.props")
           fi
 
+          target_branch="${{ parameters.releaseBranchName }}"
+          if [[ "$target_branch" == internal/* ]]; then
+            target_branch="${target_branch#internal/}"
+          fi
+
           if [ ${{ parameters.isDryRun }} = True ]; then
             echo "Doing a dry run, not submitting PR. Would have called:"
             echo "./submit-source-build-release-pr.sh"
@@ -342,18 +347,18 @@ stages:
             echo "  --sdkVersion $(sdkVersion)"
             echo "  --title $title"
             echo "  --body $body"
-            echo "  --targetBranch ${{ parameters.releaseBranchName }}"
+            echo "  --targetBranch $target_branch"
             echo "  ${extraArgs[@]}"
           else
             echo "Submitting PR"
             ./submit-source-build-release-pr.sh \
               --setupGitAuth \
-              --targetRepo $(releasePrRepo) \
-              --forkRepo $(releasePrForkRepo) \
-              --sdkVersion $(sdkVersion) \
+              --targetRepo "$(releasePrRepo)" \
+              --forkRepo "$(releasePrForkRepo)" \
+              --sdkVersion "$(sdkVersion)" \
               --title "$title" \
               --body "$body" \
-              --targetBranch "${{ parameters.releaseBranchName }}" \
+              --targetBranch "$target_branch" \
               "${extraArgs[@]}"
           fi
         displayName: Submit Release PR

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -128,6 +128,7 @@ stages:
     displayName: Announcements, PRs & Release
     steps:
     - checkout: self
+      path: $(Build.SourcesDirectory)/dotnet-source-build
 
     - ${{ if and(ne(variables.createGitHubRelease, 'skip'), ne(parameters.dotnetMajorVersion, '6.0'), ne(parameters.dotnetMajorVersion, '7.0')) }}:
       - checkout: dotnet-dotnet

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -128,7 +128,7 @@ stages:
     displayName: Announcements, PRs & Release
     steps:
     - checkout: self
-      path: $(Build.SourcesDirectory)/dotnet-source-build
+      path: dotnet-source-build
 
     - ${{ if and(ne(variables.createGitHubRelease, 'skip'), ne(parameters.dotnetMajorVersion, '6.0'), ne(parameters.dotnetMajorVersion, '7.0')) }}:
       - checkout: dotnet-dotnet
@@ -147,7 +147,7 @@ stages:
           echo "##vso[task.setvariable variable=SourceTarballPath]$tarball_path"
 
         displayName: Prepare source tarball
-        workingDirectory: $(Build.SourcesDirectory)/dotnet-dotnet
+        workingDirectory: $(Agent.BuildDirectory)/dotnet-dotnet
 
       - script: |
           set -euo pipefail
@@ -263,7 +263,7 @@ stages:
             echo "Release Notes URL: $RELEASE_NOTES_URL"
           fi
         displayName: Submit announcement discussion
-        workingDirectory: $(Build.SourcesDirectory)/dotnet-source-build/eng
+        workingDirectory: $(Agent.BuildDirectory)/dotnet-source-build/eng
         env:
           GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
 
@@ -357,6 +357,6 @@ stages:
               "${extraArgs[@]}"
           fi
         displayName: Submit Release PR
-        workingDirectory: $(Build.SourcesDirectory)/dotnet-source-build/eng
+        workingDirectory: $(Agent.BuildDirectory)/dotnet-source-build/eng
         env:
           GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)

--- a/eng/templates/steps/initialize-release-info.yml
+++ b/eng/templates/steps/initialize-release-info.yml
@@ -94,7 +94,7 @@ steps:
 
     build_name="$(resources.pipeline.dotnet-staging-pipeline-resource.runName)"
     if [ ${{ parameters.isDryRun }} = True ]; then
-      build_name="${build_name}-dryrun"
+      build_name="dryrun-${build_name}"
     fi
 
     original_build_name='$(Build.BuildNumber)'


### PR DESCRIPTION
This version of the pipeline was used to pre-release and mirror 6.0/7.0 March 2023 releases.

- Improve how dry-run behaves when triggered during various stages of actual release in progress
- Solidify re-runs of non-dry-runs when previous attempts had to be cancelled
    - E.g., more defensive approach when doing the DSP mirroring
- Fixes how we handle branches/tags for 6.0/7.0
- Do not push branches to DSP anymore, just tags
- Deduce the release month by adding 14 days instead of 1 month