### PR TITLE
Use wildcard for referencing artifacts tarball

### DIFF
--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -82,7 +82,7 @@ stages:
     - name: sourceBuildArtifactLeg
       value: CentOSStream8_Offline_MsftSdk_x64_Artifacts
     - name: sourceBuiltArtifactsFileName
-      value: Private.SourceBuilt.Artifacts.8.0.100.centos.8-x64.tar.gz
+      value: Private.SourceBuilt.Artifacts.*.centos.8-x64.tar.gz
     - name: sdkArtifactFileName
       value: dotnet-sdk-*.tar.gz
 


### PR DESCRIPTION
Now that https://github.com/dotnet/source-build/issues/3268 is fixed, it causes a mismatch in the expected artifacts tarball file name that is used for the release pipeline. The file name now contains a build number (e.g. `Private.SourceBuilt.Artifacts.8.0.100-preview.4.23260.1.centos.8-x64.tar.gz`) but the release pipeline is expecting `Private.SourceBuilt.Artifacts.8.0.100.centos.8-x64.tar.gz`.

This is fixed by using a wildcard for the version.