### PR TITLE
Prevent duplicate announcement

### DIFF
--- a/eng/submit-announcement.sh
+++ b/eng/submit-announcement.sh
@@ -12,7 +12,6 @@
 ###   --sdk-version <VER>        The .NET SDK version that is being released
 ###   --runtime-version <VER>    The .NET runtime version that is being released
 ###   --tag <TAG>                The release tag, e.g. v8.0.0-preview.1
-###   --source-version SHA       The dotnet/dotnet SHA of the commit that is being released
 ###   --dry-run                  (Optional) Runs a script in a dry-run mode that prints out the announcement only
 ###   --prerelease               (Optional) Whether this is a preview release
 ###   --help, -h                 (Optional) Print this help message and exit
@@ -31,7 +30,6 @@ channel=''
 release=''
 release_name=''
 sdk_version=''
-source_version=''
 runtime_version=''
 tag=''
 prerelease=false
@@ -80,10 +78,6 @@ while [[ $# -gt 0 ]]; do
       tag="$2"
       shift 2
       ;;
-    --source-version )
-      source_version="$2"
-      shift 2
-      ;;
     --prerelease )
       prerelease=true
       shift 1
@@ -105,7 +99,6 @@ done
 : "${release:?Missing --release}"
 : "${release_name:?Missing --release-name}"
 : "${sdk_version:?Missing --sdk-version}"
-: "${source_version:?Missing --source-version}"
 : "${runtime_version:?Missing --runtime-version}"
 : "${tag:?Missing --tag}"
 

--- a/eng/submit-announcement.sh
+++ b/eng/submit-announcement.sh
@@ -237,8 +237,8 @@ else
 
       echo "Submitting announcement"
 
-      create_discussion_url=$(gh api graphql -F RepoId="$repo_id" -F categoryId="$category_id" -F body="$body" -F title="$title" -f query="$create_discussion_query" --template '{{.data.createDiscussion.discussion.url}}' )
-      echo "Announcement URL: $create_discussion_url"
+      # create_discussion_url=$(gh api graphql -F RepoId="$repo_id" -F categoryId="$category_id" -F body="$body" -F title="$title" -f query="$create_discussion_query" --template '{{.data.createDiscussion.discussion.url}}' )
+      # echo "Announcement URL: $create_discussion_url"
   else
       duplicate_discussion_url=$(echo "$duplicate_discussions" | jq -r '.url')
       echo "##vso[task.logissue type=warning]Announcement already exists ($duplicate_discussion_url). Skipping submission"

