### PR TITLE
Add release manifest and instructions to dotnet/dotnet releases

### DIFF
--- a/eng/create-announcement-draft.sh
+++ b/eng/create-announcement-draft.sh
@@ -14,6 +14,7 @@ print-help ()
   echo "--sdk-version VERSION The .NET SDK version that is being released"
   echo "--runtime-version VER The .NET runtime version that is being released"
   echo "--tag TAG             The release tag, e.g. v8.0.0-preview.1"
+  echo "--source-version SHA  (Optional) The dotnet/dotnet SHA of the commit that is being released"
   echo "--prerelease          (Optional) Whether this is a preview release"
   echo "--help, -h            (Optional) print this help message and exit"
   echo
@@ -24,6 +25,7 @@ channel=''
 release=''
 release_name=''
 sdk_version=''
+source_version=''
 runtime_version=''
 tag=''
 prerelease=false
@@ -63,6 +65,10 @@ while [[ $# -gt 0 ]]; do
       tag="$2"
       shift 2
       ;;
+    --source-version )
+      source_version="$2"
+      shift 2
+      ;;
     --prerelease )
       prerelease=true
       shift 1
@@ -90,6 +96,7 @@ export RUNTIME_VERSION="$runtime_version"
 export RELEASE_CHANNEL="$channel"
 export SDK_VERSION="$sdk_version"
 export RELEASE_DATE=$(date +"%B %Y") # e.g. "March 2022"
+export SOURCE_VERSION="$source_version"
 
 if [[ "$channel" == '6.0' || "$channel" == '7.0' ]]; then
     export TAG_URL="https://github.com/dotnet/installer/releases/tag/$tag"

