### PR TITLE
Tag build commit before releasing

### DIFF
--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -158,18 +158,25 @@ stages:
           git config --global user.name "$git_user"
           git config --global user.email "$git_email"
 
-          git tag $releaseTag $dotnetDotnetCommit
-          
           vmr_url=$(echo $vmrPublicUrl | sed "s,https://.*@,https://$(git_user):${GH_TOKEN}@,g")
-          result=$(git push $vmr_url refs/tags/$releaseTag 2>&1)
-          
-          if [[ $? != 0 ]]; then
-            echo "##vso[task.logissue type=error]Failed to create a GitHub tag for the release: $result"
-            exit 1
-          fi
 
-          if [[ "$result" =~ "Everything up-to-date" ]]; then
-            echo "##vso[task.logissue type=warning]GitHub release tag $(releaseTag) already exists ($(vmrPublicUrl)/releases/tag/$(releaseTag))"
+          git fetch $vmr_url tag $releaseTag --no-tags
+          if [[ $? = 0 ]]; then
+            tagged_commit=$(git rev-list -1 refs/tags/$releaseTag)
+            
+            if [[ $tagged_commit != $dotnetDotnetCommit ]]; then
+              echo "##vso[task.logissue type=error]The release tag '$releaseTag' is linked to a different commit. Expected: '$dotnetDotnetCommit'; Actual: '$tagged_commit'"
+              echo "##vso[task.logissue type=error]See the tag at $vmrPublicUrl/releases/tag/$releaseTag for more info."
+              exit 1
+            fi
+          else
+            git tag $releaseTag $dotnetDotnetCommit
+            git push $vmr_url refs/tags/$releaseTag 2>&1
+          
+            if [[ $? != 0 ]]; then
+              echo "##vso[task.logissue type=error]Failed to create a GitHub tag for the release: $result"
+              exit 1
+            fi
           fi
 
           release_json="$(Build.ArtifactStagingDirectory)/release.json"

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -45,6 +45,8 @@ stages:
     value: dotnet
   - name: announcementRepo
     value: source-build
+  - name: publicVmrUrl
+    value: https://github.com/dotnet/dotnet
   - name: storageAccountName
     value: dotnetcli
   - name: blobContainerName
@@ -148,6 +150,18 @@ stages:
             draft='--draft'
           fi
 
+          git tag $releaseTag $dotnetDotnetCommit
+          
+          result=$(git push $publicVmrUrl refs/tags/$releaseTag 2>&1)
+          if [[ $? -ne 0 ]]; then
+            echo "##vso[task.logissue type=error]Failed to create a GitHub tag for the release: $result"
+            exit 1
+          fi
+
+          if [[ "$result" =~ "Everything up-to-date" ]]; then
+            echo "##vso[task.logissue type=warning]GitHub release tag $(releaseTag) already exists ($(publicVmrUrl)/releases/tag/$(releaseTag))"
+          fi
+
           release_json="$(Build.ArtifactStagingDirectory)/release.json"
 
           echo "{}" \
@@ -156,7 +170,7 @@ stages:
             | jq '. += { "tag": "$(releaseTag)" }'                                 \
             | jq '. += { "sdkVersion": "$(sdkVersion)" }'                          \
             | jq '. += { "runtimeVersion": "$(runtimeVersion)" }'                  \
-            | jq '. += { "sourceRepository": "https://github.com/dotnet/dotnet" }' \
+            | jq '. += { "sourceRepository": "$(publicVmrUrl)" }' \
             | jq '. += { "sourceVersion": "$(dotnetDotnetCommit)" }'               \
             > "$release_json"
 
@@ -187,19 +201,15 @@ stages:
             "$release_json#Release manifest"         \
             --repo dotnet/dotnet                     \
             --title "${{ parameters.releaseName }}"  \
-            --target "$(dotnetDotnetCommit)"         \
             --notes-file "$release_notes"            \
+            --verify-tag                             \
             $prerelease                              \
             $draft \
             2>&1)
 
           if [ $? -ne 0 ]; then
-            if [[ "$result" =~ "already exists" ]]; then
-              echo "##vso[task.logissue type=warning]GitHub release tag $(releaseTag) already exists (https://github.com/dotnet/dotnet/releases/tag/$(releaseTag))"
-            else
-              echo "##vso[task.logissue type=error]Failed to create the GitHub release: $result"
-              exit 1
-            fi
+            echo "##vso[task.logissue type=error]Failed to create the GitHub release: $result"
+            exit 1
           fi
 
         displayName: Create GitHub release

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -160,18 +160,17 @@ stages:
 
           vmr_url=$(echo $vmrPublicUrl | sed "s,https://.*@,https://$(git_user):${GH_TOKEN}@,g")
 
-          git fetch $vmr_url tag $releaseTag --no-tags
+          git fetch "$vmr_url" tag "$releaseTag" --no-tags
           if [[ $? = 0 ]]; then
