### PR TITLE
Mirror packages to dotnet-security-partners

### DIFF
--- a/eng/source-build-release-official.yml
+++ b/eng/source-build-release-official.yml
@@ -97,18 +97,22 @@ stages:
 
 - stage: MirrorApproval
   ${{ if or(eq(parameters.dotnetMajorVersion, '6.0'), eq(parameters.dotnetMajorVersion, '7.0')) }}:
-    displayName: Approval - Test prereqs & PR
+    displayName: Approval - PR merged & ready for dotnet-security-partners mirroring.
   ${{ else }}:
-    displayName: Approval - Test prereqs
+    displayName: Approval - Ready for dotnet-security-partners mirroring.
   dependsOn: PreRelease
   jobs:
   - deployment: MirrorApproval
-    displayName: Confirm PR merged & prereqs uploaded
+    ${{ if or(eq(parameters.dotnetMajorVersion, '6.0'), eq(parameters.dotnetMajorVersion, '7.0')) }}:
+      displayName: Confirm PR merged & ready for dotnet-security-partners mirroring
+    ${{ else }}:
+      displayName: Confirm ready for dotnet-security-partners mirroring
     environment: Source Build Release - Mirror
     pool: server
 
 - template: templates/stages/mirror.yml
   parameters:
+    dotnetStagingPipelineResource: dotnet-staging-pipeline-resource
     dotnetMajorVersion: ${{ parameters.dotnetMajorVersion }}
     releaseBranchName: ${{ parameters.releaseBranchName }}
     useCustomTag: ${{ parameters.useCustomTag }}

--- a/eng/templates/stages/mirror.yml
+++ b/eng/templates/stages/mirror.yml
@@ -13,16 +13,18 @@ parameters:
 - name: isDryRun
   type: boolean
   default: false
+- name: dotnetStagingPipelineResource
+  type: string
 
 stages:
 - stage: Mirror
-  displayName: Mirror branch to DSP
+  displayName: Mirror to DSP
   dependsOn:
   - PreRelease
   - MirrorApproval
 
   jobs:
-  - job: Mirror
+  - job: MirrorSource
     displayName: Mirror ${{ parameters.releaseBranchName }}
     variables:
     - group: DotNet-Source-Build-All-Orgs-Source-Access
@@ -112,3 +114,47 @@ stages:
         fi
       workingDirectory: $(Pipeline.Workspace)/$(RepoDir)
       displayName: Mirror and tag
+
+  - job: MirrorPackages
+    displayName: Mirror Packages
+    variables:
+    # Destination package feed. If this feed changes, you must also change feedServiceConnection to point to that feed.
+    - name: destinationPackageFeed
+      value: https://pkgs.dev.azure.com/dotnet-security-partners/dotnet/_packaging/dotnet/nuget/v3/index.json
+    - name: feedServiceConnection
+      value: 'dotnet-security-partners-dotnet-dotnet feed'
+    - name: packagesArtifactName
+      value: signed
+    - name: shippingPackages
+      value: 'shipping/packages'
+    - name: packagesDownloadLocation
+      value: $(PIPELINE.WORKSPACE)/${{ parameters.dotnetStagingPipelineResource }}/$(packagesArtifactName)/$(shippingPackages)
+
+    steps:
+    - checkout: none
+
+    # First, download all shipping nupks from the staging pipeline.
+    # These should come from the signed directory, because in 6.0 post-build signing
+    # means that the 'signed' and 'shipping' artifacts are different in content.
+    - download: ${{ parameters.dotnetStagingPipelineResource }}
+      artifact: ${{ variables.packagesArtifactName }}
+      patterns: ${{ variables.shippingPackages }}/*
+      displayName: Download shipping packages
+
+    # Then, upload these to DSP.
+    - ${{ if parameters.isDryRun }}:
+      # List the packages that would be pushed
+      - script: |
+          echo "Would push the following packages to $(destinationPackageFeed)"
+          find $(packagesDownloadLocation) -name '*.nupkg'
+    - ${{ else }}:
+      - task: NuGetCommand@2
+        displayName: Publish packages to ${{ variables.destinationPackageFeed }}
+        continueOnError: true
+        inputs:
+          command: push
+          packagesToPush: '${{ variables.packagesDownloadLocation }}/*.nupkg'
+          nuGetFeedType: external
+          publishFeedCredentials: ${{ variables.feedServiceConnection }}
+          allowPackageConflicts: true 
+

--- a/eng/templates/stages/mirror.yml
+++ b/eng/templates/stages/mirror.yml
@@ -48,6 +48,17 @@ stages:
         value: https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-dotnet
       - name: sourceVersion
         value: $[ stageDependencies.PreRelease.PreRelease.outputs['AssociatedPipelineRuns.DotnetDotnetCommit'] ]
+    # Destination package feed. If this feed changes, you must also change feedServiceConnection to point to that feed.
+    - name: destinationPackageFeed
+      value: https://pkgs.dev.azure.com/dotnet-security-partners/dotnet/_packaging/dotnet/nuget/v3/index.json
+    - name: feedServiceConnection
+      value: 'dotnet-security-partners-dotnet-dotnet feed'
+    - name: packagesArtifactName
+      value: signed
+    - name: shippingPackages
+      value: 'shipping/packages'
+    - name: packagesDownloadLocation
+      value: $(PIPELINE.WORKSPACE)/${{ parameters.dotnetStagingPipelineResource }}/$(packagesArtifactName)/$(shippingPackages)
 
     steps:
     - checkout: none
@@ -115,25 +126,7 @@ stages:
       workingDirectory: $(Pipeline.Workspace)/$(RepoDir)
       displayName: Mirror and tag
 
-  - job: MirrorPackages
-    displayName: Mirror Packages
-    variables:
-    # Destination package feed. If this feed changes, you must also change feedServiceConnection to point to that feed.
-    - name: destinationPackageFeed
-      value: https://pkgs.dev.azure.com/dotnet-security-partners/dotnet/_packaging/dotnet/nuget/v3/index.json
-    - name: feedServiceConnection
-      value: 'dotnet-security-partners-dotnet-dotnet feed'
-    - name: packagesArtifactName
-      value: signed
-    - name: shippingPackages
-      value: 'shipping/packages'
-    - name: packagesDownloadLocation
-      value: $(PIPELINE.WORKSPACE)/${{ parameters.dotnetStagingPipelineResource }}/$(packagesArtifactName)/$(shippingPackages)
-
-    steps:
-    - checkout: none
-
-    # First, download all shipping nupks from the staging pipeline.
+    # Download all shipping nupks from the staging pipeline.
     # These should come from the signed directory, because in 6.0 post-build signing
     # means that the 'signed' and 'shipping' artifacts are different in content.
     - download: ${{ parameters.dotnetStagingPipelineResource }}
@@ -147,6 +140,8 @@ stages:
       - script: |
           echo "Would push the following packages to $(destinationPackageFeed)"
           find $(packagesDownloadLocation) -name '*.nupkg'
+        displayName: Publish packages to ${{ variables.destinationPackageFeed }}
+
     - ${{ else }}:
       - task: NuGetCommand@2
         displayName: Publish packages to ${{ variables.destinationPackageFeed }}


### PR DESCRIPTION
During the relese automation, push packages from current release to feed accessible to dotnet-security-partners.