### PR TITLE
Ensure error during package publishing fails the build

### DIFF
--- a/eng/templates/stages/mirror.yml
+++ b/eng/templates/stages/mirror.yml
@@ -219,7 +219,6 @@ stages:
             nuGetServiceConnections: ${{ variables.feedServiceConnection }}
         - task: NuGetCommand@2
           displayName: Publish packages to ${{ variables.destinationPackageFeed }}
-          continueOnError: true
           inputs:
             command: push
             packagesToPush: '${{ variables.packagesDownloadLocation }}/*.nupkg'


### PR DESCRIPTION
The `continueOnError` flag is included as part of https://github.com/dotnet/source-build/pull/3394 but that's not the behavior we want. We want the publishing to be skippable but if it does run, we want it to fail the build if there's an error.