-            tagged_commit=$(git rev-list -1 refs/tags/$releaseTag)
-            
-            if [[ $tagged_commit != $dotnetDotnetCommit ]]; then
+            tagged_commit=$(git rev-list -1 "refs/tags/$releaseTag")           
+            if [[ "$tagged_commit" != "$dotnetDotnetCommit" ]]; then
               echo "##vso[task.logissue type=error]The release tag '$releaseTag' is linked to a different commit. Expected: '$dotnetDotnetCommit'; Actual: '$tagged_commit'"
               echo "##vso[task.logissue type=error]See the tag at $vmrPublicUrl/releases/tag/$releaseTag for more info."
               exit 1
             fi
           else
-            git tag $releaseTag $dotnetDotnetCommit
-            git push $vmr_url refs/tags/$releaseTag 2>&1
+            git tag "$releaseTag" "$dotnetDotnetCommit"
+            git push "$vmr_url" "refs/tags/$releaseTag" 2>&1
           
             if [[ $? != 0 ]]; then
               echo "##vso[task.logissue type=error]Failed to create a GitHub tag for the release: $result"
@@ -187,7 +186,7 @@ stages:
             | jq '. += { "tag": "$(releaseTag)" }'                                 \
             | jq '. += { "sdkVersion": "$(sdkVersion)" }'                          \
             | jq '. += { "runtimeVersion": "$(runtimeVersion)" }'                  \
-            | jq '. += { "sourceRepository": "$(vmrPublicUrl)" }' \
+            | jq '. += { "sourceRepository": "$(vmrPublicUrl)" }'                  \
             | jq '. += { "sourceVersion": "$(dotnetDotnetCommit)" }'               \
             > "$release_json"
 