--- a/eng/source-build-release-notes.md
+++ b/eng/source-build-release-notes.md
@@ -1,22 +1,4 @@
 You can build $RELEASE_NAME from the repository by cloning the release tag `$TAG` and following the build instructions in the [main README.md](https://github.com/dotnet/dotnet/blob/$TAG/README.md#building).
 
-```sh
-git clone --branch $TAG --depth 1 https://github.com/dotnet/dotnet
-(cd dotnet && ./build.sh)
-```
-
-Alternatively, you can build from the sources attached to this release. Please note that you'll need to provide the release information to the build script. This can be done directly:
-```sh
-curl -sSL https://github.com/dotnet/dotnet/archive/refs/tags/$TAG.tar.gz | tar xzf -
-(cd dotnet-* && ./build.sh --source-repository https://github.com/dotnet/dotnet --source-version $SOURCE_VERSION)
-```
-
-or by downloading the [release manifest](https://github.com/dotnet/dotnet/releases/download/$TAG/release.json) file:
-
-```sh
-curl -sSL https://github.com/dotnet/dotnet/archive/refs/tags/$TAG.tar.gz | tar xzf -
-curl -Lo release.json https://github.com/dotnet/dotnet/releases/download/$TAG/release.json
-(cd dotnet-* && ./build.sh --release-manifest ../release.json)
-```
-
+Alternatively, you can build from the sources attached to this release directly.
 More information on this process can be found in the [dotnet/dotnet repository](https://github.com/dotnet/dotnet/blob/$TAG/README.md#building-from-released-sources).

--- a/eng/source-build-release-notes.md
+++ b/eng/source-build-release-notes.md
@@ -7,17 +7,15 @@ git clone --branch $TAG --depth 1 https://github.com/dotnet/dotnet
 
 Alternatively, you can build from the sources attached to this release. Please note that you'll need to provide the release information to the build script. This can be done directly:
 ```sh
-curl -Lo dotnet-sdk-source-$TAG.tar.gz https://github.com/dotnet/dotnet/archive/refs/tags/$TAG.tar.gz
-tar zxf dotnet-sdk-source-$TAG.tar.gz
+curl -sSL https://github.com/dotnet/dotnet/archive/refs/tags/$TAG.tar.gz | tar xzf -
 (cd dotnet-* && ./build.sh --source-repository https://github.com/dotnet/dotnet --source-version $SOURCE_VERSION)
 ```
 
 or by downloading the [release manifest](https://github.com/dotnet/dotnet/releases/download/$TAG/release.json) file:
 
 ```sh
-curl -Lo dotnet-sdk-source-$TAG.tar.gz https://github.com/dotnet/dotnet/archive/refs/tags/$TAG.tar.gz
+curl -sSL https://github.com/dotnet/dotnet/archive/refs/tags/$TAG.tar.gz | tar xzf -
 curl -Lo release.json https://github.com/dotnet/dotnet/releases/download/$TAG/release.json
-tar zxf dotnet-sdk-source-$TAG.tar.gz
 (cd dotnet-* && ./build.sh --release-manifest ../release.json)
 ```
 

--- a/eng/source-build-release-notes.md
+++ b/eng/source-build-release-notes.md
@@ -1,0 +1,24 @@
+You can build $RELEASE_NAME from the repository by cloning the release tag `$TAG` and following the build instructions in the [main README.md](https://github.com/dotnet/dotnet/blob/$TAG/README.md#building).
+
+```sh
+git clone --branch $TAG --depth 1 https://github.com/dotnet/dotnet
+(cd dotnet && ./build.sh)
+```
+
+Alternatively, you can build from the sources attached to this release. Please note that you'll need to provide the release information to the build script. This can be done directly:
+```sh
+curl -Lo dotnet-sdk-source-$TAG.tar.gz https://github.com/dotnet/dotnet/archive/refs/tags/$TAG.tar.gz
+tar zxf dotnet-sdk-source-$TAG.tar.gz
+(cd dotnet-* && ./build.sh --source-repository https://github.com/dotnet/dotnet --source-version $SOURCE_VERSION)
+```
+
+or by downloading the [release manifest](https://github.com/dotnet/dotnet/releases/download/$TAG/release.json) file:
+
+```sh
+curl -Lo dotnet-sdk-source-$TAG.tar.gz https://github.com/dotnet/dotnet/archive/refs/tags/$TAG.tar.gz
+curl -Lo release.json https://github.com/dotnet/dotnet/releases/download/$TAG/release.json
+tar zxf dotnet-sdk-source-$TAG.tar.gz
+(cd dotnet-* && ./build.sh --release-manifest ../release.json)
+```
+
+More information on this process can be found in the [dotnet/dotnet repository](https://github.com/dotnet/dotnet/blob/$TAG/README.md#building-from-released-sources).

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -187,7 +187,7 @@ stages:
           echo -e "\n\nCreating GitHub release..."
 
           gh release create "$(releaseTag)"         \
-            "$release_json#Release manifest"     \
+            "$release_json#Release manifest"        \
             --repo dotnet/dotnet                    \
             --title "${{ parameters.releaseName }}" \
             --target "$(dotnetDotnetCommit)"        \

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -152,7 +152,25 @@ stages:
             draft='--draft'
           fi
 
+          release_json="$(Build.ArtifactStagingDirectory)/release.json"
+
+          echo "{}" \
+            | jq '. += { "release": "$(release)" }' \
+            | jq '. += { "channel": "$(releaseChannel)" }' \
+            | jq '. += { "tag": "$(releaseTag)" }' \
+            | jq '. += { "sdkVersion": "$(sdkVersion)" }' \
+            | jq '. += { "runtimeVersion": "$(runtimeVersion)" }' \
+            | jq '. += { "sourceRepository": "https://github.com/dotnet/dotnet" }' \
+            | jq '. += { "sourceVersion": "$(dotnetDotnetCommit)" }' \
+            > "$release_json"
+
+          echo "Generated release.json:"
+          cat "$release_json"
+
+          echo "Creating GitHub release..."
+
           gh release create "$(releaseTag)"         \
+            "$release_json#Release information"     \
             --repo dotnet/dotnet                    \
             --title "${{ parameters.releaseName }}" \
             --target "$(dotnetDotnetCommit)"        \

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -187,7 +187,7 @@ stages:
           echo -e "\n\nCreating GitHub release..."
 
           gh release create "$(releaseTag)"         \
-            "$release_json#Release information"     \
+            "$release_json#Release manifest"     \
             --repo dotnet/dotnet                    \
             --title "${{ parameters.releaseName }}" \
             --target "$(dotnetDotnetCommit)"        \

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -155,29 +155,48 @@ stages:
           release_json="$(Build.ArtifactStagingDirectory)/release.json"
 
           echo "{}" \
-            | jq '. += { "release": "$(release)" }' \
-            | jq '. += { "channel": "$(releaseChannel)" }' \
-            | jq '. += { "tag": "$(releaseTag)" }' \
-            | jq '. += { "sdkVersion": "$(sdkVersion)" }' \
-            | jq '. += { "runtimeVersion": "$(runtimeVersion)" }' \
+            | jq '. += { "release": "$(release)" }'                                \
+            | jq '. += { "channel": "$(releaseChannel)" }'                         \
+            | jq '. += { "tag": "$(releaseTag)" }'                                 \
+            | jq '. += { "sdkVersion": "$(sdkVersion)" }'                          \
+            | jq '. += { "runtimeVersion": "$(runtimeVersion)" }'                  \
             | jq '. += { "sourceRepository": "https://github.com/dotnet/dotnet" }' \
-            | jq '. += { "sourceVersion": "$(dotnetDotnetCommit)" }' \
+            | jq '. += { "sourceVersion": "$(dotnetDotnetCommit)" }'               \
             > "$release_json"
 
-          echo "Generated release.json:"
+          echo -e "\n\nGenerated release.json:\n\n"
           cat "$release_json"
 
-          echo "Creating GitHub release..."
+          release_notes="$(Build.ArtifactStagingDirectory)/release_notes.md"
+
+          ./create-announcement-draft.sh                   \
+            --template "source-build-release-notes.md"     \
+            --channel "$(releaseChannel)"                  \
+            $prerelease                                    \
+            --release "$(release)"                         \
+            --release-name "${{ parameters.releaseName }}" \
+            --runtime-version "$(runtimeVersion)"          \
+            --sdk-version "$(sdkVersion)"                  \
+            --tag "$(releaseTag)"                          \
+            --source-version "$(dotnetDotnetCommit)"       \
+            > "$release_notes"
+
+          echo -e "\n\nGenerated release notes:\n\n"
+          cat "$release_notes"
+
+          echo -e "\n\nCreating GitHub release..."
 
           gh release create "$(releaseTag)"         \
             "$release_json#Release information"     \
             --repo dotnet/dotnet                    \
             --title "${{ parameters.releaseName }}" \
             --target "$(dotnetDotnetCommit)"        \
+            --notes-file "$release_notes"           \
             $prerelease                             \
             $draft
 
         displayName: Create GitHub release
+        workingDirectory: $(Agent.BuildDirectory)/dotnet-source-build/eng
         env:
           GH_TOKEN: $(BotAccount-dotnet-bot-repo-PAT)
 


### PR DESCRIPTION
https://github.com/dotnet/source-build/issues/3366

Example release: https://github.com/dotnet/dotnet/releases/tag/untagged-563947d5583e5a29f43d
Example `release.json`:
```json
{
  "release": "8.0.100-preview.3",
  "channel": "8.0",
  "tag": "v8.0.100-preview.3.23178.7",
  "sdkVersion": "8.0.100-preview.3.23178.7",
  "runtimeVersion": "8.0.0-preview.3.23174.8",
  "sourceRepository": "https://github.com/dotnet/dotnet",
  "sourceVersion": "6d6f38c2d65c50dfc31dcdadfef1ba24ed4efc45"
}
```

The linked instructions are added here: https://github.com/dotnet/installer/pull/16184