### PR TITLE
Add Check Markdown Link GH action

### DIFF
--- a/.github/linters/.check-markdown-links.json
+++ b/.github/linters/.check-markdown-links.json
@@ -1,0 +1,17 @@
+{
+    "ignorePatterns": [
+        {
+            "pattern": "^https://github.com/dotnet/sdk/tree/main/src/SourceBuild/patches"
+        },
+        {
+            "pattern": "^https://dotnetcli.blob.core.windows.net/source-built-artifacts/sdks/"
+        },
+        {
+            "pattern": "^https://dotnetcli.blob.core.windows.net/source-built-artifacts/assets/"
+        },
+        {
+            "pattern": "^https://www.reddit.com/r/archlinux/comments/cx64r5/the_state_of_net_core_on_arch/"
+        }
+    ],
+    "aliveStatusCodes": [200, 203]
+}

--- a/.github/workflows/check-markdown-links.yml
+++ b/.github/workflows/check-markdown-links.yml
@@ -1,0 +1,24 @@
+name: 'Check Markdown Links'
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check-markdown-links:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check markdown links
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          config-file: .github/linters/.check-markdown-links.json
+          use-quiet-mode: 'yes'
+          use-verbose-mode: 'no'

--- a/Documentation/VMR-re-bootstrapping.md
+++ b/Documentation/VMR-re-bootstrapping.md
@@ -82,19 +82,19 @@ re-bootstrap the VMR:
         can try using an earlier passing build.
     1. Retrieve the built SDK version from the build.
     1. Update the dotnet version in the