--- a/eng/submit-announcement.sh
+++ b/eng/submit-announcement.sh
@@ -1,0 +1,246 @@
+#!/bin/bash
+
+### Creates a release announcement in a form of a GitHub discussion in the target repository
+###
+### Options:
+###   --announcement-org <ORG>   The GitHub organization of the target repository
+###   --announcement-repo <REPO> Target GitHub repository to create the announcement in
+###   --announcement-gist <URL>  URL of a GitHub gist to take the announcement content from
+###   --channel <CHANNEL>        Release channel, e.g. 8.0
+###   --release <NAME>           Programmatic name of the release, e.g. 8.0.0.preview-1
+###   --release-name <NAME>      Human readable name of the release, e.g. .NET 8 Preview 1
+###   --sdk-version <VER>        The .NET SDK version that is being released
+###   --runtime-version <VER>    The .NET runtime version that is being released
+###   --tag <TAG>                The release tag, e.g. v8.0.0-preview.1
+###   --source-version SHA       The dotnet/dotnet SHA of the commit that is being released
+###   --dry-run                  (Optional) Runs a script in a dry-run mode that prints out the announcement only
+###   --prerelease               (Optional) Whether this is a preview release
+###   --help, -h                 (Optional) Print this help message and exit
+
+set -euo pipefail
+source="${BASH_SOURCE[0]}"
+
+function print_help () {
+  sed -n '/^### /,/^$/p' "$source" | cut -b 5-
+}
+
+announcement_org=''
+announcement_repo=''
+announcement_gist=''
+channel=''
+release=''
+release_name=''
+sdk_version=''
+source_version=''
+runtime_version=''
+tag=''
+prerelease=false
+dry_run=false
+
+while [[ $# -gt 0 ]]; do
+  opt="$(echo "$1" | tr "[:upper:]" "[:lower:]")"
+  case "$opt" in
+    -h | --help )
+      print_help
+      exit 0
+      ;;
+    --announcement-org )
+      announcement_org="$2"
+      shift 2
+      ;;
+    --announcement-repo )
+      announcement_repo="$2"
+      shift 2
+      ;;
+    --announcement-gist )
+      announcement_gist="$2"
+      shift 2
+      ;;
+    --channel )
+      channel="$2"
+      shift 2
+      ;;
+    --release )
+      release="$2"
+      shift 2
+      ;;
+    --release-name )
+      release_name="$2"
+      shift 2
+      ;;
+    --sdk-version )
+      sdk_version="$2"
+      shift 2
+      ;;
+    --runtime-version )
+      runtime_version="$2"
+      shift 2
+      ;;
+    --tag )
+      tag="$2"
+      shift 2
+      ;;
+    --source-version )
+      source_version="$2"
+      shift 2
+      ;;
+    --prerelease )
+      prerelease=true
+      shift 1
+      ;;
+    --dry-run )
+      dry_run=true
+      shift 1
+      ;;
+    *)
+      echo "Invalid argument $1"
+      exit 1
+      ;;
+  esac
+done
+
+: "${announcement_org:?Missing --announcement-org}"
+: "${announcement_repo:?Missing --announcement-repo}"
+: "${channel:?Missing --channel}"
+: "${release:?Missing --release}"
+: "${release_name:?Missing --release-name}"
+: "${sdk_version:?Missing --sdk-version}"
+: "${source_version:?Missing --source-version}"
+: "${runtime_version:?Missing --runtime-version}"
+: "${tag:?Missing --tag}"
+
+repo_query='query {            \
+  repository(                  \
+    owner: "$announcement_org" \
+    name: "$announcement_repo" \
+  ) {                          \
+    id                         \
+  }                            \
+}'
+
+repo_id=$(gh api graphql -f query="$repo_query" --template '{{.data.repository.id}}')
+echo "$announcement_org/$announcement_repo repo ID is $repo_id"
+
+categories_query='{                                                    \
+  repository(name: "$announcement_repo", owner: "$announcement_org") { \
+    discussionCategories(first: 10) {                                  \
+      edges {                                                          \
+        node {                                                         \
+          id                                                           \
+          name                                                         \
+        }                                                              \
+      }                                                                \
+    }                                                                  \
+  }                                                                    \
+}'
+
+category_id=$( gh api graphql -f query="$categories_query" --template '{{range .data.repository.discussionCategories.edges}}{{if eq .node.name "Announcements"}}{{.node.id}}{{end}}{{end}}' )
+
+echo "Discussion category ID is $category_id"
+
+echo "##vso[task.setvariable variable=RepoId]$repo_id"
+echo "##vso[task.setvariable variable=DiscussionCategoryId]$category_id"
+
+if [[ -z "$announcement_gist" ]]; then
+  echo "Loading announcement template from source-build-release-announcement.md"
+
+  prerelease_arg=''
+  if [ "$prerelease" = true ]; then
+    prerelease_arg='--prerelease'
+  fi
+
+  announcement=$("./create-announcement-draft.sh"     \
+    --template "source-build-release-announcement.md" \
+    --channel "$channel"                              \
+    $prerelease_arg                                   \
+    --release "$release"                              \
+    --release-name "$release_name"                    \
+    --runtime-version "$runtime_version"              \
+    --sdk-version "$sdk_version"                      \
+    --tag "$tag")
+
+  # Get the line in the template that is prefixed with "Title:" and remove the prefix
+  title=$(echo "$announcement" | grep "^Title:" | cut -d " " -f2-)
+  # Get the inverse of the above selection
+  body=$(echo "$announcement" | grep -v "^Title:")
+
+else
+  echo "Loading announcement template from gist $announcement_gist"
+
+  # Get title from the gist name
+  set +o pipefail # gh fails with 141 but returns the correct output
+
+  title="$(gh gist view "$announcement_gist" --raw | head -n 1)"
+  body="$(gh gist view "$announcement_gist" | tail -n +2)"
+
+  if [[ -z "$title" ]]; then
+    echo "##vso[task.logissue type=error]Could not get title from gist $announcement_gist"
+    exit 1
+  fi
+
+  if [[ -z "$body" ]]; then
+    echo "##vso[task.logissue type=error]Could not get announcement text from gist $announcement_gist"
+    exit 1
+  fi
+
+  set -o pipefail
+fi
+
+if [ "$dry_run" = false ]; then
+  set +x
+  echo -e "\n\n\n#########################\n\n"
+  echo "Doing a dry run, not submitting announcement."
+  echo -e "\n\n#########################\n\n\n"
+  echo "Announcement title: $title"
+  echo "Announcement body: $body"
+else
+  # Checking for an already existing announcement
+  recent_discussions_query='query {                     \
+    repository(                                         \
+      name: "$announcement_repo"                        \
+      owner: "$announcement_org"                        \
+    ) {                                                 \
+      discussions(                                      \
+        last: 100                                       \
+        categoryId: "$(DiscussionCategoryId)"           \
+        orderBy: { field: UPDATED_AT, direction: DESC } \
+      ) {                                               \
+        edges {                                         \
+          node {                                        \
+            title                                       \
+            url                                         \
+          }                                             \
+        }                                               \
+      }                                                 \
+    }                                                   \
+  }'
+
+  recent_discussions=$(gh api graphql -f query="$recent_discussions_query")
+  duplicate_discussions=$(echo "$recent_discussions" | jq -r '.data.repository.discussions.edges[] | select(.node.title == "'"$title"'") | .node')
+
+  if [[ -z "$duplicate_discussions" || "$duplicate_discussions" == "null" ]]; then
+      create_discussion_query='\
+      mutation ($RepoId: ID!, $categoryId: ID!, $body: String!, $title: String!) { \
+          createDiscussion(                                                        \
+            input: {                                                               \
+              repositoryId: $RepoId                                                \
+              categoryId: $categoryId                                              \
+              body: $body                                                          \
+              title: $title                                                        \
+            }                                                                      \
+          ) {                                                                      \
+            discussion {                                                           \
+              url                                                                  \
+            }                                                                      \
+          }                                                                        \
+      }'
+
+      echo "Submitting announcement"
+
+      create_discussion_url=$(gh api graphql -F RepoId="$repo_id" -F categoryId="$category_id" -F body="$body" -F title="$title" -f query="$create_discussion_query" --template '{{.data.createDiscussion.discussion.url}}' )
+      echo "Announcement URL: $create_discussion_url"
+  else
+      duplicate_discussion_url=$(echo "$duplicate_discussions" | jq -r '.url')
+      echo "##vso[task.logissue type=warning]Announcement already exists ($duplicate_discussion_url). Skipping submission"
+  fi
+fi

