### PR TITLE
Updating PrivateSourceBuilt elements in the Versions.props file correctly.

### DIFF
--- a/eng/submit-source-build-release-pr.sh
+++ b/eng/submit-source-build-release-pr.sh
@@ -21,8 +21,8 @@ a PR in the target repo."
    echo "--targetBranch, -b    (Optional) branch to submit the PR to, calculated automatically otherwise"
    echo "--globalJson, -g      (Optional) path to the global.json file to update"
    echo "--versionsProps, -p   (Optional) path to the Versions.props file to update"
-   echo "--sourceBuiltArtifactsFileName, -a   name of the archive containing source build artifacts"
-   echo "--sdkArtifactFileName, -s   name of the archive containing the source built SDK"
+   echo "--sourceBuiltArtifactsFileName   name of the archive containing source build artifacts"
+   echo "--sdkArtifactFileName   name of the archive containing the source built SDK"
    echo "--setupGitAuth, -G    (Optional) set up git authentication using the gh CLI"
    echo "--help, -h            (Optional) print this help message and exit"
    echo
@@ -84,11 +84,11 @@ while true ; do
       custom_target_branch="$2"
       shift 2
       ;;
-    -a | --sourceBuiltArtifactsFileName )
+    --sourceBuiltArtifactsFileName )
       source_built_artifacts_file_name="$2"
       shift 2
       ;;
-    -s | --sdkArtifactFileName )
+    --sdkArtifactFileName )
       sdk_artifact_file_name="$2"
       shift 2
       ;;
@@ -172,14 +172,13 @@ function modify_url_in_xml() {
   echo "Replacing value of $element_name with $new_url"
 }
 
-if [[ $sdk_version == "6"* ]]; then
-        sed -i "s#<PrivateSourceBuiltArtifactsPackageVersion>.*</PrivateSourceBuiltArtifactsPackageVersion>#<PrivateSourceBuiltArtifactsPackageVersion>$sdk_version</PrivateSourceBuiltArtifactsPackageVersion>#" $versions_props_path
+if [[ $sdk_version == "6"* || $sdk_version == "7"* ]]; then
+  sed -i "s#<PrivateSourceBuiltArtifactsPackageVersion>.*</PrivateSourceBuiltArtifactsPackageVersion>#<PrivateSourceBuiltArtifactsPackageVersion>$sdk_version</PrivateSourceBuiltArtifactsPackageVersion>#" $versions_props_path
 elif [[ $sdk_version == "7"* ]]; then
-        sed -i "s#<PrivateSourceBuiltArtifactsPackageVersion>.*</PrivateSourceBuiltArtifactsPackageVersion>#<PrivateSourceBuiltArtifactsPackageVersion>$sdk_version</PrivateSourceBuiltArtifactsPackageVersion>#" $versions_props_path
-        sed -i "s#<PrivateSourceBuiltSDKVersion>.*</PrivateSourceBuiltSDKVersion>#<PrivateSourceBuiltSDKVersion>$sdk_version</PrivateSourceBuiltSDKVersion>#" $versions_props_path
+  sed -i "s#<PrivateSourceBuiltSDKVersion>.*</PrivateSourceBuiltSDKVersion>#<PrivateSourceBuiltSDKVersion>$sdk_version</PrivateSourceBuiltSDKVersion>#" $versions_props_path
 else
-        modify_url_in_xml "$versions_props_path" "PrivateSourceBuiltArtifactsUrl" "$source_built_artifacts_file_name"
-        modify_url_in_xml "$versions_props_path" "PrivateSourceBuiltSdkUrl_CentOS8Stream" "$sdk_artifact_file_name"
+  modify_url_in_xml "$versions_props_path" "PrivateSourceBuiltArtifactsUrl" "$source_built_artifacts_file_name"
+  modify_url_in_xml "$versions_props_path" "PrivateSourceBuiltSdkUrl_CentOS8Stream" "$sdk_artifact_file_name"
 fi
 
 git add "$global_json_path" "$versions_props_path"

--- a/eng/submit-source-build-release-pr.sh
+++ b/eng/submit-source-build-release-pr.sh
@@ -37,6 +37,8 @@ global_json_path='src/SourceBuild/content/global.json'
 versions_props_path='src/SourceBuild/content/eng/Versions.props'
 custom_target_branch=''
 setup_git_auth=''
+resolved_source_built_artifacts_file_name=''
+resolved_sdk_artifact_file_name=''
 
 while true ; do
   case "$1" in
@@ -80,6 +82,14 @@ while true ; do
       custom_target_branch="$2"
       shift 2
       ;;
+    -a | --resolvedSourceBuiltArtifactsFileName )
+      resolved_source_built_artifacts_file_name="$2"
+      shift 2
+      ;;
+    -s | --resolvedSdkArtifactFileName )
+      resolved_sdk_artifact_file_name="$2"
+      shift 2
+      ;;
     -- )
       shift
       break
@@ -100,6 +110,9 @@ echo "global_json_path = $global_json_path"
 echo "versions_props_path = $versions_props_path"
 echo "custom_target_branch = $custom_target_branch"
 echo "setup_git_auth = $setup_git_auth"
