### PR TITLE
Add alpine artifacts to release

### DIFF
--- a/eng/templates/stages/mirror.yml
+++ b/eng/templates/stages/mirror.yml
@@ -76,6 +76,8 @@ stages:
         value: CentOSStream9_Offline_MsftSdk_x64_Artifacts
       - name: smokeTestPreReqsArtifactNameArm64
         value: Ubuntu2204Arm64_Offline_MsftSdk_arm64_Artifacts
+      - name: smokeTestPreReqsArtifactNameMuslX64
+        value: Alpine317_Offline_MsftSdk_x64_Artifacts
 
     - ${{ if or(eq(parameters.dotnetMajorVersion, '6.0'), eq(parameters.dotnetMajorVersion, '7.0')) }}:
       - name: sourceUrl


### PR DESCRIPTION
Addresses https://github.com/dotnet/source-build/issues/3635

In order to include a CI leg for Alpine using the previous SB SDK as part of the dotnet-dotnet pipeline, it is necessary to release the Alpine artifacts through SB release automation. These changes fulfill that requirement.