### PR TITLE
add tagging and pushing released commit from internal

### DIFF
--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -39,6 +39,10 @@ stages:
 
   - name: releasePrRepo
     value: dotnet/installer
+  - name: vmrPublicRepo
+    value: dotnet/dotnet
+  - name: vmrPublicUrl
+    value: https://github.com/$(vmrPublicRepo)
   - name: releasePrForkRepo
     value: dotnet-sb-bot/installer
   - name: announcementOrg
@@ -136,6 +140,40 @@ stages:
         fetchTags: true
 
       - script: |
+          git_user=dotnet-bot
+          git_email=dotnet-bot@microsoft.com
+
+          git config --global user.name "$git_user"
+          git config --global user.email "$git_email"
+
+          vmr_url="https://$git_user:${GH_TOKEN}@github.com/$(vmrPublicRepo)"
+
+          if git fetch "$vmr_url" tag "$(releaseTag)" --quiet --no-tags; then
+            # Tag exists, we need to verify that the correct commit is tagged
+            tagged_commit=$(git rev-list -1 "refs/tags/$(releaseTag)")           
+            if [[ "$tagged_commit" != "$(dotnetDotnetCommit)" ]]; then
+              echo "##vso[task.logissue type=error]The release tag '$(releaseTag)' is linked to a different commit. Expected: '$(dotnetDotnetCommit)'; Actual: '$tagged_commit'"
+              echo "##vso[task.logissue type=error]See the tag at $(vmrPublicUrl)/releases/tag/$(releaseTag) for more info."
+              exit 1
+            fi
+
+            echo "Tag already exists and is referencing the correct commit"
+          else
+            # Tag does not exist, we need to tag the commit and push it
+            echo "Pushing release tag to $(vmrPublicRepo)"
+            git tag "$(releaseTag)" "$(dotnetDotnetCommit)"
+            git push "$vmr_url" "refs/tags/$(releaseTag)"
+            if [[ $? != 0 ]]; then
+              echo "##vso[task.logissue type=error]Failed to create a GitHub tag for the release"
+              exit 1
+            fi
+          fi
+        displayName: Tag and push build commit
+        workingDirectory: $(Agent.BuildDirectory)/dotnet-dotnet
+        env:
+          GH_TOKEN: $(BotAccount-dotnet-bot-repo-PAT)
+
+      - script: |
           set -euo pipefail
 
           prerelease=''
@@ -156,7 +194,7 @@ stages:
             | jq '. += { "tag": "$(releaseTag)" }'                                 \
             | jq '. += { "sdkVersion": "$(sdkVersion)" }'                          \
             | jq '. += { "runtimeVersion": "$(runtimeVersion)" }'                  \
-            | jq '. += { "sourceRepository": "https://github.com/dotnet/dotnet" }' \
+            | jq '. += { "sourceRepository": "$(vmrPublicUrl)" }'                  \
             | jq '. += { "sourceVersion": "$(dotnetDotnetCommit)" }'               \
             > "$release_json"
 
@@ -185,23 +223,18 @@ stages:
           set +e
           result=$(gh release create "$(releaseTag)" \
             "$release_json#Release manifest"         \
-            --repo dotnet/dotnet                     \
+            --repo "$(vmrPublicRepo)"                \
             --title "${{ parameters.releaseName }}"  \
-            --target "$(dotnetDotnetCommit)"         \
             --notes-file "$release_notes"            \
+            --verify-tag                             \
             $prerelease                              \
             $draft \
             2>&1)
 
           if [ $? -ne 0 ]; then
-            if [[ "$result" =~ "already exists" ]]; then
-              echo "##vso[task.logissue type=warning]GitHub release tag $(releaseTag) already exists (https://github.com/dotnet/dotnet/releases/tag/$(releaseTag))"
-            else
-              echo "##vso[task.logissue type=error]Failed to create the GitHub release: $result"
-              exit 1
-            fi
+            echo "##vso[task.logissue type=error]Failed to create the GitHub release: $result"
+            exit 1
           fi
-
         displayName: Create GitHub release
         workingDirectory: $(Agent.BuildDirectory)/dotnet-source-build/eng
         env:


### PR DESCRIPTION
Resolves https://github.com/dotnet/source-build/issues/3653
Fixes issues originally introduced with https://github.com/dotnet/source-build/issues/3637

Test runs:
  - dry-run: [build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2290487&view=results)
  - tag does not exist: [build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2290464&view=logs&j=b6422d7d-1f12-5a27-5bca-0651b2848f2b&t=cd58d141-4f7b-58b2-52d5-fbefaad1d9e4)
  - tag does not exist and tag push failed: [build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2290461&view=logs&j=b6422d7d-1f12-5a27-5bca-0651b2848f2b&t=cd58d141-4f7b-58b2-52d5-fbefaad1d9e4)
  - tag exists and is referencing the correct commit: [build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2290469&view=logs&j=b6422d7d-1f12-5a27-5bca-0651b2848f2b&t=cd58d141-4f7b-58b2-52d5-fbefaad1d9e4)
  - tag exists and is referencing the wrong commit: [build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2290478&view=logs&j=b6422d7d-1f12-5a27-5bca-0651b2848f2b&t=cd58d141-4f7b-58b2-52d5-fbefaad1d9e4)