+echo "resolved_source_built_artifacts_file_name = $resolved_source_built_artifacts_file_name"
+echo "resolved_sdk_artifact_file_name = $resolved_sdk_artifact_file_name"
+
 
 if [[ ${setup_git_auth} == true ]]; then
   echo "Setting up git auth"
@@ -136,17 +149,13 @@ cat "$global_json_path" \
 mv "$global_json_path.new" "$global_json_path"
 
 if [[ $sdk_version == "6"* ]]; then
-        echo sdk_version == "6"
         sed -i "s#<PrivateSourceBuiltArtifactsPackageVersion>.*</PrivateSourceBuiltArtifactsPackageVersion>#<PrivateSourceBuiltArtifactsPackageVersion>$sdk_version</PrivateSourceBuiltArtifactsPackageVersion>#" $versions_props_path
 elif [[ $sdk_version == "7"* ]]; then
-        echo sdk_version == "7"
         sed -i "s#<PrivateSourceBuiltArtifactsPackageVersion>.*</PrivateSourceBuiltArtifactsPackageVersion>#<PrivateSourceBuiltArtifactsPackageVersion>$sdk_version</PrivateSourceBuiltArtifactsPackageVersion>#" $versions_props_path
         sed -i "s#<PrivateSourceBuiltSDKVersion>.*</PrivateSourceBuiltSDKVersion>#<PrivateSourceBuiltSDKVersion>$sdk_version</PrivateSourceBuiltSDKVersion>#" $versions_props_path
 elif [[ $sdk_version == "8"* ]]; then
-        echo sdk_version == "8"
-        # buna ihtiyacim var sdkArtifactFileName
-        sed -i "s#<PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/.*</PrivateSourceBuiltArtifactsUrl>#<PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/XXXX</PrivateSourceBuiltArtifactsUrl>#" $versions_props_path
-        sed -i "s#<PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/assets/.*</PrivateSourceBuiltSdkUrl_CentOS8Stream>#<PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/assets/YYY</PrivateSourceBuiltSdkUrl_CentOS8Stream>#" $versions_props_path
+        sed -i "s#<PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/.*</PrivateSourceBuiltArtifactsUrl>#<PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/$resolved_source_built_artifacts_file_name</PrivateSourceBuiltArtifactsUrl>#" $versions_props_path
+        sed -i "s#<PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/assets/.*</PrivateSourceBuiltSdkUrl_CentOS8Stream>#<PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/assets/$resolved_sdk_artifact_file_name</PrivateSourceBuiltSdkUrl_CentOS8Stream>#" $versions_props_path
 else
         echo "Unexpected SDK version!"
         exit 1

--- a/eng/submit-source-build-release-pr.sh
+++ b/eng/submit-source-build-release-pr.sh
@@ -184,26 +184,25 @@ else
         echo "Unexpected SDK version!"
         exit 1
 fi
-
+# Validate changes in Version.props file
 git diff
 
+git add "$global_json_path" "$versions_props_path"
 
-# git add "$global_json_path" "$versions_props_path"
+git config --global user.name "dotnet-sb-bot"
+git config --global user.email "dotnet-sb-bot@microsoft.com"
+git commit -m "update global.json and Versions.props for .NET SDK ${sdk_version}"
 
-# git config --global user.name "dotnet-sb-bot"
-# git config --global user.email "dotnet-sb-bot@microsoft.com"
-# git commit -m "update global.json and Versions.props for .NET SDK ${sdk_version}"
+# push changes to fork
+git push -u origin "${new_branch_name}"
 
-# # push changes to fork
-# git push -u origin "${new_branch_name}"
+readarray -d '/' -t fork_repo_split <<< "${fork_repo}"
+fork_owner="${fork_repo_split[0]}"
 
-# readarray -d '/' -t fork_repo_split <<< "${fork_repo}"
-# fork_owner="${fork_repo_split[0]}"
-
-# create pull request
-# gh pr create \
-#     --head "${fork_owner}:${new_branch_name}" \
-#     --repo "${target_repo}" \
-#     --base "${pr_target_branch}" \
-#     --title "${title}" \
-#     --body "${body}"
+create pull request
+gh pr create \
+    --head "${fork_owner}:${new_branch_name}" \
+    --repo "${target_repo}" \
+    --base "${pr_target_branch}" \
+    --title "${title}" \
+    --body "${body}"

--- a/eng/submit-source-build-release-pr.sh
+++ b/eng/submit-source-build-release-pr.sh
@@ -197,10 +197,12 @@ git push -u origin "${new_branch_name}"
 readarray -d '/' -t fork_repo_split <<< "${fork_repo}"
 fork_owner="${fork_repo_split[0]}"
 
+cat "$versions_props_path"
+
 # create pull request
-gh pr create \
-    --head "${fork_owner}:${new_branch_name}" \
-    --repo "${target_repo}" \
-    --base "${pr_target_branch}" \
-    --title "${title}" \
-    --body "${body}"
+# gh pr create \
+#     --head "${fork_owner}:${new_branch_name}" \
+#     --repo "${target_repo}" \
+#     --base "${pr_target_branch}" \
+#     --title "${title}" \
+#     --body "${body}"

