### PR TITLE
Skipping PR creation in the absence of any commits

### DIFF
--- a/eng/push-tarball.sh
+++ b/eng/push-tarball.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -xeuo pipefail
+set -euo pipefail
 
 print-help ()
 {
@@ -107,7 +107,12 @@ pushd "$vmr_path"
 
   # Re-runs should expect the branch being merged previously already
   git add -f .
-  git diff --staged --quiet || git commit -m "Update to .NET $sdk_version"
+  if git diff --staged --quiet; then
+    echo "##vso[task.logissue type=warning]The PR creation is skipped since it contains no commits."
+    exit 0
+  fi
+
+  git commit -m "Update to .NET $sdk_version"
 
   pr_url=$(echo $upstream_url | sed "s,_git.*,_apis/git/repositories/security-partners-dotnet/pullrequests?api-version=7.0,g")
   data="{

--- a/eng/push-tarball.sh
+++ b/eng/push-tarball.sh
@@ -105,14 +105,15 @@ pushd "$vmr_path"
   git config user.email "dotnet-maestro[bot]@users.noreply.github.com"
   git config user.name "dotnet-maestro[bot]"
 
-  # Re-runs should expect the branch being merged previously already
   git add -f .
-  if git diff --staged --quiet; then
+  git diff --staged --quiet || git commit -m "Update to .NET $sdk_version"
+
+  # If the new and target branches are identical, the code has already been merged by a previous run and PR;
+  # hence, there is no need for a new PR.
+  if git diff "$new_branch_name" "$target_branch" --quiet; then
     echo "##vso[task.logissue type=warning]The PR creation is skipped since it contains no commits."
     exit 0
   fi
-
-  git commit -m "Update to .NET $sdk_version"
 
   pr_url=$(echo $upstream_url | sed "s,_git.*,_apis/git/repositories/security-partners-dotnet/pullrequests?api-version=7.0,g")
   data="{

--- a/eng/push-tarball.sh
+++ b/eng/push-tarball.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -xeuo pipefail
 
 print-help ()
 {

--- a/eng/push-tarball.sh
+++ b/eng/push-tarball.sh
@@ -111,7 +111,7 @@ pushd "$vmr_path"
   # If the new and target branches are identical, the code has already been merged by a previous run and PR;
   # hence, there is no need for a new PR.
   if git diff "$new_branch_name" "$target_branch" --quiet; then
-    echo "##vso[task.logissue type=warning]The PR creation is skipped since it contains no commits."
+    echo "##vso[task.logissue type=warning]No PR created because there are no new changes against $target_branch"
     exit 0
   fi
 

--- a/eng/templates/stages/pre-release.yml
+++ b/eng/templates/stages/pre-release.yml
@@ -123,7 +123,7 @@ stages:
           azureStorageKey: $(dotnetclimsrc-access-key)
       
       - script: |
-          set -euo pipefail
+          set -xeuo pipefail
 
           upstream_with_pat=$(echo $(vmrUpstreamUrl) | sed "s,https://.*@,https://dn-bot:${AZDO_PAT}@,g")
 

--- a/eng/templates/stages/pre-release.yml
+++ b/eng/templates/stages/pre-release.yml
@@ -123,7 +123,7 @@ stages:
           azureStorageKey: $(dotnetclimsrc-access-key)
       
       - script: |
-          set -xeuo pipefail
+          set -euo pipefail
 
           upstream_with_pat=$(echo $(vmrUpstreamUrl) | sed "s,https://.*@,https://dn-bot:${AZDO_PAT}@,g")
 


### PR DESCRIPTION
It is conceivable that the PR created by Update security-partners-dotnet has already been merged if Pre-release stage is executed more than once. 

Issue Link: https://github.com/dotnet/source-build/issues/3353

Pipeline Link: https://dev.azure.com/dnceng/internal/_build/results?buildId=2174527&view=logs&j=3a04dffd-22cf-5707-fa41-9bd4708cc1db&t=43d9a424-b64c-5d30-c3bd-0fca912bd01a