### PR TITLE
Update SB artifacts filename to include RID for 6.0/7.0

### DIFF
--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -66,7 +66,7 @@ stages:
     - name: sourceBuildArtifactLeg
       value: Build_Tarball_x64 CentOS7-Offline_Artifacts
     - name: sourceBuiltArtifactsFileName
-      value: Private.SourceBuilt.Artifacts.$(sdkVersion).tar.gz
+      value: Private.SourceBuilt.Artifacts.$(sdkVersion).centos.7-x64.tar.gz
     - name: sdkArtifactFileName
       value: dotnet-sdk-$(sdkVersion)-*.tar.gz
 
@@ -74,7 +74,7 @@ stages:
     - name: sourceBuildArtifactLeg
       value: Build_Tarball_x64 CentOSStream8-Offline_Artifacts
     - name: sourceBuiltArtifactsFileName
-      value: Private.SourceBuilt.Artifacts.$(sdkVersion).tar.gz
+      value: Private.SourceBuilt.Artifacts.$(sdkVersion).centos.8-x64.tar.gz
     - name: sdkArtifactFileName
       value: dotnet-sdk-$(sdkVersion)-*.tar.gz
 


### PR DESCRIPTION
A dry run of the release pipeline for 6.0 revealed a failure when attempting to upload the SB artifacts tarball in the release stage:

```
##[error]File /mnt/vss/_work/1/Private.SourceBuilt.Artifacts.6.0.121.tar.gz not found on disk. It might not have been downloaded. Exiting...'
```

This is due to the changes in https://github.com/dotnet/installer/pull/16855. The tarball has a new name that needs to be reflected in the release pipeline.