### PR TITLE
Set content type for uploaded tarball

### DIFF
--- a/eng/templates/stages/pre-release.yml
+++ b/eng/templates/stages/pre-release.yml
@@ -121,6 +121,7 @@ stages:
           containerName: $(blobContainerName)
           uploadPath: $(blobContainerUploadBaseFilePath)/$(ReadReleaseInfo.ReleaseChannel)/$(ReadReleaseInfo.RuntimeVersion)-$(ReadReleaseInfo.SdkVersion)
           azureStorageKey: $(dotnetclimsrc-access-key)
+          contentType: $(TARBALL_BLOB_CONTENT_TYPE)
       
       - script: |
           set -euo pipefail

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -304,6 +304,7 @@ stages:
           containerName: $(blobContainerName)
           uploadPath: $(artifactsUploadBaseFilePath)
           azureStorageKey: $(dotnetcli-storage-key)
+          contentType: $(TARBALL_BLOB_CONTENT_TYPE)
 
       - template: ../steps/upload-to-blob-storage.yml
         parameters:
@@ -312,6 +313,7 @@ stages:
           containerName: $(blobContainerName)
           uploadPath: $(sdkUploadBaseFilePath)
           azureStorageKey: $(dotnetcli-storage-key)
+          contentType: $(TARBALL_BLOB_CONTENT_TYPE)
 
       - script: |
           set -euo pipefail

--- a/eng/templates/steps/upload-to-blob-storage.yml
+++ b/eng/templates/steps/upload-to-blob-storage.yml
@@ -9,6 +9,8 @@ parameters:
     type: string
   - name: azureStorageKey
     type: string
+  - name: contentType
+    type: string
 
 steps:
 - script: |
@@ -32,7 +34,7 @@ steps:
       exit 0
     fi
 
-    az storage blob upload --account-name "${{ parameters.accountName }}" --container-name "${{ parameters.containerName }}" --file "${full_filepath}" --name "${{ parameters.uploadPath }}/${filename}"
+    az storage blob upload --account-name "${{ parameters.accountName }}" --container-name "${{ parameters.containerName }}" --file "${full_filepath}" --name "${{ parameters.uploadPath }}/${filename}" --content-type "${{ parameters.contentType }}" 
 
     # Check if the uploaded file is reachable in the blob storage account
     file_blob_list=$(az storage blob list --account-name "${{ parameters.accountName }}" --container-name "${{ parameters.containerName }}" --prefix "${{ parameters.uploadPath }}/${filename}")

--- a/eng/templates/variables/pipelines.yml
+++ b/eng/templates/variables/pipelines.yml
@@ -10,3 +10,5 @@ variables:
   value: 1011
 - name: DOTNET_DOTNET_CI_PIPELINE_ID
   value: 1219
+- name: TARBALL_BLOB_CONTENT_TYPE
+  value: application/x-gzip


### PR DESCRIPTION
There's been some sort of change in behavior with Azure storage that causes the downloading of tarballs that were uploaded by the release pipeline to not have a `.gz` extension. They get downloaded just as a `.tar` extension. This is now true for even tarballs that were uploaded from previous releases that, at the time, were working but now get downloaded with the incorrect file extension.

I tracked this down to the content type that's set by default for these files. They have a content type of `application/x-tar`. In order to have the expected behavior, they need to have a content type of `application/x-gzip`.

To fix this, I've updated the command which uploads the files to explicitly set the content type to `application/x-gzip`.