### PR TITLE
Prevent nuking of `global.json` in release PRs

### DIFF
--- a/eng/submit-source-build-release-pr.sh
+++ b/eng/submit-source-build-release-pr.sh
@@ -132,7 +132,9 @@ git checkout -b "${new_branch_name}" "upstream/${pr_target_branch}"
 # make pr changes
 cat "$global_json_path" \
     | jq --unbuffered ".tools.dotnet=\"${sdk_version}\"" \
-    | tee "$global_json_path"
+    | tee "$global_json_path.new"
+mv "$global_json_path.new" "$global_json_path"
+
 sed -i "s#<PrivateSourceBuiltArtifactsPackageVersion>.*</PrivateSourceBuiltArtifactsPackageVersion>#<PrivateSourceBuiltArtifactsPackageVersion>$sdk_version</PrivateSourceBuiltArtifactsPackageVersion>#" $versions_props_path
 git add "$global_json_path" "$versions_props_path"
 


### PR DESCRIPTION
This didn't happen 100% of the time so I guess we didn't notice earlier. Probably a race condition in how `jq` reads and writes to the same file at the same time

Fixes #3378