### PR TITLE
Upload smoke test prereqs tarball

### DIFF
--- a/.github/ISSUE_TEMPLATE/releases/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/releases/release_checklist.md
@@ -31,26 +31,14 @@
                 - Please note that failures of these tests manifest as warnings in the `Run Tests` build step and not as failed tests in the test result viewer. This means you need to verify the `dotnet-dotnet` build doesn't have any warnings regarding these tests.
            - [ ] The `Create announcement draft` step should produce a valid announcement text. When using the announcement gist, copy the text to your gist file, copy the suggested title to your gist's title.
       1. - [ ] `Approval - PR merged & ready for dotnet-security-partners mirroring` stage
-           - [ ] Gather smoke-test prereqs
-                - [ ] Retrieve smoke-test prereqs artifact for each architecture
-                    - [ ] ⚠️ 6.0 / 7.0: [dotnet-installer-source-build-tarball-build](https://dev.azure.com/dnceng/internal/_build?definitionId=1011)
-                        - [ ] x64 - `Build_Tarball_x64 CentOS7-Offline_Artifacts/dotnet-smoke-test-prereqs.6.0.xxx.tar.gz`
-                        - [ ] arm64 - `Build_Tarball_arm64 Debian9-Offline_Artifacts/dotnet-smoke-test-prereqs.6.0.xxx.tar.gz`
-                    - [ ] ⚠️ 8.0: [dotnet-dotnet](https://dev.azure.com/dnceng/internal/_build?definitionId=1219)
-                        - [ ] x64 - `CentOSStream8_Offline_x64_Artifacts/dotnet-smoke-test-prereqs.8.0.xxx.centos.8-x64.tar.gz`
-                        - [ ] arm64 - `Debian11_Offline_arm64_Artifacts/dotnet-smoke-test-prereqs.8.0.xxx.debian.11-arm64.tar.gz`
-                - [ ] Retrieve additional packages from internal MSFT feed using [this project](https://github.com/dotnet/source-build/blob/main/test/GatherPackages.csproj).
-                - [ ] Create a new tarball of unique packages using [this script](https://github.com/dotnet/source-build/blob/main/eng/gather-prereqs.sh).
-                - [ ] Upload `smoke-test-prereqs` tarball to `dotnetclimsrc` storage account, following the pattern of previous releases for directory and filename.
-                    - Never overwrite a tarball. At least change the blob storage virtual dir to represent a new build. This can help avoid timing issues and make it more obvious if stale links were accidentally re-sent rather than new ones.
            - [ ] ⚠️ 6.0 / 7.0: Update `dotnet-security-partners`
                 - [ ] A PR will be created for the appropriate `release/*` branch on [dnceng/security-partners-dotnet](https://dev.azure.com/dnceng/internal/_git/security-partners-dotnet). A branch was automatically created during the `Pre-Release` stage.
                      - [ ] Review and squash-merge the PR once CI finishes successfully.
-           - [ ] Approve the `Approval - Test prereqs` approval stage.
+           - [ ] Approve the `Approval - PR merged & ready for dotnet-security-partners mirroring` approval stage.
       1. - [ ] `Mirror sources & packages` stage
            - This stage mirrors and tags branches associated with the current release.
            - This stage should be ran only once per hand-off. If a new run is needed, removal of the previously created tags/branches might be needed.
-      1. - [ ] `Approval - Partner notification` approval stage
+      1. - [ ] `Approval - Partner notification` approval stage (Servicing releases only)
            - [ ] Create a wiki page for the release in [dotnet-security-partners](https://dev.azure.com/dotnet-security-partners/dotnet/_wiki/wikis/dotnet.wiki). Include the following information:
                 - links to [MSRC work items in the dotnet-security-partners org](https://dev.azure.com/dotnet-security-partners/dotnet/_workitems/recentlycreated/).
                 - links to each release's source tarball and smoke test prereqs tarball in the `dotnetclimsrc` storage account. [Generate a URL with a SAS token](https://learn.microsoft.com/azure/vs-azure-tools-storage-explorer-blobs?toc=%2Fazure%2Fstorage%2Fblobs%2Ftoc.json&bc=%2Fazure%2Fstorage%2Fblobs%2Fbreadcrumb%2Ftoc.json#get-the-sas-for-a-blob-container) that expires in 1 month.
@@ -58,7 +46,7 @@
                 - links to each release's dotnet-security-partners tag that was created with the source-build-release-mirror pipeline.
                 - the expected release date.
                 - information about how confident we are that this is the final release.
-           - [ ] Notify partners of release. Send one email for all releases ([🔁 automation tracking issue for this step](https://github.com/dotnet/source-build/issues/3196)). Include the following in your email:
+           - [ ] Notify partners of release. Send one email for all releases. Include the following in your email:
                 - Link to the wiki page created in the previous step.
                 - TO line should be dnsbReleaseAnnounce alias.
                 - BCC line should be the list found [here](https://microsoft.sharepoint.com/teams/dotNETDeployment/_layouts/OneNote.aspx?id=%2Fteams%2FdotNETDeployment%2FShared%20Documents%2FGeneral%2FNET%20Core%20Acquisition%20and%20Deployment&wd=target%28source-build%2FServicing.one%7CB33C6848-FC82-4585-B69F-204C8449E219%2FPartner%20notification%20emails%7C359F2672-DA5F-4631-9526-423F2BF408AC%2F%29).
@@ -72,7 +60,6 @@
       1. - [ ] `Release` stage
            - [ ] Verify that the announcement was posted to [dotnet/source-build discussions](https://github.com/dotnet/source-build/discussions) and that the content is correct and all links work.
                 - If special edits to the announcement are needed, or the content of the announcement discussion is incorrect, source-build repo maintainers can edit the discussion directly once it is posted.
-                - [ ] ⚠️ 7.0 / 8.0: Fix the release notes link ([known issue](https://github.com/dotnet/source-build/issues/3178))
            - [ ] ⚠️ 8.0: In case a release has been published into `dotnet/dotnet` as draft, check its contents and publish it. The URL to the draft can be find in the `Create GitHub release` step.
            - [ ] Verify that the release-day PR was submitted to [dotnet/installer](https://github.com/dotnet/installer/pulls) and the content is correct.
                 - If there is an error in the PR, commit directly to the PR branch directly to fix the problem by hand, then submit an issue to [dotnet/source-build](https://github.com/dotnet/source-build).

--- a/eng/combine-tarballs.sh
+++ b/eng/combine-tarballs.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+### Usage: combine-tarballs.sh [OPTIONS] [file1] [file2] ... [fileN]
+###
+### Combines the contents of multiple tarballs into a single tarball.
+###
+### Options:
+###   --output <FILE>  The destination path of the output tarball
+###   --help, -h       (Optional) Print this help message and exit
+
+set -euo pipefail
+source="${BASH_SOURCE[0]}"
+
+function print_help () {
+  sed -n '/^### /,/^$/p' "$source" | cut -b 5-
+}
+
+outputPath=''
+
+if [[ $# -gt 0 ]]; then
+  opt="$(echo "$1" | tr "[:upper:]" "[:lower:]")"
+  case "$opt" in
+    -h | --help )
+      print_help
+      exit 0
+      ;;
+    --output )
+      outputPath="$2"
+      shift 2
+      ;;
+    *)
+    ;;
+  esac
+else
+  print_help
+  exit 0
+fi
+
+: "${outputPath:?Missing --output}"
+
+tmpDir=$(mktemp -d)
+
+# The rest of the args are the paths to the input tarball
+for arg in "$@"
+do
+  echo "Extracting '${arg}' to '${tmpDir}'"
+  tar -xf "${arg}" -C $tmpDir
+done
+
+echo "Generating tarball '${outputPath}' from '${tmpDir}'"
+tar -cf "${outputPath}" -C $tmpDir .
+
+rm -rf $tmpDir

--- a/eng/combine-tarballs.sh
+++ b/eng/combine-tarballs.sh
@@ -48,6 +48,6 @@ do
 done
 
 echo "Generating tarball '${outputPath}' from '${tmpDir}'"
-tar -cf "${outputPath}" -C $tmpDir .
+tar --numeric-owner -cf "${outputPath}" -C $tmpDir .
 
 rm -rf $tmpDir

--- a/eng/templates/stages/mirror.yml
+++ b/eng/templates/stages/mirror.yml
@@ -26,6 +26,10 @@ stages:
   - job: Mirror
     displayName: Mirror sources & packages
     variables:
+    - template: ../variables/pipelines.yml
+    - template: ../variables/msrc-storage-variables.yml
+      parameters:
+        isDryRun: ${{ parameters.isDryRun }}
     - group: DotNet-Source-Build-All-Orgs-Source-Access
     - name: RepoDir
       value: vmr
@@ -48,17 +52,49 @@ stages:
       value: $(PIPELINE.WORKSPACE)/${{ parameters.dotnetStagingPipelineResource }}/$(packagesArtifactName)/$(shippingPackages)
     - name: releaseTag
       value: $[ stageDependencies.PreRelease.PreRelease.outputs['ReadReleaseInfo.ReleaseTag'] ]
+    - name: sdkVersion
+      value: $[ stageDependencies.PreRelease.PreRelease.outputs['ReadReleaseInfo.SdkVersion'] ]
+    - name: runtimeVersion
+      value: $[ stageDependencies.PreRelease.PreRelease.outputs['ReadReleaseInfo.RuntimeVersion'] ]
+    - name: releaseChannel
+      value: $[ stageDependencies.PreRelease.PreRelease.outputs['ReadReleaseInfo.ReleaseChannel'] ]
+    - name: combinedSmokeTestPrereqsTarballPath
+      value: $(Pipeline.Workspace)/dotnet-smoke-test-prereqs-$(sdkVersion).tar.gz
+
+    - ${{ if eq(parameters.dotnetMajorVersion, '6.0') }}:
+      - name: smokeTestPreReqsArtifactNameX64
+        value: Build_Tarball_x64 CentOSStream9-Offline_Artifacts
+      - name: smokeTestPreReqsArtifactNameArm64
+        value: Build_Tarball_arm64 Debian9-Offline_Artifacts
+    - ${{ if eq(parameters.dotnetMajorVersion, '7.0') }}:
+      - name: smokeTestPreReqsArtifactNameX64
+        value: Build_Tarball_x64 CentOSStream9-Offline_Artifacts
+      - name: smokeTestPreReqsArtifactNameArm64
+        value: Build_Tarball_arm64 Debian11-Offline_Artifacts
+    - ${{ if eq(parameters.dotnetMajorVersion, '8.0') }}:
+      - name: smokeTestPreReqsArtifactNameX64
+        value: CentOSStream9_Offline_MsftSdk_x64_Artifacts
+      - name: smokeTestPreReqsArtifactNameArm64
+        value: Debian11_Offline_MsftSdk_arm64_Artifacts
 
     - ${{ if or(eq(parameters.dotnetMajorVersion, '6.0'), eq(parameters.dotnetMajorVersion, '7.0')) }}:
       - name: sourceUrl
         value: https://dnceng@dev.azure.com/dnceng/internal/_git/security-partners-dotnet
       - name: sourceVersion
         value: $[ stageDependencies.PreRelease.PreRelease.outputs['AssociatedPipelineRuns.InstallerCommit'] ]
+      - name: officialBuildPipelineId
+        value: $(INSTALLER_TARBALL_BUILD_CI_PIPELINE_ID)
+      - name: officialBuildRunId
+        value: $[ stageDependencies.PreRelease.PreRelease.outputs['AssociatedPipelineRuns.InstallerTarballBuildRunId'] ]
     - ${{ else }}:
       - name: sourceUrl
         value: https://dnceng@dev.azure.com/dnceng/internal/_git/dotnet-dotnet
       - name: sourceVersion
         value: $[ stageDependencies.PreRelease.PreRelease.outputs['AssociatedPipelineRuns.DotnetDotnetCommit'] ]
+      - name: officialBuildPipelineId
+        value: $(DOTNET_DOTNET_CI_PIPELINE_ID)
+      - name: officialBuildRunId
+        value: $[ stageDependencies.PreRelease.PreRelease.outputs['AssociatedPipelineRuns.DotnetDotnetRunId'] ]
 
     # We're using a different pool than the rest of the pipeline here to get more disk space
     # More information here: https://github.com/dotnet/arcade/issues/13036
@@ -67,8 +103,6 @@ stages:
       demands: ImageOverride -equals Build.Ubuntu.2004.Amd64
 
     steps:
-    - checkout: none
-
     - script: |
         set -euo pipefail
 
@@ -177,3 +211,40 @@ stages:
             publishFeedCredentials: ${{ variables.feedServiceConnection }}
             allowPackageConflicts: true
 
+    - template: ../steps/download-smoke-test-prereqs.yml
+      parameters:
+        officialBuildPipelineId: $(officialBuildPipelineId)
+        officialBuildRunId: $(officialBuildRunId)
+        taskLabel: x64
+        artifactName: $(smokeTestPreReqsArtifactNameX64)
+
+    - template: ../steps/download-smoke-test-prereqs.yml
+      parameters:
+        officialBuildPipelineId: $(officialBuildPipelineId)
+        officialBuildRunId: $(officialBuildRunId)
+        taskLabel: arm64
+        artifactName: $(smokeTestPreReqsArtifactNameArm64)
+
+    - script: |
+        "$(Build.SourcesDirectory)/eng/combine-tarballs.sh" \
+          --output "$(combinedSmokeTestPrereqsTarballPath)" \
+          $(Pipeline.Workspace)/dotnet-smoke-test-prereqs.*.tar.gz
+      displayName: Combine smoke test prereqs tarballs
+
+    # Install requirements needed to upload to blob storage
+    # These aren't included by default in the agent image
+    - script: |
+        curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash && \
+          sudo apt-get update && \
+          sudo apt-get install -y \
+            jq
+      displayName: Install upload prereqs
+
+    - template: ../steps/upload-to-blob-storage.yml
+      parameters:
+        file: $(combinedSmokeTestPrereqsTarballPath)
+        accountName: $(storageAccountName)
+        containerName: $(blobContainerName)
+        uploadPath: $(blobContainerUploadBaseFilePath)/$(releaseChannel)/$(runtimeVersion)-$(sdkVersion)
+        azureStorageKey: $(dotnetclimsrc-access-key)
+        contentType: $(TARBALL_BLOB_CONTENT_TYPE)

--- a/eng/templates/stages/mirror.yml
+++ b/eng/templates/stages/mirror.yml
@@ -75,7 +75,7 @@ stages:
       - name: smokeTestPreReqsArtifactNameX64
         value: CentOSStream9_Offline_MsftSdk_x64_Artifacts
       - name: smokeTestPreReqsArtifactNameArm64
-        value: Debian11_Offline_MsftSdk_arm64_Artifacts
+        value: Ubuntu2204Arm64_Offline_MsftSdk_arm64_Artifacts
 
     - ${{ if or(eq(parameters.dotnetMajorVersion, '6.0'), eq(parameters.dotnetMajorVersion, '7.0')) }}:
       - name: sourceUrl

--- a/eng/templates/stages/mirror.yml
+++ b/eng/templates/stages/mirror.yml
@@ -75,7 +75,7 @@ stages:
       - name: smokeTestPreReqsArtifactNameX64
         value: CentOSStream9_Offline_MsftSdk_x64_Artifacts
       - name: smokeTestPreReqsArtifactNameArm64
-        value: Ubuntu2204Arm64_Offline_MsftSdk_arm64_Artifacts
+        value: Debian11_Offline_MsftSdk_arm64_Artifacts
 
     - ${{ if or(eq(parameters.dotnetMajorVersion, '6.0'), eq(parameters.dotnetMajorVersion, '7.0')) }}:
       - name: sourceUrl

--- a/eng/templates/stages/pre-release.yml
+++ b/eng/templates/stages/pre-release.yml
@@ -54,20 +54,11 @@ stages:
       displayName: Get build info
     variables:
     - template: ../variables/pipelines.yml
-    - ${{ if or(eq(parameters.dotnetMajorVersion, '6.0'), eq(parameters.dotnetMajorVersion, '7.0')) }}:
-      - group: DotNet-MSRC-Storage
-      - group: DotNet-Source-Build-All-Orgs-Source-Access
-      - name: storageAccountName
-        value: dotnetclimsrc
-      - name: blobContainerName
-        value: source-build
-      - name: vmrUpstreamUrl
-        value: https://dnceng@dev.azure.com/dnceng/internal/_git/security-partners-dotnet
-      - name: blobContainerUploadBaseFilePath
-        ${{ if parameters.isDryRun }}:
-          value: Dev
-        ${{ else }}:
-          value: release
+    - template: ../variables/msrc-storage-variables.yml
+      parameters:
+        isDryRun: ${{ parameters.isDryRun }}
+    - name: vmrUpstreamUrl
+      value: https://dnceng@dev.azure.com/dnceng/internal/_git/security-partners-dotnet
 
     steps:
     - template: ../steps/initialize-release-info.yml

--- a/eng/templates/steps/download-smoke-test-prereqs.yml
+++ b/eng/templates/steps/download-smoke-test-prereqs.yml
@@ -1,0 +1,21 @@
+parameters:
+- name: taskLabel
+  type: string
+- name: artifactName
+  type: string
+- name: officialBuildPipelineId
+  type: string
+- name: officialBuildRunId
+  type: string
+
+steps:
+- task: DownloadPipelineArtifact@2
+  displayName: Download Smoke Test Prereqs (${{ parameters.taskLabel }})
+  inputs:
+    source: specific
+    artifact: ${{ parameters.artifactName }}
+    patterns: dotnet-smoke-test-prereqs.*.tar.gz
+    project: $(AZDO_PROJECT)
+    pipeline: ${{ parameters.officialBuildPipelineId }}
+    runVersion: specific
+    runId: ${{ parameters.officialBuildRunId}}

--- a/eng/templates/variables/msrc-storage-variables.yml
+++ b/eng/templates/variables/msrc-storage-variables.yml
@@ -1,0 +1,16 @@
+parameters:
+- name: isDryRun
+  type: boolean
+  
+variables:
+- group: DotNet-MSRC-Storage
+- group: DotNet-Source-Build-All-Orgs-Source-Access
+- name: storageAccountName
+  value: dotnetclimsrc
+- name: blobContainerName
+  value: source-build
+- name: blobContainerUploadBaseFilePath
+  ${{ if parameters.isDryRun }}:
+    value: Dev
+  ${{ else }}:
+    value: release


### PR DESCRIPTION
Updates the release pipeline to generate the smoke test prereqs tarball and upload it to blob storage for use by .NET security partners. This is implemented by combining the individual smoke test prereqs tarballs from an x64 and arm64 build leg of the source-build pipeline.

This does not implement logic to provide this tarball for public use. That's in the scope of https://github.com/dotnet/source-build/issues/3015.

Fixes https://github.com/dotnet/source-build/issues/3386