### PR TITLE
Use runtime version as the release tag for 6.0/7.0

### DIFF
--- a/eng/source-build-release-official.yml
+++ b/eng/source-build-release-official.yml
@@ -119,7 +119,9 @@ stages:
   parameters:
     dotnetStagingPipelineResource: dotnet-staging-pipeline-resource
     dotnetMajorVersion: ${{ parameters.dotnetMajorVersion }}
+    isPreviewRelease: ${{ parameters.isPreviewRelease }}
     releaseBranchName: ${{ parameters.releaseBranchName }}
+    useCustomTag: ${{ parameters.useCustomTag }}
     isDryRun: ${{ parameters.isDryRun }}
 
 - stage: NotificationApproval

--- a/eng/source-build-release-official.yml
+++ b/eng/source-build-release-official.yml
@@ -120,8 +120,6 @@ stages:
     dotnetStagingPipelineResource: dotnet-staging-pipeline-resource
     dotnetMajorVersion: ${{ parameters.dotnetMajorVersion }}
     releaseBranchName: ${{ parameters.releaseBranchName }}
-    useCustomTag: ${{ parameters.useCustomTag }}
-    customTag: ${{ replace(parameters.customTag, ' ', '') }}
     isDryRun: ${{ parameters.isDryRun }}
 
 - stage: NotificationApproval

--- a/eng/templates/stages/mirror.yml
+++ b/eng/templates/stages/mirror.yml
@@ -1,10 +1,12 @@
 parameters:
 - name: dotnetMajorVersion
-  displayName: Major .NET version being released
   type: string
 - name: releaseBranchName
-  displayName: Release branch name (e.g. release/8.0.1xx-preview1)
   type: string
+- name: isPreviewRelease
+  type: boolean
+- name: useCustomTag
+  type: boolean
 - name: isDryRun
   type: boolean
   default: false
@@ -31,18 +33,6 @@ stages:
       value: dn-bot@microsoft.com
     - name: destinationUrl
       value: https://dotnet-security-partners@dev.azure.com/dotnet-security-partners/dotnet/_git/dotnet
-    - name: releaseTag
-      value: $[ stageDependencies.PreRelease.PreRelease.outputs['ReadReleaseInfo.ReleaseTag'] ]
-    - ${{ if or(eq(parameters.dotnetMajorVersion, '6.0'), eq(parameters.dotnetMajorVersion, '7.0')) }}:
-      - name: sourceUrl
-        value: https://dnceng@dev.azure.com/dnceng/internal/_git/security-partners-dotnet
-      - name: sourceVersion
-        value: $[ stageDependencies.PreRelease.PreRelease.outputs['AssociatedPipelineRuns.InstallerCommit'] ]
-    - ${{ else }}:
-      - name: sourceUrl
-        value: https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-dotnet
-      - name: sourceVersion
-        value: $[ stageDependencies.PreRelease.PreRelease.outputs['AssociatedPipelineRuns.DotnetDotnetCommit'] ]
     # Destination package feed. If this feed changes, you must also change feedServiceConnection to point to that feed.
     - name: destinationPackageFeed
       value: https://pkgs.dev.azure.com/dotnet-security-partners/dotnet/_packaging/dotnet/nuget/v3/index.json
@@ -54,6 +44,24 @@ stages:
       value: 'shipping/packages'
     - name: packagesDownloadLocation
       value: $(PIPELINE.WORKSPACE)/${{ parameters.dotnetStagingPipelineResource }}/$(packagesArtifactName)/$(shippingPackages)
+
+    - ${{ if or(eq(parameters.dotnetMajorVersion, '6.0'), eq(parameters.dotnetMajorVersion, '7.0')) }}:
+      - name: sourceUrl
+        value: https://dnceng@dev.azure.com/dnceng/internal/_git/security-partners-dotnet
+      - name: sourceVersion
+        value: $[ stageDependencies.PreRelease.PreRelease.outputs['AssociatedPipelineRuns.InstallerCommit'] ]
+    - ${{ else }}:
+      - name: sourceUrl
+        value: https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-dotnet
+      - name: sourceVersion
+        value: $[ stageDependencies.PreRelease.PreRelease.outputs['AssociatedPipelineRuns.DotnetDotnetCommit'] ]
+
+    - ${{ if or(parameters.isPreviewRelease, parameters.useCustomTag) }}:
+      - name: releaseTag
+        value: $[ stageDependencies.PreRelease.PreRelease.outputs['ReadReleaseInfo.ReleaseTag'] ]
+    - ${{ else }}:
+      - name: releaseTag
+        value: $[ stageDependencies.PreRelease.PreRelease.outputs['ReadReleaseInfo.SdkVersion'] ]
 
     steps:
     - checkout: none

