### PR TITLE
Include SBRP attribute info in poison docs

### DIFF
--- a/Documentation/leak-detection.md
+++ b/Documentation/leak-detection.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Source-build includes a mechanism for *poisoning* its input files, and then for checking for that poison in the build output.  This allows us to ensure that all output files were built during the build rather than copied directly from the input, which would be an illegal prebuilt usage.
+Source-build includes a mechanism for *poisoning* its input files, and then for checking for that poison in the build output. This allows us to ensure that all output files were built during the build rather than copied directly from the input, which would be an illegal prebuilt usage.
 
 ## Before the build
 
@@ -19,6 +19,8 @@ Before the build, the MarkAndCatalogFiles task runs.  This does a few things:
 
 There's no change in source-build operation in poisoning mode during the build.
 
+**Note**: During the build of the source-build-reference-packages repository (regardless of poisoning mode), reference packages have the ```System.Reflection.AssemblyMetadataAttribute("source", "source-build-reference-packages")``` attribute injected into their respective reference assemblies. This attribute is looked for after the build as part of the poisoning mode.
+
 ## After the build
 
-After the build, the CheckForPoison task is run on the source-build output directory.  It again unpacks any archives and packages recursively, and checks for all three kinds of markers injected before the build.  It then writes out a [report](poison-report-format.md) that details everything that was found.
+After the build, the CheckForPoison task is run on the source-build output directory.  It again unpacks any archives and packages recursively, and checks for the three kinds of markers injected before the build and the source-build-reference-packages attribute added during the build.  It then writes out a [report](poison-report-format.md) that details everything that was found.

--- a/Documentation/leak-detection.md
+++ b/Documentation/leak-detection.md
@@ -8,7 +8,7 @@ Source-build includes a mechanism for *poisoning* its input files, and then for 
 
 Before the build, the MarkAndCatalogFiles task runs.  This does a few things:
 
-- Record the hash of every file in the source-build binary input directories (prebuilts and previously-source-built, and reference-packages).  If the file is a zip, tarball, or nupkg, unpack it and do the same thing recursively.
+- Record the hash of every file in the source-build binary input directories (prebuilts, previously-source-built, and reference-packages).  If the file is a zip, tarball, or nupkg, unpack it and do the same thing recursively.
 - For managed DLLs, either bare or in an archive, add a custom attribute that marks the file as poisoned.
 - For nupkgs, drop a `.poisoned` file.
 - Repack the poisoned assemblies and extra files, removing nupkg signatures so they don't fail verification.

--- a/Documentation/leak-detection.md
+++ b/Documentation/leak-detection.md
@@ -8,7 +8,7 @@ Source-build includes a mechanism for *poisoning* its input files, and then for 
 
 Before the build, the MarkAndCatalogFiles task runs.  This does a few things:
 
-- Record the hash of every file in the source-build binary input directories (prebuilts and previously-source-built, in the future [reference-packages](https://github.com/dotnet/source-build/issues/2817)).  If the file is a zip, tarball, or nupkg, unpack it and do the same thing recursively.
+- Record the hash of every file in the source-build binary input directories (prebuilts and previously-source-built, and reference-packages).  If the file is a zip, tarball, or nupkg, unpack it and do the same thing recursively.
 - For managed DLLs, either bare or in an archive, add a custom attribute that marks the file as poisoned.
 - For nupkgs, drop a `.poisoned` file.
 - Repack the poisoned assemblies and extra files, removing nupkg signatures so they don't fail verification.
@@ -19,8 +19,8 @@ Before the build, the MarkAndCatalogFiles task runs.  This does a few things:
 
 There's no change in source-build operation in poisoning mode during the build.
 
-**Note**: During the build of the source-build-reference-packages repository (regardless of poisoning mode), reference packages have the ```System.Reflection.AssemblyMetadataAttribute("source", "source-build-reference-packages")``` attribute injected into their respective reference assemblies. This attribute is looked for after the build as part of the poisoning mode.
+**Note**: During the build of the source-build-reference-packages repository (regardless of poisoning mode), reference packages have the `System.Reflection.AssemblyMetadataAttribute("source", "source-build-reference-packages")` attribute injected into their respective reference assemblies. Leak detection flags all assemblies with this attribute.
 
 ## After the build
 
-After the build, the CheckForPoison task is run on the source-build output directory.  It again unpacks any archives and packages recursively, and checks for the three kinds of markers injected before the build and the source-build-reference-packages attribute added during the build.  It then writes out a [report](poison-report-format.md) that details everything that was found.
+After the build, the CheckForPoison task is run on the source-build output directory.  It again unpacks any archives and packages recursively, and checks for the three kinds of markers (AssemblyAttribute, Hash, and NupkgFile) injected before the build and the source-build-reference-packages attribute added during the build.  It then writes out a [report](poison-report-format.md) that details everything that was found.

--- a/Documentation/poison-report-format.md
+++ b/Documentation/poison-report-format.md
@@ -13,6 +13,10 @@ This is an explanation of the poison report and its interpretation.  For an over
     <Type>AssemblyAttribute</Type>
     <Hash>cf80cd8aed482d5d1527d7dc72fceff84e6326592848447d2dc0b0e87dfc9a90</Hash>
   </File>
+  <File Path="artifacts/x64/Release/Private.SourceBuilt.Artifacts.8.0.100-rtm.23519.1.fedora.38-x64.tar.gz/Microsoft.TestPlatform.CLI.17.8.0-release-23468-02.nupkg/contentFiles/any/net8.0/Microsoft.Extensions.DependencyModel.dll">
+    <Hash>3961408c6033157f4c612b56247b35c3ad28dac0b26f95a6fe55315f440a48eb</Hash>
+    <Type>SourceBuildReferenceAssembly</Type>
+  </File>
   <File Path="Microsoft.DotNet.GenFacades.1.0.0-beta.20316.7/.poisoned">
     <Type>NupkgFile</Type>
     <Hash>e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855</Hash>
@@ -32,6 +36,10 @@ This means that we detected a custom attribute that source-build adds to each pr
 - Reference assemblies (these should not ship, but also will very rarely cause problems).
 - Test or resource assemblies - these should be removed.
 - N-1 (previously-source-built) assemblies included in shipping packages to break cycles - this is expected behavior.  Usually this use case is covered by reference packages but in rare cases we need to actually run an N-1 binary in the build.
+
+### SourceBuildReferenceAssembly
+
+This means that a reference assembly originating from the source-build-reference-packages repo was leaked.
 
 ### Hash
 


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/3732

Adds information related to adding detection of leaked reference assemblies.