### PR TITLE
Fix markdown link checker action reference

### DIFF
--- a/.github/workflows/check-markdown-links.yml
+++ b/.github/workflows/check-markdown-links.yml
@@ -17,7 +17,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check markdown links
-        uses: umbrelladocs/action-linkspector@568ec8d29fa92b31fd9ea5381e155c51e922af83 # v1.5.5
+        # The enterprise Actions allowlist requires this tag; do not pin a SHA unless the policy changes.
+        uses: umbrelladocs/action-linkspector@v1
         with:
           config_file: .github/linters/.linkspector.yml
           fail_on_error: true


### PR DESCRIPTION
## Problem

The **Check Markdown Links** workflow fails before creating any jobs because it pins `umbrelladocs/action-linkspector` to a commit SHA. The dotnet enterprise Actions policy only permits this action through the `umbrelladocs/action-linkspector@v1` reference.

## Solution

Change the action reference to the enterprise-allowed `@v1` tag. Add a comment documenting that the tag is intentional and should not be replaced with a SHA unless the enterprise policy changes.