### PR TITLE
Use the `Build.Ubuntu.2004.Amd64` pool for package mirroring

### DIFF
--- a/eng/templates/stages/mirror.yml
+++ b/eng/templates/stages/mirror.yml
@@ -60,6 +60,12 @@ stages:
       - name: sourceVersion
         value: $[ stageDependencies.PreRelease.PreRelease.outputs['AssociatedPipelineRuns.DotnetDotnetCommit'] ]
 
+    # We're using a different pool than the rest of the pipeline here to get more disk space
+    # More information here: https://github.com/dotnet/arcade/issues/13036
+    pool:
+      name: NetCore1ESPool-Svc-Internal
+      demands: ImageOverride -equals Build.Ubuntu.2004.Amd64
+
     steps:
     - checkout: none
 


### PR DESCRIPTION
Resolves #3381

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2164071&view=logs&j=b6422d7d-1f12-5a27-5bca-0651b2848f2b&t=3e07d252-5687-5ff1-9e2c-f75b5de04ae8