--- a/eng/submit-source-build-release-pr.sh
+++ b/eng/submit-source-build-release-pr.sh
@@ -191,13 +191,15 @@ git config --global user.name "dotnet-sb-bot"
 git config --global user.email "dotnet-sb-bot@microsoft.com"
 git commit -m "update global.json and Versions.props for .NET SDK ${sdk_version}"
 
+cat "$versions_props_path"
+git diff
+
 # push changes to fork
 git push -u origin "${new_branch_name}"
 
 readarray -d '/' -t fork_repo_split <<< "${fork_repo}"
 fork_owner="${fork_repo_split[0]}"
 
-cat "$versions_props_path"
 
 # create pull request
 # gh pr create \

--- a/eng/submit-source-build-release-pr.sh
+++ b/eng/submit-source-build-release-pr.sh
@@ -135,7 +135,23 @@ cat "$global_json_path" \
     | tee "$global_json_path.new"
 mv "$global_json_path.new" "$global_json_path"
 
-sed -i "s#<PrivateSourceBuiltArtifactsPackageVersion>.*</PrivateSourceBuiltArtifactsPackageVersion>#<PrivateSourceBuiltArtifactsPackageVersion>$sdk_version</PrivateSourceBuiltArtifactsPackageVersion>#" $versions_props_path
+if [[ $sdk_version == "6"* ]]; then
+        echo sdk_version == "6"
+        sed -i "s#<PrivateSourceBuiltArtifactsPackageVersion>.*</PrivateSourceBuiltArtifactsPackageVersion>#<PrivateSourceBuiltArtifactsPackageVersion>$sdk_version</PrivateSourceBuiltArtifactsPackageVersion>#" $versions_props_path
+elif [[ $sdk_version == "7"* ]]; then
+        echo sdk_version == "7"
+        sed -i "s#<PrivateSourceBuiltArtifactsPackageVersion>.*</PrivateSourceBuiltArtifactsPackageVersion>#<PrivateSourceBuiltArtifactsPackageVersion>$sdk_version</PrivateSourceBuiltArtifactsPackageVersion>#" $versions_props_path
+        sed -i "s#<PrivateSourceBuiltSDKVersion>.*</PrivateSourceBuiltSDKVersion>#<PrivateSourceBuiltSDKVersion>$sdk_version</PrivateSourceBuiltSDKVersion>#" $versions_props_path
+elif [[ $sdk_version == "8"* ]]; then
+        echo sdk_version == "8"
+        # buna ihtiyacim var sdkArtifactFileName
+        sed -i "s#<PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/.*</PrivateSourceBuiltArtifactsUrl>#<PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/XXXX</PrivateSourceBuiltArtifactsUrl>#" $versions_props_path
+        sed -i "s#<PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/assets/.*</PrivateSourceBuiltSdkUrl_CentOS8Stream>#<PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/assets/YYY</PrivateSourceBuiltSdkUrl_CentOS8Stream>#" $versions_props_path
+else
+        echo "Unexpected SDK version!"
+        exit 1
+fi
+
 git add "$global_json_path" "$versions_props_path"
 
 git config --global user.name "dotnet-sb-bot"

--- a/eng/submit-source-build-release-pr.sh
+++ b/eng/submit-source-build-release-pr.sh
@@ -186,21 +186,19 @@ else
 fi
 
 git diff
-cat "$versions_props_path"
-
-git add "$global_json_path" "$versions_props_path"
-
-git config --global user.name "dotnet-sb-bot"
-git config --global user.email "dotnet-sb-bot@microsoft.com"
-git commit -m "update global.json and Versions.props for .NET SDK ${sdk_version}"
 
 
-# push changes to fork
-git push -u origin "${new_branch_name}"
+# git add "$global_json_path" "$versions_props_path"
 
-readarray -d '/' -t fork_repo_split <<< "${fork_repo}"
-fork_owner="${fork_repo_split[0]}"
+# git config --global user.name "dotnet-sb-bot"
+# git config --global user.email "dotnet-sb-bot@microsoft.com"
+# git commit -m "update global.json and Versions.props for .NET SDK ${sdk_version}"
 
+# # push changes to fork
+# git push -u origin "${new_branch_name}"
+
+# readarray -d '/' -t fork_repo_split <<< "${fork_repo}"
+# fork_owner="${fork_repo_split[0]}"
 
 # create pull request
 # gh pr create \

--- a/eng/submit-source-build-release-pr.sh
+++ b/eng/submit-source-build-release-pr.sh
@@ -21,13 +21,15 @@ a PR in the target repo."
    echo "--targetBranch, -b    (Optional) branch to submit the PR to, calculated automatically otherwise"
    echo "--globalJson, -g      (Optional) path to the global.json file to update"
    echo "--versionsProps, -p   (Optional) path to the Versions.props file to update"
+   echo "--resolvedSourceBuiltArtifactsFileName, -a   (Optional) actul Source Built Artifacts File Name"
+   echo "--resolvedSdkArtifactFileName, -s   (Optional) actul Sdk Artifact File Name"
    echo "--setupGitAuth, -G    (Optional) set up git authentication using the gh CLI"
    echo "--help, -h            (Optional) print this help message and exit"
    echo
 }
 
