### PR TITLE
[main] Use new CI leg name

### DIFF
--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -78,6 +78,7 @@ stages:
 
   - ${{ if eq(parameters.dotnetMajorVersion, '8.0') }}:
     - name: sourceBuildArtifactLeg
+      # When .NET 8.0 is released, gather artifacts from the `PreviousSourceBuiltSdk` leg instead
       value: CentOSStream8_Offline_MsftSdk_x64_Artifacts
     - name: sourceBuiltArtifactsFileName
       value: Private.SourceBuilt.Artifacts.8.0.100.centos.8-x64.tar.gz

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -78,7 +78,6 @@ stages:
 
   - ${{ if eq(parameters.dotnetMajorVersion, '8.0') }}:
     - name: sourceBuildArtifactLeg
-      # When .NET 8.0 is released, gather artifacts from the `PreviousSourceBuiltSdk` leg instead
       value: CentOSStream8_Offline_MsftSdk_x64_Artifacts
     - name: sourceBuiltArtifactsFileName
       value: Private.SourceBuilt.Artifacts.8.0.100.centos.8-x64.tar.gz

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -78,7 +78,7 @@ stages:
 
   - ${{ if eq(parameters.dotnetMajorVersion, '8.0') }}:
     - name: sourceBuildArtifactLeg
-      value: CentOSStream8_Offline_x64_Artifacts
+      value: CentOSStream8_Offline_MsftSdk_x64_Artifacts
     - name: sourceBuiltArtifactsFileName
       value: Private.SourceBuilt.Artifacts.8.0.100.centos.8-x64.tar.gz
     - name: sdkArtifactFileName


### PR DESCRIPTION
I have updated the CI leg names in https://github.com/dotnet/installer/pull/15603.

There is still an open question of how we can make sure leg names are shared across these multiple pipelines.

I think that after .NET 8 is released, or whenever we are prebuilt-clean and will likely not require a re-bootstrap, we should get artifacts from the `CentOSStream8_Offline_PreviousSourceBuiltSdk` leg instead of the `CentOSStream8_Offline_MsftSdk` leg. This would prevent us from using any Microsoft-built binaries at any point past the initial bootstrap during the .NET 8.0 servicing.