### PR TITLE
Fix broken link

### DIFF
--- a/Documentation/VMR-re-bootstrapping.md
+++ b/Documentation/VMR-re-bootstrapping.md
@@ -82,19 +82,19 @@ re-bootstrap the VMR:
         can try using an earlier passing build.
     1. Retrieve the built SDK version from the build.
     1. Update the dotnet version in the
-       [global.json](https://github.com/dotnet/sdk/blob/main/src/SourceBuild/content/global.json).
+       [global.json](https://github.com/dotnet/dotnet/blob/main/global.json).
 1. Update arcade
     1. Lookup the arcade commit and version. From a VMR commit, you can find the
     corresponding arcade commit/version by looking at the
     [source-manifest.json](https://github.com/dotnet/dotnet/blob/main/src/source-manifest.json).
     1. Update the arcade SDK version in the
-       [global.json](https://github.com/dotnet/sdk/blob/main/src/SourceBuild/content/global.json).
+       [global.json](https://github.com/dotnet/dotnet/blob/main/global.json).
     1. Update the arcade dependency commit and version in the
-       [Version.Details.xml](https://github.com/dotnet/sdk/blob/main/src/SourceBuild/content/eng/Version.Details.xml).
+       [Version.Details.xml](https://github.com/dotnet/dotnet/blob/main/eng/Version.Details.xml).
 1. Update private source-built SDK and artifacts versions
     1. Update `PrivateSourceBuiltSdkVersion` and
        `PrivateSourceBuiltArtifactsVersion` in the
-       [Versions.props](https://github.com/dotnet/sdk/blob/main/src/SourceBuild/content/eng/Versions.props).
+       [Versions.props](https://github.com/dotnet/dotnet/blob/main/eng/Versions.props).
 
 [Tracking issue for automating this
 process.](https://github.com/dotnet/source-build/issues/4246)

--- a/Documentation/ci-platform-coverage-guidelines.md
+++ b/Documentation/ci-platform-coverage-guidelines.md
@@ -36,7 +36,7 @@ and architecture. Rather, smart decisions should be made to best utilize
 resources.
 
 The following distro versions will be included in the [CI
-matrix](https://github.com/dotnet/sdk/blob/main/eng/pipelines/templates/stages/vmr-build.yml):
+matrix](https://github.com/dotnet/dotnet/blob/main/eng/pipelines/templates/stages/vmr-build.yml):
 
 1. CentOS Stream - Latest version (amd64)
 1. Fedora - Latest version (amd64)

--- a/Documentation/patching-guidelines.md
+++ b/Documentation/patching-guidelines.md
@@ -54,7 +54,7 @@ patch or create a new commit on top that you can be sure will apply cleanly.
 
 > **Note:** The VMR has all of the `src/SourceBuild/patches` applied. This is
 done as part of the [synchronization
-process](https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/VMR-Design-And-Operation.md#source-build-patches).
+process](https://github.com/dotnet/dotnet/blob/main/docs/VMR-Design-And-Operation.md#source-build-patches).
 
 ## Patch Guidelines
 
@@ -113,7 +113,7 @@ patch or by re-applying the changes to the repo and recreating the patch.
 ## Unified Build Plans
 
 The [Unified
-Build](https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/README.md)
+Build](https://github.com/dotnet/dotnet/blob/main/docs/README.md)
 project will add support for source edits in the
 [VMR](https://github.com/dotnet/dotnet). This will eliminate the need for
 patches as the required changes can be directly made in the VMR. All changes

--- a/Documentation/planning/arcade-powered-source-build/README.md
+++ b/Documentation/planning/arcade-powered-source-build/README.md
@@ -119,9 +119,9 @@ into the Arcade SDK proper to reuse the code.
 
 * [in-arcade.md]
 * [Source code location in Arcade SDK
-  (`Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild`)](https://github.com/dotnet/arcade/tree/master/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild)
+  (`Microsoft.DotNet.Arcade.Sdk/tools/TrackPrebuiltUsage.targets`)](https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.Arcade.Sdk/tools/TrackPrebuiltUsage.targets)
 * [Source-build-specific MSBuild tool source in Arcade SDK
-  (`Microsoft.DotNet.SourceBuild`)](https://github.com/dotnet/arcade/tree/master/src/Microsoft.DotNet.SourceBuild)
+  (`Microsoft.DotNet.SourceBuild`)](https://github.com/dotnet/arcade/tree/main/src/Microsoft.DotNet.SourceBuild)
 
 ## Incremental progress
 

--- a/Documentation/planning/multi-sdk-band-support.md
+++ b/Documentation/planning/multi-sdk-band-support.md
@@ -4,7 +4,7 @@ This document serves as the design planning document for how .NET source build
 will support multiple SDK feature bands. More generally, this support could be
 described as "partial VMR support". This is the implementation plan for
 [Managing SDK Bands Unified Build
-feature](https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/VMR-Managing-SDK-Bands.md).
+feature](https://github.com/dotnet/dotnet/blob/main/docs/VMR-Managing-SDK-Bands.md).
 
 ## Terminology for this document
 

--- a/Documentation/sourcebuild-in-repos/new-repo.md
+++ b/Documentation/sourcebuild-in-repos/new-repo.md
@@ -37,7 +37,7 @@ conditionally exclude.
 Condition="'$(DotNetBuildSourceOnly)' != 'true'"
 ```
 
-See the [Unified Build Controls](https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/Unified-Build-Controls.md)
+See the [Unified Build Controls](https://github.com/dotnet/dotnet/blob/main/docs/VMR-Controls.md)
 for more options on how to exclude components from source build.
 
 ## Setup CI

--- a/Documentation/system-requirements.md
+++ b/Documentation/system-requirements.md
@@ -12,7 +12,7 @@ a targeted platform.
 * [Preconfigured Container
   Images](https://github.com/dotnet/dotnet-buildtools-prereqs-docker) - These
   images are used by
-  [CI](https://github.com/dotnet/dotnet/blob/main/src/sdk/eng/pipelines/templates/stages/vmr-build.yml)
+  [CI](https://github.com/dotnet/dotnet/blob/main/eng/pipelines/templates/stages/vmr-build.yml)
   to build and test source-build.
 * [Distros Source Building
   .NET](https://github.com/dotnet/source-build#net-in-linux-distributions)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ There are two primary goals of the source-build effort:
    require changes to both the runtime and the SDK.
 
    For more details about this Unified Build, see [this
-   overview](https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/Overview.md).
+   overview](https://github.com/dotnet/dotnet/blob/main/docs/Overview.md).
 
 Source-build can help achieve both these goals by making it easier for everyone
 to build and release the entire .NET product end-to-end.


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/5217

The broken links are caused by https://github.com/dotnet/sdk/pull/48695, https://github.com/dotnet/dotnet/pull/226 and https://github.com/dotnet/dotnet/pull/679