### PR TITLE
Update distro version upgrade workflow to account for feature band dependencies

### DIFF
--- a/Documentation/ci-platform-coverage-guidelines.md
+++ b/Documentation/ci-platform-coverage-guidelines.md
@@ -91,7 +91,8 @@ before downstream consumers can be updated.
 
 1. **Update release pipelines:**
    - Update the artifact names for the relevant .NET version in the release infrastructure.
-     ([example 8.0/9.0](https://dev.azure.com/dnceng/internal/_git/dotnet-release/commit/c9be53307205765ebae48c18d00ef6260e596817?path=/eng/pipeline/source-build-release/steps/re-bootstrap.yml&version=GBmain&line=90&lineEnd=91&lineStartColumn=1&lineEndColumn=1&type=2&lineStyle=plain&_a=files), [example 10.0+](https://dev.azure.com/dnceng/internal/_git/dotnet-release?path=/src/release-pipeline/ReleasePipeline.Lib/StaticResources/ReleaseTemplates/dotnet-10.0-template.yaml&version=GBmain&line=209&lineEnd=214&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents)).
+     - ([example 8.0/9.0](https://dev.azure.com/dnceng/internal/_git/dotnet-release/commit/c9be53307205765ebae48c18d00ef6260e596817?path=/eng/pipeline/source-build-release/steps/re-bootstrap.yml&version=GBmain&line=90&lineEnd=91&lineStartColumn=1&lineEndColumn=1&type=2&lineStyle=plain&_a=files)
+     - [example 10.0+](https://dev.azure.com/dnceng/internal/_git/dotnet-release?path=/src/release-pipeline/ReleasePipeline.Lib/StaticResources/ReleaseTemplates/dotnet-10.0-template.yaml&version=GBmain&line=209&lineEnd=214&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents))
    - (8.0/9.0 only) The release validation will fail until the next source-build
      release; file an issue to update the artifacts used for the release
      validation after the next release.


### PR DESCRIPTION
Updates to this doc are needed because of the dependency that feature bands have on the artifacts coming from the 1xx band. It helps to be familiar with https://github.com/dotnet/source-build/blob/main/Documentation/feature-band-source-building.md when reviewing this.