-       [global.json](https://github.com/dotnet/installer/blob/main/src/SourceBuild/content/global.json).
+       [global.json](https://github.com/dotnet/sdk/blob/main/src/SourceBuild/content/global.json).
 1. Update arcade
     1. Lookup the arcade commit and version. From a VMR commit, you can find the
     corresponding arcade commit/version by looking at the
     [source-manifest.json](https://github.com/dotnet/dotnet/blob/main/src/source-manifest.json).
     1. Update the arcade SDK version in the
-       [global.json](https://github.com/dotnet/installer/blob/main/src/SourceBuild/content/global.json).
+       [global.json](https://github.com/dotnet/sdk/blob/main/src/SourceBuild/content/global.json).
     1. Update the arcade dependency commit and version in the
-       [Version.Details.xml](https://github.com/dotnet/installer/blob/main/src/SourceBuild/content/eng/Version.Details.xml).
+       [Version.Details.xml](https://github.com/dotnet/sdk/blob/main/src/SourceBuild/content/eng/Version.Details.xml).
 1. Update private source-built SDK and artifacts versions
     1. Update `PrivateSourceBuiltSdkVersion` and
        `PrivateSourceBuiltArtifactsVersion` in the
-       [Versions.props](https://github.com/dotnet/installer/blob/main/src/SourceBuild/content/eng/Versions.props).
+       [Versions.props](https://github.com/dotnet/sdk/blob/main/src/SourceBuild/content/eng/Versions.props).
 
 [Tracking issue for automating this
 process.](https://github.com/dotnet/source-build/issues/4246)

--- a/Documentation/planning/arcade-powered-source-build/README.md
+++ b/Documentation/planning/arcade-powered-source-build/README.md
@@ -51,9 +51,7 @@ ArPow consists of two main goals with some key benefits:
      has to root-cause and patch over problems.
 
    * Gives us a place to add additional source-build-specific tests for common
-     problems, such as [nongranular servicing
-     readiness](../nongranular-servicing-readiness) and (most critically)
-     prebuilt usage regressions.
+     problems, such as prebuilt usage regressions.
 
 This doc is about where we can start, what incremental progress would look like,
 and the vision.
@@ -183,30 +181,6 @@ compatible with source-build requirements, and if validation runs into a
 problem, they are able to reproduce the build locally using an Arcade build
 command.
 
----
-
-## Q&A
-
-### Q: How do we patch without an orchestration-focused repo?
-
-A: There are two reasons to make a patch:
-
-1. The repository doesn't properly build from source, and it will take a long
-    time to figure out a fix that works both in source-build and in the
-    Microsoft build. The practical solution is to put a `.patch` file into the
-    repo itself that is only applied during a build from source.
-    * See [onboarding/local-onboarding.md#patching]
-
-2. The repository successfully builds from source in its local build and
-    official build, but doesn't work when built inside a tarball. This *should*
-    be considered a build break, and be fixed in the repository directly. The
-    fix then flows down to dotnet/installer to produce a fixed tarball. However,
-    release deadlines may prevent this.
-    * The dotnet/installer build process may need a way to inject a `.patch`
-      file into the tarball. The `.patch` file would be checked into
-      dotnet/installer and copied into the output tarball. This reduces the
-      scope of a build reset.
-
 [in-arcade.md]: in-arcade.md
 [incremental-official-chunked.md]: incremental-official-chunked.md
 [incremental-official.md]: incremental-official.md
@@ -214,8 +188,6 @@ A: There are two reasons to make a patch:
 [speculative-build.md]: speculative-build.md
 [intermediate-nupkg.md]: intermediate-nupkg.md
 [intermediate nupkgs]: intermediate-nupkg.md
-[onboarding/local-onboarding.md#patching]:
-    onboarding/local-onboarding.md#patching
 
 ---
 

--- a/Documentation/planning/multi-sdk-band-support.md
+++ b/Documentation/planning/multi-sdk-band-support.md
@@ -23,7 +23,7 @@ feature](https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/V
   functionality. Examples include
   [runtime](https://github.com/dotnet/dotnet/tree/main/src/runtime),
   [roslyn](https://github.com/dotnet/dotnet/tree/main/src/roslyn) or
-  [installer](https://github.com/dotnet/dotnet/tree/main/src/installer).
+  [sdk](https://github.com/dotnet/dotnet/tree/main/src/sdk).
 - **Previously source-built (PSB)** - Artifacts from a previous
   servicing/preview iteration, or from a bootstrap build. These may be used when
   building the current dotnet VMR branch, but may not be bundled into any

--- a/Documentation/sourcebuild-in-repos/new-repo.md
+++ b/Documentation/sourcebuild-in-repos/new-repo.md
@@ -24,7 +24,7 @@ These changes are all needed before source build will work:
   List of allowed prebuilts (approval required).
 * [`eng/Version.Details.xml`](#engversiondetailsxml) - Already exists, but
   modifications are needed to pull dependencies from upstream [intermediate
-  nupkgs](planning/arcade-powered-source-build/README.md#intermediate-nupkg-outputsinputs).
+  nupkgs](../planning/arcade-powered-source-build/README.md#intermediate-nupkg-outputsinputs).
 
 See the following sections for details:
 
@@ -162,7 +162,7 @@ elements, and adding a new `source-build-reference-packages` element.
 [intermediate nupkg]s from the upstream repo's official build, rather than using
 prebuilt binaries to fulfill the dependencies. Note that `RepoName` is used to
 calculate the ID of the [intermediate
-nupkg](planning/arcade-powered-source-build/README.md#intermediate-nupkg-outputsinputs):
+nupkg](../planning/arcade-powered-source-build/README.md#intermediate-nupkg-outputsinputs):
 the `Dependency` `Name` is ignored by source build.
 
 Building with the source-built versions of your dependencies also means that any
@@ -172,7 +172,7 @@ where your source build depends on an upstream component that isn't actually
 built in source build.
 
 `ManagedOnly` determines whether a RID suffix is necessary on the [intermediate
-nupkg](planning/arcade-powered-source-build/README.md#intermediate-nupkg-outputsinputs)
+nupkg](../planning/arcade-powered-source-build/README.md#intermediate-nupkg-outputsinputs)
 ID. For example, running source build on `dotnet/installer` with `linux-x64`
 with the above example configuration will restore:
 

--- a/Documentation/system-requirements.md
+++ b/Documentation/system-requirements.md
@@ -22,7 +22,7 @@ a targeted platform.
 MacOS is not currently supported: [Tracking
 Issue](https://github.com/dotnet/source-build/issues/2909).  However, community
 users have created a [Homebrew
-project](https://github.com/Homebrew/homebrew-core/blob/master/Formula/dotnet.rb)
+project](https://github.com/Homebrew/homebrew-core/blob/master/Formula/d/dotnet.rb)
 to build .NET for OSX.  Please feel free to open new issues in individual repos
 or in source-build for OSX issues.
 


### PR DESCRIPTION
These changes include:

Add a GH action that validates links in all Markdown files. The action is the same one used in several dotnet repos already - core, monitor, etc.
Fix the numerous invalid links surfaced by the new link validator.