### PR TITLE
Update CI policy to cover testing on oldest glibc version

### DIFF
--- a/Documentation/ci-platform-coverage-guidelines.md
+++ b/Documentation/ci-platform-coverage-guidelines.md
@@ -10,6 +10,8 @@ the source build CI.
 1. Use CentOS Stream instead of Red Hat because it is the free alternative.
 1. Include a permutation of distros for the supported C standard library implementations
 (e.g. glibc and musl).
+1. For each C standard library implementation, include at least one distro that uses the minimum
+supported version of this library.
 1. Only test [distros that are officially supported by .NET](https://github.com/dotnet/core/blob/main/os-lifecycle-policy.md#net-supported-os-policy).
 Community supported distros will not be covered.
 


### PR DESCRIPTION
Without testing on an old glibc version, it's possible we will have a release of .NET that doesn't actually work there. That could be an issue with the bootstrap artifacts, or with something else.

This came up in https://github.com/dotnet/source-build/issues/4399.