--- a/eng/submit-source-build-release-pr.sh
+++ b/eng/submit-source-build-release-pr.sh
@@ -205,9 +205,9 @@ readarray -d '/' -t fork_repo_split <<< "${fork_repo}"
 fork_owner="${fork_repo_split[0]}"
 
 # create pull request
-gh pr create \
-    --head "${fork_owner}:${new_branch_name}" \
-    --repo "${target_repo}" \
-    --base "${pr_target_branch}" \
-    --title "${title}" \
-    --body "${body}"
+# gh pr create \
+#     --head "${fork_owner}:${new_branch_name}" \
+#     --repo "${target_repo}" \
+#     --base "${pr_target_branch}" \
+#     --title "${title}" \
+#     --body "${body}"

--- a/eng/submit-source-build-release-pr.sh
+++ b/eng/submit-source-build-release-pr.sh
@@ -205,9 +205,9 @@ readarray -d '/' -t fork_repo_split <<< "${fork_repo}"
 fork_owner="${fork_repo_split[0]}"
 
 # create pull request
-# gh pr create \
-#     --head "${fork_owner}:${new_branch_name}" \
-#     --repo "${target_repo}" \
-#     --base "${pr_target_branch}" \
-#     --title "${title}" \
-#     --body "${body}"
+gh pr create \
+    --head "${fork_owner}:${new_branch_name}" \
+    --repo "${target_repo}" \
+    --base "${pr_target_branch}" \
+    --title "${title}" \
+    --body "${body}"

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -304,10 +304,16 @@ stages:
             echo "Announcement title: $title"
             echo "Announcement body: $body"
           else
-            echo "Submitting announcement."
-            announcement_url=$( gh api graphql -F RepoId=$(RepoId) -F categoryId=$(DiscussionCategoryId) -F body="$body" -F title="$title" -f query="$query" --template '{{.data.createDiscussion.discussion.url}}' )
+            existing_announcement_url=$(gh api graphql -F RepoId=$(RepoId) -f query="$query" --template '{{if gt (len .data.repository.discussion.categories.edges) 0}}{{index .data.repository.discussion.categories.edges 0}}{ "categoryId": .node.id }{{end}}' 2>/dev/null)
+            if [ -z "$existing_announcement_url" ]; then
+              echo "Submitting announcement."
+              announcement_url=$( gh api graphql -F RepoId=$(RepoId) -F categoryId=$(DiscussionCategoryId) -F body="$body" -F title="$title" -f query="$query" --template '{{.data.createDiscussion.discussion.url}}' )
 
-            echo "Announcement URL: $announcement_url"
+              echo "Announcement URL: $announcement_url"
+            else
+              echo "##vso[task.logissue type=warning]Announcement already exists. Skipping submission."
+              echo "##vso[task.logissue type=warning]Existing Announcement URL: $existing_announcement_url"
+            fi
           fi
         displayName: Submit announcement discussion
         workingDirectory: $(Agent.BuildDirectory)/dotnet-source-build/eng

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -302,7 +302,7 @@ stages:
             echo "Announcement title: $title"
             echo "Announcement body: $body"
           else
-            query='query { repository(name: "${{ variables.announcementRepo }}", owner: "${{ variables.announcementOrg }}") { discussions(last: 100, categoryId: $(DiscussionCategoryId), orderBy: {field: UPDATED_AT, direction: DESC}) { edges { node { title url } } } } }'
+            query='query { repository(name: "${{ variables.announcementRepo }}", owner: "${{ variables.announcementOrg }}") { discussions(last: 100, categoryId: "$(DiscussionCategoryId)", orderBy: {field: UPDATED_AT, direction: DESC}) { edges { node { title url } } } } }'
 
             response=$(gh api graphql -f query="$query")
             discussion=$(echo "$response" | jq -r '.data.repository.discussions.edges[] | select(.node.title == "'"$title"'") | .node')

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -247,7 +247,7 @@ stages:
           GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
 
       - script: |