-SHORT=t:f:v:T:B:b:g:p:Gh
-LONG=targetRepo:,forkRepo:,sdkVersion:,title:,body:,targetBranch:,globalJson:,versionsProps:,setupGitAuth,help
+SHORT=t:f:v:T:B:b:g:p:a:s:Gh
+LONG=targetRepo:,forkRepo:,sdkVersion:,title:,body:,targetBranch:,globalJson:,versionsProps:,resolvedSourceBuiltArtifactsFileName:,resolvedSdkArtifactFileName:,setupGitAuth,help
 
 OPTS=$(getopt --options $SHORT --long $LONG --name "$0" -- "$@")
 if [ $? != 0 ] ; then echo "Failed to parse options." >&2 ; exit 1 ; fi

--- a/eng/submit-source-build-release-pr.sh
+++ b/eng/submit-source-build-release-pr.sh
@@ -185,14 +185,15 @@ else
         exit 1
 fi
 
+git diff
+cat "$versions_props_path"
+
 git add "$global_json_path" "$versions_props_path"
 
 git config --global user.name "dotnet-sb-bot"
 git config --global user.email "dotnet-sb-bot@microsoft.com"
 git commit -m "update global.json and Versions.props for .NET SDK ${sdk_version}"
 
-cat "$versions_props_path"
-git diff
 
 # push changes to fork
 git push -u origin "${new_branch_name}"

--- a/eng/submit-source-build-release-pr.sh
+++ b/eng/submit-source-build-release-pr.sh
@@ -154,7 +154,7 @@ elif [[ $sdk_version == "7"* ]]; then
         sed -i "s#<PrivateSourceBuiltArtifactsPackageVersion>.*</PrivateSourceBuiltArtifactsPackageVersion>#<PrivateSourceBuiltArtifactsPackageVersion>$sdk_version</PrivateSourceBuiltArtifactsPackageVersion>#" $versions_props_path
         sed -i "s#<PrivateSourceBuiltSDKVersion>.*</PrivateSourceBuiltSDKVersion>#<PrivateSourceBuiltSDKVersion>$sdk_version</PrivateSourceBuiltSDKVersion>#" $versions_props_path
 elif [[ $sdk_version == "8"* ]]; then
-        sed -i "s#<PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/.*</PrivateSourceBuiltArtifactsUrl>#<PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/$resolved_source_built_artifacts_file_name</PrivateSourceBuiltArtifactsUrl>#" $versions_props_path
+        sed -i "s#<PrivateSourceBuiltArtifactsUrl>.*</PrivateSourceBuiltArtifactsUrl>#<PrivateSourceBuiltArtifactsUrl>https://dotnetcli.azureedge.net/source-built-artifacts/assets/$resolved_source_built_artifacts_file_name</PrivateSourceBuiltArtifactsUrl>#" $versions_props_path
         sed -i "s#<PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/assets/.*</PrivateSourceBuiltSdkUrl_CentOS8Stream>#<PrivateSourceBuiltSdkUrl_CentOS8Stream>https://dotnetcli.azureedge.net/source-built-artifacts/assets/$resolved_sdk_artifact_file_name</PrivateSourceBuiltSdkUrl_CentOS8Stream>#" $versions_props_path
 else
         echo "Unexpected SDK version!"

--- a/eng/submit-source-build-release-pr.sh
+++ b/eng/submit-source-build-release-pr.sh
@@ -188,6 +188,7 @@ git add "$global_json_path" "$versions_props_path"
 git config --global user.name "dotnet-sb-bot"
 git config --global user.email "dotnet-sb-bot@microsoft.com"
 git commit -m "update global.json and Versions.props for .NET SDK ${sdk_version}"
+git diff
 
 # push changes to fork
 git push -u origin "${new_branch_name}"
@@ -196,9 +197,9 @@ readarray -d '/' -t fork_repo_split <<< "${fork_repo}"
 fork_owner="${fork_repo_split[0]}"
 
 # create pull request
-gh pr create \
-    --head "${fork_owner}:${new_branch_name}" \
-    --repo "${target_repo}" \
-    --base "${pr_target_branch}" \
-    --title "${title}" \
-    --body "${body}"
+# gh pr create \
+#     --head "${fork_owner}:${new_branch_name}" \
+#     --repo "${target_repo}" \
+#     --base "${pr_target_branch}" \
+#     --title "${title}" \
+#     --body "${body}"

--- a/eng/submit-source-build-release-pr.sh
+++ b/eng/submit-source-build-release-pr.sh
@@ -177,12 +177,9 @@ if [[ $sdk_version == "6"* ]]; then
 elif [[ $sdk_version == "7"* ]]; then
         sed -i "s#<PrivateSourceBuiltArtifactsPackageVersion>.*</PrivateSourceBuiltArtifactsPackageVersion>#<PrivateSourceBuiltArtifactsPackageVersion>$sdk_version</PrivateSourceBuiltArtifactsPackageVersion>#" $versions_props_path
         sed -i "s#<PrivateSourceBuiltSDKVersion>.*</PrivateSourceBuiltSDKVersion>#<PrivateSourceBuiltSDKVersion>$sdk_version</PrivateSourceBuiltSDKVersion>#" $versions_props_path
-elif [[ $sdk_version == "8"* ]]; then
+else
         modify_url_in_xml "$versions_props_path" "PrivateSourceBuiltArtifactsUrl" "$source_built_artifacts_file_name"
         modify_url_in_xml "$versions_props_path" "PrivateSourceBuiltSdkUrl_CentOS8Stream" "$sdk_artifact_file_name"
