### PR TITLE
Remove 6.0 references from documentation

### DIFF
--- a/Documentation/planning/multi-sdk-band-support.md
+++ b/Documentation/planning/multi-sdk-band-support.md
@@ -36,7 +36,7 @@ build of additional SDK feature bands as being any different from any other
 source build. Each build of the product combines a set of inputs (previously
 source-built artifacts + source) to produce a set of outputs that can ship to
 customers. When building two completely different major versions of .NET, the
-set of inputs is different (e.g. different source, 6.0 SDK vs. 8.0 SDK). Some of
+set of inputs is different (e.g. different source, 8.0 SDK vs. 9.0 SDK). Some of
 the previously source-built artifacts come from .NET, some may come from the
 source-built package ecosystem (e.g. icu or clang/llvm). If a repo were to be
 eliminated from the input sources, the binaries previously built from those
@@ -173,8 +173,8 @@ of precedence from highest to lowest:
 
 - 1. A version just produced by a component built earlier in the build (if
      available).
-- 2. A version in the previously source-built packages (if available).
-- 3. The version in the checked in `Versions.props` for a repo.
+- 1. A version in the previously source-built packages (if available).
+- 1. The version in the checked in `Versions.props` for a repo.
 
 With the addition of a new input set (CSB), we now have an additional set.
 Changes should be made such that a PackageVersions.props file is generated for
@@ -182,9 +182,9 @@ this new set, and is imported in the correct place based on its precedence.
 
 - 1. A version just produced by a component built earlier in the build (if
      available).
-- 2. A version in the current source-built packages (if available).
-- 3. A version in the previously source-built packages (if available).
-- 3. The version in the checked in `Versions.props` for a repo.
+- 1. A version in the current source-built packages (if available).
+- 1. A version in the previously source-built packages (if available).
+- 1. The version in the checked in `Versions.props` for a repo.
 
 ### Filtering builds of components
 

--- a/Documentation/sourcebuild-in-repos/build-info.md
+++ b/Documentation/sourcebuild-in-repos/build-info.md
@@ -21,8 +21,8 @@ Source-build supplies a *previously-source-built* set of packages for this
 bootstrapping process.  This is one way we have of breaking cycles in the build.
 However, none of these packages can make it to the final build output. This also
 means that your repo should be buildable with the immediately previous version
-of the SDK than you are building for; i.e., if you are building for 6.0.103,
-everything should be buildable with the 6.0.102 SDK.
+of the SDK than you are building for; i.e., if you are building for 8.0.103,
+everything should be buildable with the 8.0.102 SDK.
 
 We also only build one version of each repo.  This means that if your repo turns
 production of some packages on and off, for instance, if you only produce

--- a/Documentation/sourcebuild-in-repos/update-dependencies.md
+++ b/Documentation/sourcebuild-in-repos/update-dependencies.md
@@ -8,7 +8,7 @@ when doing manual updates.  If you are manually updating a version, also see
 ## Internal packages
 
 If you are manually updating a package, please make sure it's from a compatible
-branch (e.g. runtime release/6.0 to sdk release/6.0.1xx, release/6.0.2xx, etc).
+branch (e.g. runtime release/8.0 to sdk release/8.0.1xx).
 Package versions that you are updating to should be source-built in their
 respective repos.  If the version you need is produced in a branch that is not
 yet source-build-compatible please let the [source-build

--- a/Documentation/system-requirements.md
+++ b/Documentation/system-requirements.md
@@ -60,10 +60,6 @@ A minimum of 8 GB of memory is recommended.
 
 The following assets will need to be downloaded in order to build.
 
-* Source:
-  * .NET 8.0: ~300 MB
-  * .NET 6.0: ~500 MB
+* Source: ~300 MB
 * SDK: ~200 MB
-* Artifacts
-  * .NET 8.0: ~1 GB
-  * .NET 6.0: ~4 GB
+* Artifacts: ~1 GB

--- a/README.md
+++ b/README.md
@@ -12,27 +12,11 @@ documentation, tools, and is used for issue tracking.
 
 * [Build system requirements](Documentation/system-requirements.md)
 
-## Building .NET 8.0+
+## Building .NET
 
-.NET 8.0 and newer will be built from the
-[dotnet/dotnet](https://github.com/dotnet/dotnet) repo. Clone the dotnet/dotnet
-repo and check out the tag for the desired release. Then, follow the
-instructions in [dotnet/dotnet's
+Follow the instructions in [dotnet/dotnet's
 README](https://github.com/dotnet/dotnet/blob/main/README.md#dev-instructions)
 to build .NET from source.
-
-## Building .NET 6.0
-
-.NET 6.0 is built from source using the
-[dotnet/installer](https://github.com/dotnet/installer/tree/release/6.0.1xx)
-repo. Clone the dotnet/installer repo and check out the tag for the desired
-release. Then, follow the instructions in [dotnet/installer's
-README](https://github.com/dotnet/installer/tree/release/6.0.1xx?tab=readme-ov-file#build-net-from-source-source-build)
-to build .NET from source. Please see the [support](#support) section below to
-see which feature branches are currently supported.
-
-> The source-build repository doesn't currently support Windows. See
-> [source-build#1190](https://github.com/dotnet/source-build/issues/1190).
 
 ## Source-build goals
 
@@ -124,16 +108,15 @@ to build the whole .NET SDK from source.
 | CentOS Stream | [CentOS Stream Mirror](http://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/) | [@omajid](https://github.com/omajid) |
 | [Fedora](https://fedoraproject.org/wiki/DotNet) | [Default](https://packages.fedoraproject.org/search?query=dotnet) | [@omajid](https://github.com/omajid) |
 | Homebrew | [Formula](https://formulae.brew.sh/formula/dotnet) | [@asbjornu](https://github.com/asbjornu) |
-| [Red Hat Enterprise Linux](https://developers.redhat.com/products/dotnet/overview) | [Default](https://access.redhat.com/documentation/en-us/net/6.0) | [@omajid](https://github.com/omajid) |
+| [Red Hat Enterprise Linux](https://developers.redhat.com/products/dotnet/overview) | [Default](https://access.redhat.com/documentation/en-us/net/8.0) | [@omajid](https://github.com/omajid) |
 | [Ubuntu](https://canonical.com/blog/install-dotnet-on-ubuntu) | [Default](https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=dotnet&searchon=names)<br>[Personal Package Archives](https://launchpad.net/ubuntu/+ppas?name_filter=dotnet) | [@mirespace](https://github.com/mirespace) |
 
 ## Support
 
-.NET Source-Build is supported on the oldest available .NET SDK feature update
-for each major release, and on Linux only. For example, if .NET `6.0.1xx`,
-`6.0.2xx`, `8.0.1xx`, and `8.0.2xx` feature updates are available from
-[dotnet.microsoft.com](https://dotnet.microsoft.com/en-us/download/dotnet/6.0),
-Source-Build will support `6.0.1xx` and `8.0.1xx`.
+.NET source build supports the following:
+
+1. Linux only, Windows and MacOS is not supported
+1. 1xx SDK feature band only (e.g. 8.0.1xx)
 
 For the latest information about Source-Build support for new .NET versions,
 please check our [GitHub Discussions


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4705.

Note:  There are a few remaining 6.0 references that are appropriate to leave as is (e.g. https://github.com/MichaelSimons/source-build/blob/9615023d4b99c46a62e20466100029084f70d74b/Documentation/poison-report-format.md#L8-L9)