### PR TITLE
Do not publish draft VMR release on dry runs

### DIFF
--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -86,8 +86,7 @@ stages:
     - name: sdkArtifactFileName
       value: dotnet-sdk-*.tar.gz
 
-  # GitHub release is skipped for 6.0/7.0
-  # For dry run, we only create a draft release
+  # GitHub release is skipped for 6.0/7.0 and dry runs
   - name: createGitHubRelease
     ${{ if eq(parameters.createGitHubRelease, 'auto') }}:
       ${{ if or(eq(parameters.isDryRun, parameters.dotnetMajorVersion, '6.0'), eq(parameters.dotnetMajorVersion, '7.0')) }}:

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -90,13 +90,10 @@ stages:
   # For dry run, we only create a draft release
   - name: createGitHubRelease
     ${{ if eq(parameters.createGitHubRelease, 'auto') }}:
-      ${{ if or(eq(parameters.dotnetMajorVersion, '6.0'), eq(parameters.dotnetMajorVersion, '7.0')) }}:
+      ${{ if or(eq(parameters.isDryRun, parameters.dotnetMajorVersion, '6.0'), eq(parameters.dotnetMajorVersion, '7.0')) }}:
         value: skip
       ${{ else }}:
-        ${{ if parameters.isDryRun }}:
-          value: draft
-        ${{ else }}:
-          value: full
+        value: full
     ${{ else }}:
       value: ${{ parameters.createGitHubRelease }}
 

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -89,7 +89,7 @@ stages:
   # GitHub release is skipped for 6.0/7.0 and dry runs
   - name: createGitHubRelease
     ${{ if eq(parameters.createGitHubRelease, 'auto') }}:
-      ${{ if or(eq(parameters.isDryRun, parameters.dotnetMajorVersion, '6.0'), eq(parameters.dotnetMajorVersion, '7.0')) }}:
+      ${{ if or(parameters.isDryRun, eq(parameters.dotnetMajorVersion, '6.0'), eq(parameters.dotnetMajorVersion, '7.0')) }}:
         value: skip
       ${{ else }}:
         value: full


### PR DESCRIPTION
There were 35 draft releases published in the repo. I think we should skip on dry runs and if you want to test what the release in `dotnet/dotnet` looks like, you can run a dry run and set the setting to `draft`

Additionally, the GitHub page is buggy so it was hard to delete the draft releases 