@@ -216,7 +215,7 @@ stages:
           set +e
           result=$(gh release create "$(releaseTag)" \
             "$release_json#Release manifest"         \
-            --repo $vmrPublicRepo                     \
+            --repo $vmrPublicRepo                    \
             --title "${{ parameters.releaseName }}"  \
             --notes-file "$release_notes"            \
             --verify-tag                             \

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -42,7 +42,7 @@ stages:
   - name: vmrPublicRepo
     value: dotnet/dotnet
   - name: vmrPublicUrl
-    name: https://github.com/$(vmrPublicRepo)
+    value: https://github.com/$(vmrPublicRepo)
   - name: releasePrForkRepo
     value: dotnet-sb-bot/installer
   - name: announcementOrg
@@ -152,31 +152,34 @@ stages:
             draft='--draft'
           fi
 
-          git_user=dotnet-bot
-          git_email=dotnet-bot@microsoft.com
+        git_user=dotnet-bot
+        git_email=dotnet-bot@microsoft.com
 
-          git config --global user.name "$git_user"
-          git config --global user.email "$git_email"
+        git config --global user.name "$git_user"
+        git config --global user.email "$git_email"
 
-          vmr_url=$(echo $vmrPublicUrl | sed "s,https://.*@,https://$(git_user):${GH_TOKEN}@,g")
+        vmr_url="https://$git_user:${GH_TOKEN}@github.com/$(vmrPublicRepo)"
 
-          git fetch "$vmr_url" tag "$releaseTag" --no-tags
-          if [[ $? = 0 ]]; then
-            tagged_commit=$(git rev-list -1 "refs/tags/$releaseTag")           
-            if [[ "$tagged_commit" != "$dotnetDotnetCommit" ]]; then
-              echo "##vso[task.logissue type=error]The release tag '$releaseTag' is linked to a different commit. Expected: '$dotnetDotnetCommit'; Actual: '$tagged_commit'"
-              echo "##vso[task.logissue type=error]See the tag at $vmrPublicUrl/releases/tag/$releaseTag for more info."
-              exit 1
-            fi
-          else
-            git tag "$releaseTag" "$dotnetDotnetCommit"
-            git push "$vmr_url" "refs/tags/$releaseTag" 2>&1
-          
-            if [[ $? != 0 ]]; then
-              echo "##vso[task.logissue type=error]Failed to create a GitHub tag for the release: $result"
-              exit 1
-            fi
+        set +e
+        if git fetch "$vmr_url" tag "$(releaseTag)" --no-tags; then
+          # Tag exists, we need to verify that the correct commit is tagged
+          tagged_commit=$(git rev-list -1 "refs/tags/$(releaseTag)")           
+          if [[ "$tagged_commit" != "$(dotnetDotnetCommit)" ]]; then
+            echo "##vso[task.logissue type=error]The release tag '$(releaseTag)' is linked to a different commit. Expected: '$(dotnetDotnetCommit)'; Actual: '$tagged_commit'"
+            echo "##vso[task.logissue type=error]See the tag at $(vmrPublicUrl)/releases/tag/$(releaseTag) for more info."
+            exit 1
           fi
+        else
+          # Tag does not exist, we need to tag the commit and push it
+          echo "Pushing release tag to $(vmrPublicRepo)"
+          git tag "$(releaseTag)" "$(dotnetDotnetCommit)"
+          git push "$vmr_url" "refs/tags/$(releaseTag)"
+          if [[ $? != 0 ]]; then
+            echo "##vso[task.logissue type=error]Failed to create a GitHub tag for the release"
+            exit 1
+          fi
+        fi
+        set -e
 
           release_json="$(Build.ArtifactStagingDirectory)/release.json"
 

--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -39,14 +39,16 @@ stages:
 
   - name: releasePrRepo
     value: dotnet/installer
+  - name: vmrPublicRepo
+    value: dotnet/dotnet
+  - name: vmrPublicUrl
+    name: https://github.com/$(vmrPublicRepo)
   - name: releasePrForkRepo
     value: dotnet-sb-bot/installer
   - name: announcementOrg
     value: dotnet
   - name: announcementRepo
     value: source-build
-  - name: publicVmrUrl
-    value: https://github.com/dotnet/dotnet
   - name: storageAccountName
     value: dotnetcli
   - name: blobContainerName
@@ -150,16 +152,24 @@ stages:
             draft='--draft'
           fi
 
+          git_user=dotnet-bot
+          git_email=dotnet-bot@microsoft.com
+
+          git config --global user.name "$git_user"
+          git config --global user.email "$git_email"
+
           git tag $releaseTag $dotnetDotnetCommit
           
-          result=$(git push $publicVmrUrl refs/tags/$releaseTag 2>&1)
-          if [[ $? -ne 0 ]]; then
+          vmr_url=$(echo $vmrPublicUrl | sed "s,https://.*@,https://$(git_user):${GH_TOKEN}@,g")
+          result=$(git push $vmr_url refs/tags/$releaseTag 2>&1)
+          
+          if [[ $? != 0 ]]; then
             echo "##vso[task.logissue type=error]Failed to create a GitHub tag for the release: $result"
             exit 1
           fi
 
           if [[ "$result" =~ "Everything up-to-date" ]]; then
-            echo "##vso[task.logissue type=warning]GitHub release tag $(releaseTag) already exists ($(publicVmrUrl)/releases/tag/$(releaseTag))"
+            echo "##vso[task.logissue type=warning]GitHub release tag $(releaseTag) already exists ($(vmrPublicUrl)/releases/tag/$(releaseTag))"
           fi
 
           release_json="$(Build.ArtifactStagingDirectory)/release.json"
@@ -170,7 +180,7 @@ stages:
             | jq '. += { "tag": "$(releaseTag)" }'                                 \
             | jq '. += { "sdkVersion": "$(sdkVersion)" }'                          \
             | jq '. += { "runtimeVersion": "$(runtimeVersion)" }'                  \
-            | jq '. += { "sourceRepository": "$(publicVmrUrl)" }' \
+            | jq '. += { "sourceRepository": "$(vmrPublicUrl)" }' \
             | jq '. += { "sourceVersion": "$(dotnetDotnetCommit)" }'               \
             > "$release_json"
 
@@ -199,7 +209,7 @@ stages:
           set +e
           result=$(gh release create "$(releaseTag)" \
             "$release_json#Release manifest"         \
-            --repo dotnet/dotnet                     \
+            --repo $vmrPublicRepo                     \
             --title "${{ parameters.releaseName }}"  \
             --notes-file "$release_notes"            \
             --verify-tag                             \


### PR DESCRIPTION
Resolves https://github.com/dotnet/source-build/issues/3637

Tag VMR commit of the build being released and push the said commit before creating a GitHub release.

Even if the commit is coming from the `internal` VMR, pushing the tag would just result in dangling commits at the time of release until the `internal` branch is merged back. Example of a tag with 2 commits from `internal` pushed via a tag - https://github.com/oleksandr-didyk/installer/releases/tag/test-mirror

GitHub CLI can use an existing tag for a release ([command docs](https://cli.github.com/manual/gh_release_create)). Added `--verify-tag` as a safe-guard to make sure the tag is re-used and the command does not create a new one accidentally. Example of a release from a tag mentioned above - https://github.com/oleksandr-didyk/installer/releases

Tested in an AzDO pipeline:
  - if tag exists -> [run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2277880&view=logs&j=b6422d7d-1f12-5a27-5bca-0651b2848f2b&t=cd58d141-4f7b-58b2-52d5-fbefaad1d9e4)
  - if tag exists but links to a different commit -> [run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2277882&view=logs&j=b6422d7d-1f12-5a27-5bca-0651b2848f2b&t=cd58d141-4f7b-58b2-52d5-fbefaad1d9e4)
  - if tag does not exist and `git push` for the new tag fails -> [run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2277910&view=logs&j=b6422d7d-1f12-5a27-5bca-0651b2848f2b&t=cd58d141-4f7b-58b2-52d5-fbefaad1d9e4)