-else
-        echo "Unexpected SDK version!"
-        exit 1
 fi
 
 git add "$global_json_path" "$versions_props_path"

--- a/eng/submit-source-build-release-pr.sh
+++ b/eng/submit-source-build-release-pr.sh
@@ -157,8 +157,9 @@ mv "$global_json_path.new" "$global_json_path"
 #   3. Replacement value
 function update_version_props() {
   local element_name="$1"
-  local replacement_pattern="$2"
-  local replacement_value="$3"
+  local replacement_value="$2"
+  # This default pattern matches the entire content and replaces the entire content.
+  local replacement_pattern=${3:-".*"}
 
   # Fetch the content inside the element
   local element=$(grep -oP "<$element_name>.*<\/$element_name>" "$versions_props_path")
@@ -178,19 +179,17 @@ function update_version_props() {
   echo "Replacing content of $element_name with $new_content"
 }
 
-# This pattern matches the entire content
-content_replacement_pattern=".*"
 if [[ $sdk_version == "6"* || $sdk_version == "7"* ]]; then
-  update_version_props "PrivateSourceBuiltArtifactsPackageVersion" "$content_replacement_pattern" "$sdk_version"
+  update_version_props "PrivateSourceBuiltArtifactsPackageVersion" "$sdk_version"
   if [[ $sdk_version == "7"* ]]; then
-    update_version_props "PrivateSourceBuiltSDKVersion" "$content_replacement_pattern" "$sdk_version"
+    update_version_props "PrivateSourceBuiltSDKVersion" "$sdk_version"
   fi
 else
-  # matches a sequence of characters that does not contain any forward slashes, occurring at the end of the line.
+  # This pattern matches a sequence of characters that does not contain any forward slashes, occurring at the end of the line.
   # To replace very last part of the url
   content_replacement_pattern="/[^/]*$"
-  update_version_props "PrivateSourceBuiltArtifactsUrl" "$content_replacement_pattern" "/$source_built_artifacts_file_name"
-  update_version_props "PrivateSourceBuiltSdkUrl_CentOS8Stream" "$content_replacement_pattern" "/$sdk_artifact_file_name"
+  update_version_props "PrivateSourceBuiltArtifactsUrl" "/$source_built_artifacts_file_name" "$content_replacement_pattern"
+  update_version_props "PrivateSourceBuiltSdkUrl_CentOS8Stream" "/$sdk_artifact_file_name" "$content_replacement_pattern"
 fi
 
 git add "$global_json_path" "$versions_props_path"

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -251,12 +251,6 @@ stages:
           echo "Repo ID is $(RepoId)"
           echo "Discussion Category ID is $(DiscussionCategoryId)"
 
-          if [[ "$channel" == '6.0' || "$channel" == '7.0' ]]; then
-            TAG_URL="https://github.com/dotnet/installer/releases/tag/$tag"
-          else
-            TAG_URL="https://github.com/dotnet/dotnet/releases/tag/$tag"
-          fi
-
           if [[ -z '${{ parameters.announcementGist }}' ]]; then
             echo "Loading announcement template from source-build-release-announcement.md"
 

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -392,8 +392,8 @@ stages:
           fi
           
           # The resolved variables will be utilized to update the Versions.props file within the submit-source-build-release-pr script.
-          resolvedSourceBuiltArtifactsFileName=$(basename "$(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName)")
-          resolvedSdkArtifactFileName=$(basename "$(PIPELINE.WORKSPACE)/$(sdkArtifactFileName)")
+          resolvedSourceBuiltArtifactsFileName=$(basename $(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName))
+          resolvedSdkArtifactFileName=$(basename $(PIPELINE.WORKSPACE)/$(sdkArtifactFileName))
           
           if [ "${{ parameters.isDryRun }}" = False ]; then
             echo "Doing a dry run, not submitting PR. Would have called:"

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -392,7 +392,7 @@ stages:
           fi
           
           echo ali test
-          echo "sourceBuiltArtifactsFileName$sourceBuiltArtifactsFileName"
+          echo "sourceBuiltArtifactsFileName: ${{ variables.myVariable }}"
           resolvedSourceBuiltArtifactsFileName=$(basename $(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName))
           echo "$resolvedSourceBuiltArtifactsFileName"
           echo "sdkArtifactFileName: $sdkArtifactFileName"

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -392,10 +392,10 @@ stages:
           fi
           
           echo ali test
-          echo "sourceBuiltArtifactsFileName: ${{ variables.myVariable }}"
+          echo "sourceBuiltArtifactsFileName: ${{ variables.sourceBuiltArtifactsFileName }}"
           resolvedSourceBuiltArtifactsFileName=$(basename $(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName))
           echo "$resolvedSourceBuiltArtifactsFileName"
-          echo "sdkArtifactFileName: $sdkArtifactFileName"
+          echo "sdkArtifactFileName: ${{ variables.sdkArtifactFileName }}"
           resolvedSdkArtifactFileName=$(basename $(PIPELINE.WORKSPACE)/$(sdkArtifactFileName))
           echo "$resolvedSdkArtifactFileName"
 

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -390,6 +390,14 @@ stages:
               target_branch="${target_branch#internal/}"
             fi
           fi
+          
+          echo ali test
+          echo "sourceBuiltArtifactsFileName $(sourceBuiltArtifactsFileName)"
+          resolvedSourceBuiltArtifactsFileName=$(basename $(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName))
+          echo "$(resolvedSourceBuiltArtifactsFileName)"
+          echo "sdkArtifactFileName: $(sdkArtifactFileName)"
+          resolvedsdkArtifactFileName=$(basename $(PIPELINE.WORKSPACE)/$(sdkArtifactFileName))
+          echo "$(resolvedsdkArtifactFileName)"
 
           if [ "${{ parameters.isDryRun }}" = True ]; then
             echo "Doing a dry run, not submitting PR. Would have called:"

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -251,6 +251,12 @@ stages:
           echo "Repo ID is $(RepoId)"
           echo "Discussion Category ID is $(DiscussionCategoryId)"
 
+          if [[ "$channel" == '6.0' || "$channel" == '7.0' ]]; then
+            TAG_URL="https://github.com/dotnet/installer/releases/tag/$tag"
+          else
+            TAG_URL="https://github.com/dotnet/dotnet/releases/tag/$tag"
+          fi
+
           if [[ -z '${{ parameters.announcementGist }}' ]]; then
             echo "Loading announcement template from source-build-release-announcement.md"
 

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -395,7 +395,7 @@ stages:
           resolvedSourceBuiltArtifactsFileName=$(basename "$(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName)")
           resolvedSdkArtifactFileName=$(basename "$(PIPELINE.WORKSPACE)/$(sdkArtifactFileName)")
           
-          if [ "${{ parameters.isDryRun }}" = True ]; then
+          if [ "${{ parameters.isDryRun }}" = False ]; then
             echo "Doing a dry run, not submitting PR. Would have called:"
             echo "./submit-source-build-release-pr.sh"
             echo "  --setupGitAuth"

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -392,13 +392,13 @@ stages:
           fi
           
           echo ali test
-          echo "PIPELINE.WORKSPACE  $(PIPELINE.WORKSPACE)"
+          echo "PIPELINE.WORKSPACE  $PIPELINE.WORKSPACE"
           echo "sourceBuiltArtifactsFileName $sourceBuiltArtifactsFileName"
           resolvedSourceBuiltArtifactsFileName=$(basename $(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName))
-          echo "$(resolvedSourceBuiltArtifactsFileName)"
+          echo "$resolvedSourceBuiltArtifactsFileName"
           echo "sdkArtifactFileName: $sdkArtifactFileName"
           resolvedSdkArtifactFileName=$(basename $(PIPELINE.WORKSPACE)/$(sdkArtifactFileName))
-          echo "$(resolvedSdkArtifactFileName)"
+          echo "$resolvedSdkArtifactFileName"
 
           if [ "${{ parameters.isDryRun }}" = True ]; then
             echo "Doing a dry run, not submitting PR. Would have called:"

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -394,7 +394,7 @@ stages:
           resolvedSourceBuiltArtifactsFileName=$(basename $(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName))
           resolvedSdkArtifactFileName=$(basename $(PIPELINE.WORKSPACE)/$(sdkArtifactFileName))
           
-          if [ "${{ parameters.isDryRun }}" = False ]; then
+          if [ "${{ parameters.isDryRun }}" = True ]; then
             echo "Doing a dry run, not submitting PR. Would have called:"
             echo "./submit-source-build-release-pr.sh"
             echo "  --setupGitAuth"

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -393,10 +393,10 @@ stages:
           
           echo ali test
           echo "PIPELINE.WORKSPACE  $(PIPELINE.WORKSPACE)"
-          echo "sourceBuiltArtifactsFileName $(sourceBuiltArtifactsFileName)"
+          echo "sourceBuiltArtifactsFileName $sourceBuiltArtifactsFileName"
           resolvedSourceBuiltArtifactsFileName=$(basename $(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName))
           echo "$(resolvedSourceBuiltArtifactsFileName)"
-          echo "sdkArtifactFileName: $(sdkArtifactFileName)"
+          echo "sdkArtifactFileName: $sdkArtifactFileName"
           resolvedSdkArtifactFileName=$(basename $(PIPELINE.WORKSPACE)/$(sdkArtifactFileName))
           echo "$(resolvedSdkArtifactFileName)"
 

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -392,7 +392,6 @@ stages:
           fi
           
           echo ali test
-          echo "PIPELINE.WORKSPACE  $PIPELINE.WORKSPACE"
           echo "sourceBuiltArtifactsFileName $sourceBuiltArtifactsFileName"
           resolvedSourceBuiltArtifactsFileName=$(basename $(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName))
           echo "$resolvedSourceBuiltArtifactsFileName"

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -392,10 +392,10 @@ stages:
           fi
           
           echo ali test
-          echo "sourceBuiltArtifactsFileName $sourceBuiltArtifactsFileName"
+          echo "sourceBuiltArtifactsFileName${{sourceBuiltArtifactsFileName}}"
           resolvedSourceBuiltArtifactsFileName=$(basename $(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName))
           echo "$resolvedSourceBuiltArtifactsFileName"
-          echo "sdkArtifactFileName: $sdkArtifactFileName"
+          echo "sdkArtifactFileName: $(sdkArtifactFileName)"
           resolvedSdkArtifactFileName=$(basename $(PIPELINE.WORKSPACE)/$(sdkArtifactFileName))
           echo "$resolvedSdkArtifactFileName"
 

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -391,6 +391,7 @@ stages:
             fi
           fi
           
+          # The resolved variables will be utilized to update the Versions.props file within the submit-source-build-release-pr script.
           resolvedSourceBuiltArtifactsFileName=$(basename $(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName))
           resolvedSdkArtifactFileName=$(basename $(PIPELINE.WORKSPACE)/$(sdkArtifactFileName))
           

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -391,7 +391,7 @@ stages:
             fi
           fi
           
-          # The resolved variables will be utilized to update the Versions.props file within the submit-source-build-release-pr script.
+          # We get the actual final version from the file names - it differs as it comes from the VMR build, not from the official installer one
           resolvedSourceBuiltArtifactsFileName=$(basename $(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName))
           resolvedSdkArtifactFileName=$(basename $(PIPELINE.WORKSPACE)/$(sdkArtifactFileName))
           

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -61,8 +61,6 @@ stages:
       value: sdks
   - name: Codeql.Enabled
     value: true
-  - name: pipelineWorkSpace
-    value: $(PIPELINE.WORKSPACE)
 
   - ${{ if eq(parameters.dotnetMajorVersion, '6.0') }}:
     - name: sourceBuildArtifactLeg
@@ -394,7 +392,6 @@ stages:
           fi
           
           echo ali test
-          echo "pipelineWorkSpace $pipelineWorkSpace"
           echo "PIPELINE.WORKSPACE  $(PIPELINE.WORKSPACE)"
           echo "sourceBuiltArtifactsFileName $(sourceBuiltArtifactsFileName)"
           resolvedSourceBuiltArtifactsFileName=$(basename $(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName))

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -392,8 +392,8 @@ stages:
           fi
           
           # The resolved variables will be utilized to update the Versions.props file within the submit-source-build-release-pr script.
-          resolvedSourceBuiltArtifactsFileName=$(basename $(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName))
-          resolvedSdkArtifactFileName=$(basename $(PIPELINE.WORKSPACE)/$(sdkArtifactFileName))
+          resolvedSourceBuiltArtifactsFileName=$(basename "$(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName)")
+          resolvedSdkArtifactFileName=$(basename "$(PIPELINE.WORKSPACE)/$(sdkArtifactFileName)")
           
           if [ "${{ parameters.isDryRun }}" = True ]; then
             echo "Doing a dry run, not submitting PR. Would have called:"
@@ -405,8 +405,8 @@ stages:
             echo "  --title $title"
             echo "  --body $body"
             echo "  --targetBranch $target_branch"
-            echo "  --resolvedSdkArtifactFileName $resolvedSdkArtifactFileName"
-            echo "  --resolvedSourceBuiltArtifactsFileName $resolvedSourceBuiltArtifactsFileName"
+            echo "  --sdkArtifactFileName $resolvedSdkArtifactFileName"
+            echo "  --sourceBuiltArtifactsFileName $resolvedSourceBuiltArtifactsFileName"
             echo "  ${extraArgs[@]}"
           else
             echo "Submitting PR"
@@ -418,8 +418,8 @@ stages:
               --title "$title" \
               --body "$body" \
               --targetBranch "$target_branch" \
-              --resolvedSdkArtifactFileName "$resolvedSdkArtifactFileName" \
-              --resolvedSourceBuiltArtifactsFileName "$resolvedSourceBuiltArtifactsFileName" \
+              --sdkArtifactFileName "$resolvedSdkArtifactFileName" \
+              --sourceBuiltArtifactsFileName "$resolvedSourceBuiltArtifactsFileName" \
               "${extraArgs[@]}"
           fi
         displayName: Submit Release PR

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -61,6 +61,8 @@ stages:
       value: sdks
   - name: Codeql.Enabled
     value: true
+  - name: pipelineWorkSpace
+    value: $(PIPELINE.WORKSPACE)
 
   - ${{ if eq(parameters.dotnetMajorVersion, '6.0') }}:
     - name: sourceBuildArtifactLeg
@@ -392,12 +394,14 @@ stages:
           fi
           
           echo ali test
+          echo "pipelineWorkSpace $pipelineWorkSpace"
+          echo "PIPELINE.WORKSPACE  $(PIPELINE.WORKSPACE)"
           echo "sourceBuiltArtifactsFileName $(sourceBuiltArtifactsFileName)"
           resolvedSourceBuiltArtifactsFileName=$(basename $(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName))
           echo "$(resolvedSourceBuiltArtifactsFileName)"
           echo "sdkArtifactFileName: $(sdkArtifactFileName)"
-          resolvedsdkArtifactFileName=$(basename $(PIPELINE.WORKSPACE)/$(sdkArtifactFileName))
-          echo "$(resolvedsdkArtifactFileName)"
+          resolvedSdkArtifactFileName=$(basename $(PIPELINE.WORKSPACE)/$(sdkArtifactFileName))
+          echo "$(resolvedSdkArtifactFileName)"
 
           if [ "${{ parameters.isDryRun }}" = True ]; then
             echo "Doing a dry run, not submitting PR. Would have called:"
@@ -409,6 +413,8 @@ stages:
             echo "  --title $title"
             echo "  --body $body"
             echo "  --targetBranch $target_branch"
+            echo "  --resolvedSdkArtifactFileName $resolvedSdkArtifactFileName"
+            echo "  --resolvedSourceBuiltArtifactsFileName $resolvedSourceBuiltArtifactsFileName"
             echo "  ${extraArgs[@]}"
           else
             echo "Submitting PR"
@@ -420,6 +426,8 @@ stages:
               --title "$title" \
               --body "$body" \
               --targetBranch "$target_branch" \
+              --resolvedSdkArtifactFileName "$resolvedSdkArtifactFileName" \
+              --resolvedSourceBuiltArtifactsFileName "$resolvedSourceBuiltArtifactsFileName" \
               "${extraArgs[@]}"
           fi
         displayName: Submit Release PR

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -394,7 +394,7 @@ stages:
           resolvedSourceBuiltArtifactsFileName=$(basename $(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName))
           resolvedSdkArtifactFileName=$(basename $(PIPELINE.WORKSPACE)/$(sdkArtifactFileName))
           
-          if [ "${{ parameters.isDryRun }}" = True ]; then
+          if [ "${{ parameters.isDryRun }}" = False ]; then
             echo "Doing a dry run, not submitting PR. Would have called:"
             echo "./submit-source-build-release-pr.sh"
             echo "  --setupGitAuth"

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -392,10 +392,10 @@ stages:
           fi
           
           echo ali test
-          echo "sourceBuiltArtifactsFileName${{sourceBuiltArtifactsFileName}}"
+          echo "sourceBuiltArtifactsFileName$sourceBuiltArtifactsFileName"
           resolvedSourceBuiltArtifactsFileName=$(basename $(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName))
           echo "$resolvedSourceBuiltArtifactsFileName"
-          echo "sdkArtifactFileName: $(sdkArtifactFileName)"
+          echo "sdkArtifactFileName: $sdkArtifactFileName"
           resolvedSdkArtifactFileName=$(basename $(PIPELINE.WORKSPACE)/$(sdkArtifactFileName))
           echo "$resolvedSdkArtifactFileName"
 

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -395,7 +395,7 @@ stages:
           resolvedSourceBuiltArtifactsFileName=$(basename $(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName))
           resolvedSdkArtifactFileName=$(basename $(PIPELINE.WORKSPACE)/$(sdkArtifactFileName))
           
-          if [ "${{ parameters.isDryRun }}" = False ]; then
+          if [ "${{ parameters.isDryRun }}" = True ]; then
             echo "Doing a dry run, not submitting PR. Would have called:"
             echo "./submit-source-build-release-pr.sh"
             echo "  --setupGitAuth"

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -391,15 +391,10 @@ stages:
             fi
           fi
           
-          echo ali test
-          echo "sourceBuiltArtifactsFileName: ${{ variables.sourceBuiltArtifactsFileName }}"
           resolvedSourceBuiltArtifactsFileName=$(basename $(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName))
-          echo "$resolvedSourceBuiltArtifactsFileName"
-          echo "sdkArtifactFileName: ${{ variables.sdkArtifactFileName }}"
           resolvedSdkArtifactFileName=$(basename $(PIPELINE.WORKSPACE)/$(sdkArtifactFileName))
-          echo "$resolvedSdkArtifactFileName"
-
-          if [ "${{ parameters.isDryRun }}" = True ]; then
+          
+          if [ "${{ parameters.isDryRun }}" = False ]; then
             echo "Doing a dry run, not submitting PR. Would have called:"
             echo "./submit-source-build-release-pr.sh"
             echo "  --setupGitAuth"


### PR DESCRIPTION
### Related issues: 
https://github.com/dotnet/source-build/issues/3344
https://github.com/dotnet/source-build/issues/3385

### Description
In .Net 8.0.*, the content of the relevant element has been obtained, and the very last part of the URL has been replaced using regex. But in .Net 7.0.* and 6.0.* the entire content has been set to the SDK version.


### Test
In DryRun mode, the submit-sorce-build-release-pr script has been called.
In the final phase, right before raising the PR, the creation of the pull request has been disabled. 
The contents of the VersionsProps file were compared and printed to ensure that the desired changes were implemented correctly. The results for each version are shown below.

Test for 8.0
https://dev.azure.com/dnceng/internal/_build/results?buildId=2184104&view=logs&j=19992227-62fb-5b50-4e29-3b72bd33eea1&t=9281c869-17dc-5ef7-6bc6-1c1da071debd

Test for 7.0
https://dev.azure.com/dnceng/internal/_build/results?buildId=2185462&view=logs&j=19992227-62fb-5b50-4e29-3b72bd33eea1&t=9281c869-17dc-5ef7-6bc6-1c1da071debd

Test for 6.0
https://dev.azure.com/dnceng/internal/_build/results?buildId=2185416&view=logs&j=19992227-62fb-5b50-4e29-3b72bd33eea1&t=9281c869-17dc-5ef7-6bc6-1c1da071debd