-          set -exuo pipefail
+          set -euo pipefail
           echo "Repo ID is $(RepoId)"
           echo "Discussion Category ID is $(DiscussionCategoryId)"
 
@@ -294,7 +294,7 @@ stages:
             set -o pipefail
           fi
 
-          if [ ${{ parameters.isDryRun }} = False ]; then
+          if [ ${{ parameters.isDryRun }} = True ]; then
             set +x
             echo -e "\n\n\n#########################\n\n"
             echo "Doing a dry run, not submitting announcement."
@@ -311,7 +311,7 @@ stages:
               query='mutation($RepoId: ID!, $categoryId: ID!, $body: String!, $title: String!) { createDiscussion(input: {repositoryId: $RepoId, categoryId: $categoryId, body: $body, title: $title}) { discussion { url } } }'
 
               echo "Submitting announcement."
-              # announcement_url=$( gh api graphql -F RepoId=$(RepoId) -F categoryId=$(DiscussionCategoryId) -F body="$body" -F title="$title" -f query="$query" --template '{{.data.createDiscussion.discussion.url}}' )
+              announcement_url=$( gh api graphql -F RepoId=$(RepoId) -F categoryId=$(DiscussionCategoryId) -F body="$body" -F title="$title" -f query="$query" --template '{{.data.createDiscussion.discussion.url}}' )
               echo "Announcement URL: $announcement_url"
             else
               existing_announcement_url=$(echo "$discussion" | jq -r '.url')

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -247,7 +247,7 @@ stages:
           GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
 
       - script: |
-          set -euo pipefail
+          set -exuo pipefail
           echo "Repo ID is $(RepoId)"
           echo "Discussion Category ID is $(DiscussionCategoryId)"
 
@@ -308,7 +308,7 @@ stages:
             discussion=$(echo "$response" | jq -r '.data.repository.discussions.edges[] | select(.node.title == "'"$title"'") | .node')
 
             if [[ -z "$discussion" || "$discussion" == "null" ]]; then
-              query='mutation($RepoId: ID!, $categoryId: ID!, $body: String!, $title: String!) { createDiscussion(input: {repositoryId: $RepoId, categoryId: $categoryId, body: $body, title: $title}) { discussion { url } } }
+              query='mutation($RepoId: ID!, $categoryId: ID!, $body: String!, $title: String!) { createDiscussion(input: {repositoryId: $RepoId, categoryId: $categoryId, body: $body, title: $title}) { discussion { url } } }'
 
               echo "Submitting announcement."
               # announcement_url=$( gh api graphql -F RepoId=$(RepoId) -F categoryId=$(DiscussionCategoryId) -F body="$body" -F title="$title" -f query="$query" --template '{{.data.createDiscussion.discussion.url}}' )

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -251,7 +251,7 @@ stages:
             --release-name "${{ parameters.releaseName }}"           \
             --runtime-version "$(runtimeVersion)"                    \
             --sdk-version "$(sdkVersion)"                            \
-            --tag "$(releaseTag)")
+            --tag "$(releaseTag)"
 
         displayName: Submit announcement discussion
         workingDirectory: $(Agent.BuildDirectory)/dotnet-source-build/eng

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -296,7 +296,7 @@ stages:
 
           query='mutation($RepoId: ID!, $categoryId: ID!, $body: String!, $title: String!) { createDiscussion(input: {repositoryId: $RepoId, categoryId: $categoryId, body: $body, title: $title}) { discussion { url } } }'
 
-          if [ ${{ parameters.isDryRun }} = True ]; then
+          if [ ${{ parameters.isDryRun }} = False ]; then
             set +x
             echo -e "\n\n\n#########################\n\n"
             echo "Doing a dry run, not submitting announcement."

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -302,7 +302,7 @@ stages:
             echo "Announcement title: $title"
             echo "Announcement body: $body"
           else
-            query='query { repository(name: "${{ variables.announcementRepo }}", owner: "${{ variables.announcementOrg }}") { discussions(last: 100, categoryId: "'"$DiscussionCategoryId"'", orderBy: {field: UPDATED_AT, direction: DESC}) { edges { node { title url } } } } }'
+            query='query { repository(name: "${{ variables.announcementRepo }}", owner: "${{ variables.announcementOrg }}") { discussions(last: 100, categoryId: $(DiscussionCategoryId), orderBy: {field: UPDATED_AT, direction: DESC}) { edges { node { title url } } } } }'
 
             response=$(gh api graphql -f query="$query")
             discussion=$(echo "$response" | jq -r '.data.repository.discussions.edges[] | select(.node.title == "'"$title"'") | .node')

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -301,7 +301,7 @@ stages:
             echo -e "\n\n#########################\n\n\n"
             echo "Announcement title: $title"
             echo "Announcement body: $body"
