### PR TITLE
Update feature band doc

### DIFF
--- a/Documentation/feature-band-source-building.md
+++ b/Documentation/feature-band-source-building.md
@@ -667,7 +667,8 @@ cd dotnet
 # ===
 
 # Downloads Microsoft-built artifacts and Microsoft SDK
-./prep-source-build.sh
+./prep-source-build.sh # (.NET 10)
+./prep-source-build.sh --no-shared-components # (.NET 11+)
 
 # Build the SDK referencing assets from current 1xx release
 ./build.sh --source-only --with-shared-components /path/to/source-built-1xx/artifacts


### PR DESCRIPTION
Updates the feature band doc's bootstrapping scenario to account for the new `--no-shared-components` option in the prep script from the changes in https://github.com/dotnet/dotnet/pull/6712.