### PR TITLE
fixup tagGrepQuery

### DIFF
--- a/eng/templates/stages/mirror.yml
+++ b/eng/templates/stages/mirror.yml
@@ -160,7 +160,7 @@ stages:
         #   083b8b9fe09d04205e87bca0b378e4a3ad74a239        refs/tags/v8.0.0-rc.1.23419.4
         #   113d797bc90104bb4f1cc51e1a462cf3d4ef18fc        refs/tags/v8.0.0-rc.1.23419.4^{}
         # We want to match on both.
-        tagGrepQuery="refs/tags/$tag_name\(^{}\)\?$"
+        tagGrepQuery="refs/tags/$tag_name\(\^{}\)\?$"
 
         echo "git ls-remote --tags destination | grep -q $tagGrepQuery"
         if git ls-remote --tags destination | grep -q "$tagGrepQuery"; then


### PR DESCRIPTION
Resolves issue found by https://dev.azure.com/dnceng/internal/_git/dotnet-release/pullRequest/35064#1699280994

During porting the changes introduced by https://github.com/dotnet/source-build/pull/3716 to internal project discovered a small issue with the `tagGrepQuery` regex, specifically an un-escaped symbol.

Fix tested in internal project - https://dev.azure.com/dnceng/internal/_git/dotnet-release/pullrequest/35064