-          else            
+          else
             query='query { repository(name: "${{ variables.announcementRepo }}", owner: "${{ variables.announcementOrg }}") { discussions(last: 100, categoryId: "'"$DiscussionCategoryId"'", orderBy: {field: UPDATED_AT, direction: DESC}) { edges { node { title url } } } } }'
 
             response=$(gh api graphql -f query="$query")
@@ -311,7 +311,7 @@ stages:
               query='mutation($RepoId: ID!, $categoryId: ID!, $body: String!, $title: String!) { createDiscussion(input: {repositoryId: $RepoId, categoryId: $categoryId, body: $body, title: $title}) { discussion { url } } }
 
               echo "Submitting announcement."
-              announcement_url=$( gh api graphql -F RepoId=$(RepoId) -F categoryId=$(DiscussionCategoryId) -F body="$body" -F title="$title" -f query="$query" --template '{{.data.createDiscussion.discussion.url}}' )
+              # announcement_url=$( gh api graphql -F RepoId=$(RepoId) -F categoryId=$(DiscussionCategoryId) -F body="$body" -F title="$title" -f query="$query" --template '{{.data.createDiscussion.discussion.url}}' )
               echo "Announcement URL: $announcement_url"
             else
               existing_announcement_url=$(echo "$discussion" | jq -r '.url')

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -302,6 +302,7 @@ stages:
             echo "Announcement title: $title"
             echo "Announcement body: $body"
           else
+            # Checking for an already existing announcement
             query='query { repository(name: "${{ variables.announcementRepo }}", owner: "${{ variables.announcementOrg }}") { discussions(last: 100, categoryId: "$(DiscussionCategoryId)", orderBy: {field: UPDATED_AT, direction: DESC}) { edges { node { title url } } } } }'
 
             response=$(gh api graphql -f query="$query")
@@ -315,8 +316,7 @@ stages:
               echo "Announcement URL: $announcement_url"
             else
               existing_announcement_url=$(echo "$discussion" | jq -r '.url')
-              echo "##vso[task.logissue type=warning]Announcement already exists. Skipping submission."
-              echo "##vso[task.logissue type=warning]Existing Announcement URL: $existing_announcement_url"
+              echo "##vso[task.logissue type=warning]Announcement already exists ($existing_announcement_url). Skipping submission."
             fi
           fi
         displayName: Submit announcement discussion

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -303,20 +303,52 @@ stages:
             echo "Announcement body: $body"
           else
             # Checking for an already existing announcement
-            query='query { repository(name: "${{ variables.announcementRepo }}", owner: "${{ variables.announcementOrg }}") { discussions(last: 100, categoryId: "$(DiscussionCategoryId)", orderBy: {field: UPDATED_AT, direction: DESC}) { edges { node { title url } } } } }'
+            recent_discussions_query='query {                     \
+              repository(                                         \
+                name: "${{ variables.announcementRepo }}"         \
+                owner: "${{ variables.announcementOrg }}"         \
+              ) {                                                 \
+                discussions(                                      \
+                  last: 100                                       \
+                  categoryId: "$(DiscussionCategoryId)"           \
+                  orderBy: { field: UPDATED_AT, direction: DESC } \
+                ) {                                               \
+                  edges {                                         \
+                    node {                                        \
+                      title                                       \
+                      url                                         \
+                    }                                             \
+                  }                                               \
+                }                                                 \
+              }                                                   \
+            }'
 
-            response=$(gh api graphql -f query="$query")
-            discussion=$(echo "$response" | jq -r '.data.repository.discussions.edges[] | select(.node.title == "'"$title"'") | .node')
+            recent_discussions=$(gh api graphql -f query="$recent_discussions_query")
+            duplicate_discussions=$(echo "$recent_discussions" | jq -r '.data.repository.discussions.edges[] | select(.node.title == "'"$title"'") | .node')
 
-            if [[ -z "$discussion" || "$discussion" == "null" ]]; then
-              query='mutation($RepoId: ID!, $categoryId: ID!, $body: String!, $title: String!) { createDiscussion(input: {repositoryId: $RepoId, categoryId: $categoryId, body: $body, title: $title}) { discussion { url } } }'
+            if [[ -z "$duplicate_discussions" || "$duplicate_discussions" == "null" ]]; then
+                create_discussion_query='\
+                mutation ($RepoId: ID!, $categoryId: ID!, $body: String!, $title: String!) { \
+                    createDiscussion(                                                        \
+                      input: {                                                               \
+                        repositoryId: $RepoId                                                \
+                        categoryId: $categoryId                                              \
+                        body: $body                                                          \
+                        title: $title                                                        \
+                      }                                                                      \
+                    ) {                                                                      \
+                      discussion {                                                           \
+                        url                                                                  \
+                      }                                                                      \
+                    }                                                                        \
+                }'
 