--- a/eng/templates/stages/mirror.yml
+++ b/eng/templates/stages/mirror.yml
@@ -5,11 +5,6 @@ parameters:
 - name: releaseBranchName
   displayName: Release branch name (e.g. release/8.0.1xx-preview1)
   type: string
-- name: useCustomTag
-  type: boolean
-  default: false
-- name: customTag
-  type: string
 - name: isDryRun
   type: boolean
   default: false
@@ -36,8 +31,8 @@ stages:
       value: dn-bot@microsoft.com
     - name: destinationUrl
       value: https://dotnet-security-partners@dev.azure.com/dotnet-security-partners/dotnet/_git/dotnet
-    - name: sdkVersion
-      value: $[ stageDependencies.PreRelease.PreRelease.outputs['ReadReleaseInfo.SdkVersion'] ]
+    - name: releaseTag
+      value: $[ stageDependencies.PreRelease.PreRelease.outputs['ReadReleaseInfo.ReleaseTag'] ]
     - ${{ if or(eq(parameters.dotnetMajorVersion, '6.0'), eq(parameters.dotnetMajorVersion, '7.0')) }}:
       - name: sourceUrl
         value: https://dnceng@dev.azure.com/dnceng/internal/_git/security-partners-dotnet
@@ -105,13 +100,8 @@ stages:
         git fetch source "$ref_to_tag"
         git checkout "$ref_to_tag"
 
-        if [ "${{ parameters.useCustomTag }}" = "True" ] ; then
-          tag_name="${{ parameters.customTag }}"
-          echo "Using custom tag ${tag_name}"
-        else
-          tag_name="v$(SdkVersion)"
-          echo "Using tag ${tag_name}"
-        fi
+        tag_name="v$(releaseTag)"
+        echo "Tagging $ref_to_tag as $tag_name"
 
         # Check if the tag already exists and points to the same commit
         sha=$(git rev-parse HEAD)
@@ -129,7 +119,7 @@ stages:
           fi
         fi
 
-        message=".NET Source-build $(sdkVersion)-SDK"
+        message=".NET Source-build $(releaseTag)"
         git tag "$tag_name" "$ref_to_tag" -m "$message"
 
         if [ "${{ parameters.isDryRun }}" = "True" ]; then

--- a/eng/templates/stages/mirror.yml
+++ b/eng/templates/stages/mirror.yml
@@ -50,18 +50,15 @@ stages:
         value: https://dnceng@dev.azure.com/dnceng/internal/_git/security-partners-dotnet
       - name: sourceVersion
         value: $[ stageDependencies.PreRelease.PreRelease.outputs['AssociatedPipelineRuns.InstallerCommit'] ]
+      - name: releaseTag
+        value: $[ stageDependencies.PreRelease.PreRelease.outputs['ReadReleaseInfo.SdkVersion'] ]
     - ${{ else }}:
       - name: sourceUrl
         value: https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-dotnet
       - name: sourceVersion
         value: $[ stageDependencies.PreRelease.PreRelease.outputs['AssociatedPipelineRuns.DotnetDotnetCommit'] ]
-
-    - ${{ if or(parameters.isPreviewRelease, parameters.useCustomTag) }}:
       - name: releaseTag
         value: $[ stageDependencies.PreRelease.PreRelease.outputs['ReadReleaseInfo.ReleaseTag'] ]
-    - ${{ else }}:
-      - name: releaseTag
-        value: $[ stageDependencies.PreRelease.PreRelease.outputs['ReadReleaseInfo.SdkVersion'] ]
 
     steps:
     - checkout: none


### PR DESCRIPTION
One final adjustment to match what was discussed in https://github.com/dotnet/source-build/issues/3317#issuecomment-1472501742