### PR TITLE
Fix Debian Arm leg reference for 6.0

### DIFF
--- a/eng/templates/stages/mirror.yml
+++ b/eng/templates/stages/mirror.yml
@@ -65,7 +65,7 @@ stages:
       - name: smokeTestPreReqsArtifactNameX64
         value: Build_Tarball_x64 CentOSStream9-Offline_Artifacts
       - name: smokeTestPreReqsArtifactNameArm64
-        value: Build_Tarball_arm64 Debian9-Offline_Artifacts
+        value: Build_Tarball_arm64 Debian11-Offline_Artifacts
     - ${{ if eq(parameters.dotnetMajorVersion, '7.0') }}:
       - name: smokeTestPreReqsArtifactNameX64
         value: Build_Tarball_x64 CentOSStream9-Offline_Artifacts


### PR DESCRIPTION
Updates the leg name based on the change made here: https://github.com/dotnet/installer/pull/17696