-              echo "Submitting announcement."
-              announcement_url=$( gh api graphql -F RepoId=$(RepoId) -F categoryId=$(DiscussionCategoryId) -F body="$body" -F title="$title" -f query="$query" --template '{{.data.createDiscussion.discussion.url}}' )
-              echo "Announcement URL: $announcement_url"
+                echo "Submitting announcement"
+                create_discussion_url=$(gh api graphql -F RepoId=$(RepoId) -F categoryId=$(DiscussionCategoryId) -F body="$body" -F title="$title" -f query="$create_discussion_query" --template '{{.data.createDiscussion.discussion.url}}' )
+                echo "Announcement URL: $create_discussion_url"
             else
-              existing_announcement_url=$(echo "$discussion" | jq -r '.url')
-              echo "##vso[task.logissue type=warning]Announcement already exists ($existing_announcement_url). Skipping submission."
+                duplicate_discussion_url=$(echo "$duplicate_discussions" | jq -r '.url')
+                echo "##vso[task.logissue type=warning]Announcement already exists ($duplicate_discussion_url). Skipping submission"
             fi
           fi
         displayName: Submit announcement discussion

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -294,8 +294,6 @@ stages:
             set -o pipefail
           fi
 
-          query='mutation($RepoId: ID!, $categoryId: ID!, $body: String!, $title: String!) { createDiscussion(input: {repositoryId: $RepoId, categoryId: $categoryId, body: $body, title: $title}) { discussion { url } } }'
-
           if [ ${{ parameters.isDryRun }} = False ]; then
             set +x
             echo -e "\n\n\n#########################\n\n"
@@ -303,14 +301,19 @@ stages:
             echo -e "\n\n#########################\n\n\n"
             echo "Announcement title: $title"
             echo "Announcement body: $body"
-          else
-            existing_announcement_url=$(gh api graphql -F RepoId=$(RepoId) -f query="$query" --template '{{if gt (len .data.repository.discussion.categories.edges) 0}}{{index .data.repository.discussion.categories.edges 0}}{ "categoryId": .node.id }{{end}}' 2>/dev/null)
-            if [ -z "$existing_announcement_url" ]; then
+          else            
+            query='query($title: String!) { search(query: $title, type: DISCUSSION, first: 1) { nodes { ... on Discussion { id, title, url } } } }'
+            response=$(gh api graphql -f query="$query" -f title="$title")
+            discussion=$(echo "$response" | jq -r '.data.search.nodes[0]')
+
+            if [[ -z "$discussion" || "$discussion" == "null" ]]; then
+              query='mutation($RepoId: ID!, $categoryId: ID!, $body: String!, $title: String!) { createDiscussion(input: {repositoryId: $RepoId, categoryId: $categoryId, body: $body, title: $title}) { discussion { url } } }
+
               echo "Submitting announcement."
               announcement_url=$( gh api graphql -F RepoId=$(RepoId) -F categoryId=$(DiscussionCategoryId) -F body="$body" -F title="$title" -f query="$query" --template '{{.data.createDiscussion.discussion.url}}' )
-
               echo "Announcement URL: $announcement_url"
             else
+              existing_announcement_url=$(echo "$discussion" | jq -r '.url')
               echo "##vso[task.logissue type=warning]Announcement already exists. Skipping submission."
               echo "##vso[task.logissue type=warning]Existing Announcement URL: $existing_announcement_url"
             fi

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -393,7 +393,7 @@ stages:
           resolvedSourceBuiltArtifactsFileName=$(basename $(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName))
           resolvedSdkArtifactFileName=$(basename $(PIPELINE.WORKSPACE)/$(sdkArtifactFileName))
           
-          if [ "${{ parameters.isDryRun }}" = True ]; then
+          if [ "${{ parameters.isDryRun }}" = False ]; then
             echo "Doing a dry run, not submitting PR. Would have called:"
             echo "./submit-source-build-release-pr.sh"
             echo "  --setupGitAuth"

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -302,9 +302,10 @@ stages:
             echo "Announcement title: $title"
             echo "Announcement body: $body"
           else            
-            query='query($title: String!) { search(query: $title, type: DISCUSSION, first: 1) { nodes { ... on Discussion { id, title, url } } } }'
-            response=$(gh api graphql -f query="$query" -f title="$title")
-            discussion=$(echo "$response" | jq -r '.data.search.nodes[0]')
+            query='query { repository(name: "${{ variables.announcementRepo }}", owner: "${{ variables.announcementOrg }}") { discussions(last: 100, categoryId: "'"$DiscussionCategoryId"'", orderBy: {field: UPDATED_AT, direction: DESC}) { edges { node { title url } } } } }'
+
+            response=$(gh api graphql -f query="$query")
+            discussion=$(echo "$response" | jq -r '.data.repository.discussions.edges[] | select(.node.title == "'"$title"'") | .node')
 
             if [[ -z "$discussion" || "$discussion" == "null" ]]; then
               query='mutation($RepoId: ID!, $categoryId: ID!, $body: String!, $title: String!) { createDiscussion(input: {repositoryId: $RepoId, categoryId: $categoryId, body: $body, title: $title}) { discussion { url } } }

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -228,129 +228,31 @@ stages:
 
     - ${{ if parameters.createReleaseAnnouncement }}:
       - script: |
