### PR TITLE
Omit build number in announcement title of preview releases

### DIFF
--- a/eng/create-announcement-draft.sh
+++ b/eng/create-announcement-draft.sh
@@ -1,22 +1,26 @@
 #!/bin/bash
-set -euo pipefail
 
-print-help ()
-{
-  echo "Uses a template to draft a release announcement and outputs it into a file."
-  echo
-  echo "Options:"
-  echo "--template FILE       The base template to use for the announcement"
-  echo "--channel CHANNEL     Release channel, e.g. '8.0'"
-  echo "                      Note that when 6.0/7.0, dotnet/installer is targeted, otherwise dotnet/dotnet"
-  echo "--release RELEASE     Programmatic name of the release, e.g. '8.0.0.preview-1'"
-  echo "--release-name NAME   Human readable name of the release, e.g. '.NET 8 Preview 1'"
-  echo "--sdk-version VERSION The .NET SDK version that is being released"
-  echo "--runtime-version VER The .NET runtime version that is being released"
-  echo "--tag TAG             The release tag, e.g. v8.0.0-preview.1"
-  echo "--prerelease          (Optional) Whether this is a preview release"
-  echo "--help, -h            (Optional) print this help message and exit"
-  echo
+### Usage: $0 [options]
+###
+### Fills out a template of a release announcement and prints it out.
+###
+### Options:
+###   --template <FILE>        The base template to use for the announcement
+###   --channel <CHANNEL>      Release channel, e.g. 8.0
+###                            Note that when 6.0/7.0, dotnet/installer is targeted, otherwise dotnet/dotnet
+###   --release <NAME>         Programmatic name of the release, e.g. 8.0.0.preview-1
+###   --release-name <NAME>    Human readable name of the release, e.g. .NET 8 Preview 1
+###   --sdk-version <VER>      The .NET SDK version that is being released
+###   --runtime-version <VER>  The .NET runtime version that is being released
+###   --tag <TAG>              The release tag, e.g. v8.0.0-preview.1
+###   --prerelease             (Optional) Whether this is a preview release
+###   --help, -h               (Optional) Print this help message and exit
+
+set -euo pipefail
+source="${BASH_SOURCE[0]}"
+
+function print_help () {
+  sed -n '/^### /,/^$/p' "$source" | cut -b 5-
 }
 
 template=''
@@ -32,7 +36,7 @@ while [[ $# -gt 0 ]]; do
   opt="$(echo "$1" | tr "[:upper:]" "[:lower:]")"
   case "$opt" in
     -h | --help )
-      print-help
+      print_help
       exit 0
       ;;
     --template )
@@ -92,9 +96,9 @@ export SDK_VERSION="$sdk_version"
 export RELEASE_DATE=$(date +"%B %Y") # e.g. "March 2022"
 
 if [[ "$channel" == '6.0' || "$channel" == '7.0' ]]; then
-    export TAG_URL="https://github.com/dotnet/installer/releases/tag/$tag"
+  export TAG_URL="https://github.com/dotnet/installer/releases/tag/$tag"
 else
-    export TAG_URL="https://github.com/dotnet/dotnet/releases/tag/$tag"
+  export TAG_URL="https://github.com/dotnet/dotnet/releases/tag/$tag"
 fi
 
 if [[ "$prerelease" == true ]]; then

--- a/eng/create-announcement-draft.sh
+++ b/eng/create-announcement-draft.sh
@@ -99,8 +99,14 @@ fi
 
 if [[ "$prerelease" == true ]]; then
   export RELEASE_NOTES_URL="https://github.com/dotnet/core/blob/main/release-notes/$RELEASE_CHANNEL/preview/$RELEASE.md"
+
+  # Removes the build number so that 8.0.100-preview.3.23178.7 becomes 8.0.100-preview.3
+  export SDK_VERSION_SHORT=$(echo "$SDK_VERSION" | sed 's/\(.*preview\.[0-9]\+\).*/\1/')
+  export RUNTIME_VERSION_SHORT=$(echo "$RUNTIME_VERSION" | sed 's/\(.*preview\.[0-9]\+\).*/\1/')
 else
   export RELEASE_NOTES_URL="https://github.com/dotnet/core/blob/main/release-notes/$RELEASE_CHANNEL/$RUNTIME_VERSION/$SDK_VERSION.md"
+  export SDK_VERSION_SHORT="$SDK_VERSION"
+  export RUNTIME_VERSION_SHORT="$RUNTIME_VERSION"
 fi
 
 envsubst < "$template"

--- a/eng/source-build-release-announcement.md
+++ b/eng/source-build-release-announcement.md
@@ -1,6 +1,6 @@
 <!-- This file is a template for a GitHub Discussion post. -->
 <!-- The line prefixed by 'Title:' will be submitted as the title of the discussion, and the rest of the file will be submitted as the body. -->
-Title: $RELEASE_NAME $RELEASE_DATE Update - .NET $RUNTIME_VERSION and SDK $SDK_VERSION
+Title: $RELEASE_NAME $RELEASE_DATE Update - .NET $RUNTIME_VERSION_SHORT and SDK $SDK_VERSION_SHORT
 
 Please use the [$TAG tag]($TAG_URL) to source-build .NET version $RUNTIME_VERSION / $SDK_VERSION.
 


### PR DESCRIPTION
Resolves #3382

Example build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2166629&view=logs&j=3a04dffd-22cf-5707-fa41-9bd4708cc1db&t=b33c9200-20e6-56d2-908d-d0d0eca38f08&l=14