### PR TITLE
fixup failure on existing release

### DIFF
--- a/eng/templates/stages/release.yml
+++ b/eng/templates/stages/release.yml
@@ -232,8 +232,12 @@ stages:
             2>&1)
 
           if [ $? -ne 0 ]; then
-            echo "##vso[task.logissue type=error]Failed to create the GitHub release: $result"
-            exit 1
+            if [[ "$result" =~ "already exists" ]]; then
+              echo "##vso[task.logissue type=warning]GitHub release $(releaseTag) already exists ($(vmrPublicUrl)/releases/tag/$(releaseTag))"
+            else
+              echo "##vso[task.logissue type=error]Failed to create the GitHub release: $result"
+              exit 1
+            fi
           fi
         displayName: Create GitHub release
         workingDirectory: $(Agent.BuildDirectory)/dotnet-source-build/eng


### PR DESCRIPTION
Found during work on https://github.com/dotnet/arcade-services/issues/2956

In initial implementation I forgot about a case where both the tag and the release exist. Currently it will fail the pipeline, so added a warning for it instead (similar to what is in the internal pipeline as per the corresponding [PR](https://dev.azure.com/dnceng/internal/_git/dotnet-release/pullrequest/34985?path=/eng/pipeline/source-build-release/source-build-pr-net6.yml&discussionId=149407))

Test runs:
  - dry run -> https://dev.azure.com/dnceng/internal/_build/results?buildId=2305971&view=results