-          set -euxo pipefail
-
-          query='query { repository(owner: "${{ variables.announcementOrg }}", name: "${{ variables.announcementRepo }}") { id } }'
-          echo "${query}"
-          repo_id=$( gh api graphql -f query="$query" --template '{{.data.repository.id}}' )
-          echo ${{ variables.announcementOrg }}/${{ variables.announcementRepo }} repo ID is ${repo_id}
-
-          query='query { repository(name: "${{ variables.announcementRepo }}", owner: "${{ variables.announcementOrg }}") { discussionCategories(first: 10) { edges { node { id, name } } } } }'
-          echo "${query}"
-          category_id=$( gh api graphql -f query="$query" --template '{{range .data.repository.discussionCategories.edges}}{{if eq .node.name "Announcements"}}{{.node.id}}{{end}}{{end}}' )
-          echo Discussion Category ID is ${category_id}
-
-          echo "##vso[task.setvariable variable=RepoId]$repo_id"
-          echo "##vso[task.setvariable variable=DiscussionCategoryId]$category_id"
-        displayName: Get announcement category
-        env:
-          GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
-
-      - script: |
           set -euo pipefail
-          echo "Repo ID is $(RepoId)"
-          echo "Discussion Category ID is $(DiscussionCategoryId)"
 
-          if [[ -z '${{ parameters.announcementGist }}' ]]; then
-            echo "Loading announcement template from source-build-release-announcement.md"
-
-            prerelease=''
-            if [ ${{ parameters.isPreviewRelease }} = True ]; then
-              prerelease='--prerelease'
-            fi
-
-            announcement=$("./create-announcement-draft.sh"     \
-              --template "source-build-release-announcement.md" \
-              --channel "$(releaseChannel)"                     \
-              $prerelease                                       \
-              --release "$(release)"                            \
-              --release-name "${{ parameters.releaseName }}"    \
-              --runtime-version "$(runtimeVersion)"             \
-              --sdk-version "$(sdkVersion)"                     \
-              --tag "$(releaseTag)")
-
-            # Get the line in the template that is prefixed with "Title:" and remove the prefix
-            title=$(echo "$announcement" | grep "^Title:" | cut -d " " -f2-)
-            # Get the inverse of the above selection
-            body=$(echo "$announcement" | grep -v "^Title:")
-          else
-            echo "Loading announcement template from gist ${{ parameters.announcementGist }}"
-
-            # Get title from the gist name
-            set +o pipefail # gh fails with 141 but returns the correct output
-            title="$(gh gist view '${{ parameters.announcementGist }}' --raw | head -n 1)"
-            body="$(gh gist view '${{ parameters.announcementGist }}' | tail -n +2)"
-
-            if [[ -z "$title" ]]; then
-              echo "##vso[task.logissue type=error]Could not get title from gist ${{ parameters.announcementGist }}"
-              exit 1
-            fi
-
-            if [[ -z "$body" ]]; then
-              echo "##vso[task.logissue type=error]Could not get announcement text from gist ${{ parameters.announcementGist }}"
-              exit 1
-            fi
-
-            set -o pipefail
+          prerelease=''
+          if [ ${{ parameters.isPreviewRelease }} = True ]; then
+            prerelease='--prerelease'
           fi
 
