### PR TITLE
add doc for transitive dependency pre-builts

### DIFF
--- a/Documentation/sourcebuild-in-repos/new-dependencies.md
+++ b/Documentation/sourcebuild-in-repos/new-dependencies.md
@@ -63,7 +63,7 @@ dependency and the nuances it may have.
       for all packages from the repo.
 1. Is the repo already built in source-build including the specific
   package you want?
-    1. Add the dependency using `darc add-dependency` as normal, then
+    1. Add the dependency using [`darc add-dependency`](https://github.com/dotnet/arcade/blob/main/Documentation/Darc.md#add-dependency) as normal, then
       add the [source-build metadata](#Basics) as above.
 1. Is the repo already built in source-build but the specific package is not?
     1. There's probably an issue with source-building this package.  Please


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/3763

Added a small section in the pre-built doc for handling transitive dependency pre-builts 