### PR TITLE
Fix YAML formatting in release stage

### DIFF
--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -152,34 +152,34 @@ stages:
             draft='--draft'
           fi
 
-        git_user=dotnet-bot
-        git_email=dotnet-bot@microsoft.com
+          git_user=dotnet-bot
+          git_email=dotnet-bot@microsoft.com
 
-        git config --global user.name "$git_user"
-        git config --global user.email "$git_email"
+          git config --global user.name "$git_user"
+          git config --global user.email "$git_email"
 
-        vmr_url="https://$git_user:${GH_TOKEN}@github.com/$(vmrPublicRepo)"
+          vmr_url="https://$git_user:${GH_TOKEN}@github.com/$(vmrPublicRepo)"
 
-        set +e
-        if git fetch "$vmr_url" tag "$(releaseTag)" --no-tags; then
-          # Tag exists, we need to verify that the correct commit is tagged
-          tagged_commit=$(git rev-list -1 "refs/tags/$(releaseTag)")           
-          if [[ "$tagged_commit" != "$(dotnetDotnetCommit)" ]]; then
-            echo "##vso[task.logissue type=error]The release tag '$(releaseTag)' is linked to a different commit. Expected: '$(dotnetDotnetCommit)'; Actual: '$tagged_commit'"
-            echo "##vso[task.logissue type=error]See the tag at $(vmrPublicUrl)/releases/tag/$(releaseTag) for more info."
-            exit 1
+          set +e
+          if git fetch "$vmr_url" tag "$(releaseTag)" --no-tags; then
+            # Tag exists, we need to verify that the correct commit is tagged
+            tagged_commit=$(git rev-list -1 "refs/tags/$(releaseTag)")           
+            if [[ "$tagged_commit" != "$(dotnetDotnetCommit)" ]]; then
+              echo "##vso[task.logissue type=error]The release tag '$(releaseTag)' is linked to a different commit. Expected: '$(dotnetDotnetCommit)'; Actual: '$tagged_commit'"
+              echo "##vso[task.logissue type=error]See the tag at $(vmrPublicUrl)/releases/tag/$(releaseTag) for more info."
+              exit 1
+            fi
+          else
+            # Tag does not exist, we need to tag the commit and push it
+            echo "Pushing release tag to $(vmrPublicRepo)"
+            git tag "$(releaseTag)" "$(dotnetDotnetCommit)"
+            git push "$vmr_url" "refs/tags/$(releaseTag)"
+            if [[ $? != 0 ]]; then
+              echo "##vso[task.logissue type=error]Failed to create a GitHub tag for the release"
+              exit 1
+            fi
           fi
-        else
-          # Tag does not exist, we need to tag the commit and push it
-          echo "Pushing release tag to $(vmrPublicRepo)"
-          git tag "$(releaseTag)" "$(dotnetDotnetCommit)"
-          git push "$vmr_url" "refs/tags/$(releaseTag)"
-          if [[ $? != 0 ]]; then
-            echo "##vso[task.logissue type=error]Failed to create a GitHub tag for the release"
-            exit 1
-          fi
-        fi
-        set -e
+          set -e
 
           release_json="$(Build.ArtifactStagingDirectory)/release.json"
 
@@ -230,7 +230,6 @@ stages:
             echo "##vso[task.logissue type=error]Failed to create the GitHub release: $result"
             exit 1
           fi
-
         displayName: Create GitHub release
         workingDirectory: $(Agent.BuildDirectory)/dotnet-source-build/eng
         env:


### PR DESCRIPTION
The script changes that were made in https://github.com/dotnet/source-build/pull/3638 didn't have enough indentation. This prevents the pipeline from being loaded in AzDO.

It fails with the error:

```
Encountered error(s) while parsing pipeline YAML: /eng/templates/stages/release.yml: (Line: 156, Col: 9, Idx: 5047) - (Line: 156, Col: 9, Idx: 5047): While scanning a simple key, could not find expected ':'.
```