-          if [ ${{ parameters.isDryRun }} = False ]; then
-            set +x
-            echo -e "\n\n\n#########################\n\n"
-            echo "Doing a dry run, not submitting announcement."
-            echo -e "\n\n#########################\n\n\n"
-            echo "Announcement title: $title"
-            echo "Announcement body: $body"
-          else
-            # Checking for an already existing announcement
-            recent_discussions_query='query {                     \
-              repository(                                         \
-                name: "${{ variables.announcementRepo }}"         \
-                owner: "${{ variables.announcementOrg }}"         \
-              ) {                                                 \
-                discussions(                                      \
-                  last: 100                                       \
-                  categoryId: "$(DiscussionCategoryId)"           \
-                  orderBy: { field: UPDATED_AT, direction: DESC } \
-                ) {                                               \
-                  edges {                                         \
-                    node {                                        \
-                      title                                       \
-                      url                                         \
-                    }                                             \
-                  }                                               \
-                }                                                 \
-              }                                                   \
-            }'
-
-            recent_discussions=$(gh api graphql -f query="$recent_discussions_query")
-            duplicate_discussions=$(echo "$recent_discussions" | jq -r '.data.repository.discussions.edges[] | select(.node.title == "'"$title"'") | .node')
-
-            if [[ -z "$duplicate_discussions" || "$duplicate_discussions" == "null" ]]; then
-                create_discussion_query='\
-                mutation ($RepoId: ID!, $categoryId: ID!, $body: String!, $title: String!) { \
-                    createDiscussion(                                                        \
-                      input: {                                                               \
-                        repositoryId: $RepoId                                                \
-                        categoryId: $categoryId                                              \
-                        body: $body                                                          \
-                        title: $title                                                        \
-                      }                                                                      \
-                    ) {                                                                      \
-                      discussion {                                                           \
-                        url                                                                  \
-                      }                                                                      \
-                    }                                                                        \
-                }'
-
-                echo "Submitting announcement"
-                # create_discussion_url=$(gh api graphql -F RepoId=$(RepoId) -F categoryId=$(DiscussionCategoryId) -F body="$body" -F title="$title" -f query="$create_discussion_query" --template '{{.data.createDiscussion.discussion.url}}' )
-                # echo "Announcement URL: $create_discussion_url"
-            else
-                duplicate_discussion_url=$(echo "$duplicate_discussions" | jq -r '.url')
-                echo "##vso[task.logissue type=warning]Announcement already exists ($duplicate_discussion_url). Skipping submission"
-            fi
+          dry_run=''
+          if [ ${{ parameters.isDryRun }} = True ]; then
+            dry_run='--dry-run'
           fi
+
+          ./submit-announcement.sh                                   \
+            --announcement-org dotnet                                \
+            --announcement-repo source-build                         \
+            --announcement-gist "${{ parameters.announcementGist }}" \
+            --channel "$(releaseChannel)"                            \
+            $dry_run                                                 \
+            $prerelease                                              \
+            --release "$(release)"                                   \
+            --release-name "${{ parameters.releaseName }}"           \
+            --runtime-version "$(runtimeVersion)"                    \
+            --sdk-version "$(sdkVersion)"                            \
+            --tag "$(releaseTag)")
+
         displayName: Submit announcement discussion
         workingDirectory: $(Agent.BuildDirectory)/dotnet-source-build/eng
         env:

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -294,7 +294,7 @@ stages:
             set -o pipefail
           fi
 
-          if [ ${{ parameters.isDryRun }} = True ]; then
+          if [ ${{ parameters.isDryRun }} = False ]; then
             set +x
             echo -e "\n\n\n#########################\n\n"
             echo "Doing a dry run, not submitting announcement."
@@ -344,8 +344,8 @@ stages:
                 }'
 
                 echo "Submitting announcement"
-                create_discussion_url=$(gh api graphql -F RepoId=$(RepoId) -F categoryId=$(DiscussionCategoryId) -F body="$body" -F title="$title" -f query="$create_discussion_query" --template '{{.data.createDiscussion.discussion.url}}' )
-                echo "Announcement URL: $create_discussion_url"
+                # create_discussion_url=$(gh api graphql -F RepoId=$(RepoId) -F categoryId=$(DiscussionCategoryId) -F body="$body" -F title="$title" -f query="$create_discussion_query" --template '{{.data.createDiscussion.discussion.url}}' )
+                # echo "Announcement URL: $create_discussion_url"
             else
                 duplicate_discussion_url=$(echo "$duplicate_discussions" | jq -r '.url')
                 echo "##vso[task.logissue type=warning]Announcement already exists ($duplicate_discussion_url). Skipping submission"

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -403,7 +403,7 @@ stages:
           resolvedSourceBuiltArtifactsFileName=$(basename $(PIPELINE.WORKSPACE)/$(sourceBuiltArtifactsFileName))
           resolvedSdkArtifactFileName=$(basename $(PIPELINE.WORKSPACE)/$(sdkArtifactFileName))
           
-          if [ "${{ parameters.isDryRun }}" = False ]; then
+          if [ "${{ parameters.isDryRun }}" = True ]; then
             echo "Doing a dry run, not submitting PR. Would have called:"
             echo "./submit-source-build-release-pr.sh"
             echo "  --setupGitAuth"

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -240,6 +240,7 @@ stages:
             dry_run='--dry-run'
           fi
 
+          set -x
           ./submit-announcement.sh                                   \
             --announcement-org dotnet                                \
             --announcement-repo source-build                         \


### PR DESCRIPTION
### Related issue:
https://github.com/dotnet/source-build/issues/3450

### Description:
Duplication has been avoided by determining whether or not an announcement with the identical title already exists. 


### Test:
https://dev.azure.com/dnceng/internal/_build/results?buildId=2190080&view=logs&j=19992227-62fb-5b50-4e29-3b72bd33eea1&t=a83d7a9e-2e19-5733-3923-52a07f576962
In addition, the code has been checked in the test repository.


